### PR TITLE
Issue #6: Agent-task schema with example, docs, and validation

### DIFF
--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -964,11 +964,11 @@ google-api-core = {version = ">=2.11.0,<3.0.0", extras = ["grpc"]}
 google-auth = ">=2.14.1,<2.24.0 || >2.24.0,<2.25.0 || >2.25.0,<3.0.0"
 grpcio = [
     {version = ">=1.75.1,<2.0.0", markers = "python_version >= \"3.14\""},
-    {version = ">=1.33.2,<2.0.0", markers = "python_version < \"3.14\""},
+    {version = ">=1.33.2,<2.0.0"},
 ]
 proto-plus = [
     {version = ">=1.25.0,<2.0.0", markers = "python_version >= \"3.13\""},
-    {version = ">=1.22.3,<2.0.0", markers = "python_version < \"3.13\""},
+    {version = ">=1.22.3,<2.0.0"},
 ]
 protobuf = ">=4.25.8,<8.0.0"
 
@@ -989,11 +989,11 @@ google-api-core = {version = ">=2.11.0,<3.0.0", extras = ["grpc"]}
 google-auth = ">=2.14.1,<2.24.0 || >2.24.0,<2.25.0 || >2.25.0,<3.0.0"
 grpcio = [
     {version = ">=1.75.1,<2.0.0", markers = "python_version >= \"3.14\""},
-    {version = ">=1.33.2,<2.0.0"},
+    {version = ">=1.33.2,<2.0.0", markers = "python_version < \"3.14\""},
 ]
 proto-plus = [
     {version = ">=1.25.0,<2.0.0", markers = "python_version >= \"3.13\""},
-    {version = ">=1.22.3,<2.0.0"},
+    {version = ">=1.22.3,<2.0.0", markers = "python_version < \"3.13\""},
 ]
 protobuf = ">=4.25.8,<8.0.0"
 
@@ -1508,6 +1508,43 @@ files = [
     {file = "jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67f00d94b281174144d6532a04b66a12cb866cbdc47c3af3bfe2973677f9861a"},
     {file = "jiter-0.14.0.tar.gz", hash = "sha256:e8a39e66dac7153cf3f964a12aad515afa8d74938ec5cc0018adcdae5367c79e"},
 ]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+description = "An implementation of JSON Schema validation for Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce"},
+    {file = "jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326"},
+]
+
+[package.dependencies]
+attrs = ">=22.2.0"
+jsonschema-specifications = ">=2023.3.6"
+referencing = ">=0.28.4"
+rpds-py = ">=0.25.0"
+
+[package.extras]
+format = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3987", "uri-template", "webcolors (>=1.11)"]
+format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "rfc3987-syntax (>=1.1.0)", "uri-template", "webcolors (>=24.6.0)"]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+description = "The JSON Schema meta-schemas and vocabularies, exposed as a Registry"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe"},
+    {file = "jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d"},
+]
+
+[package.dependencies]
+referencing = ">=0.31.0"
 
 [[package]]
 name = "librt"
@@ -3538,6 +3575,23 @@ files = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+description = "JSON Referencing + Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231"},
+    {file = "referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8"},
+]
+
+[package.dependencies]
+attrs = ">=22.2.0"
+rpds-py = ">=0.7.0"
+typing-extensions = {version = ">=4.4.0", markers = "python_version < \"3.13\""}
+
+[[package]]
 name = "requests"
 version = "2.33.1"
 description = "Python HTTP for Humans."
@@ -3577,6 +3631,131 @@ pygments = ">=2.13.0,<3.0.0"
 
 [package.extras]
 jupyter = ["ipywidgets (>=7.5.1,<9)"]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+description = "Python bindings to Rust's persistent data structures (rpds)"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "rpds_py-0.30.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288"},
+    {file = "rpds_py-0.30.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4cc2206b76b4f576934f0ed374b10d7ca5f457858b157ca52064bdfc26b9fc00"},
+    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:389a2d49eded1896c3d48b0136ead37c48e221b391c052fba3f4055c367f60a6"},
+    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:32c8528634e1bf7121f3de08fa85b138f4e0dc47657866630611b03967f041d7"},
+    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f207f69853edd6f6700b86efb84999651baf3789e78a466431df1331608e5324"},
+    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:67b02ec25ba7a9e8fa74c63b6ca44cf5707f2fbfadae3ee8e7494297d56aa9df"},
+    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c0e95f6819a19965ff420f65578bacb0b00f251fefe2c8b23347c37174271f3"},
+    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:a452763cc5198f2f98898eb98f7569649fe5da666c2dc6b5ddb10fde5a574221"},
+    {file = "rpds_py-0.30.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e0b65193a413ccc930671c55153a03ee57cecb49e6227204b04fae512eb657a7"},
+    {file = "rpds_py-0.30.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:858738e9c32147f78b3ac24dc0edb6610000e56dc0f700fd5f651d0a0f0eb9ff"},
+    {file = "rpds_py-0.30.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:da279aa314f00acbb803da1e76fa18666778e8a8f83484fba94526da5de2cba7"},
+    {file = "rpds_py-0.30.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7c64d38fb49b6cdeda16ab49e35fe0da2e1e9b34bc38bd78386530f218b37139"},
+    {file = "rpds_py-0.30.0-cp310-cp310-win32.whl", hash = "sha256:6de2a32a1665b93233cde140ff8b3467bdb9e2af2b91079f0333a0974d12d464"},
+    {file = "rpds_py-0.30.0-cp310-cp310-win_amd64.whl", hash = "sha256:1726859cd0de969f88dc8673bdd954185b9104e05806be64bcd87badbe313169"},
+    {file = "rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425"},
+    {file = "rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d"},
+    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4"},
+    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f"},
+    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4"},
+    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97"},
+    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89"},
+    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d"},
+    {file = "rpds_py-0.30.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038"},
+    {file = "rpds_py-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7"},
+    {file = "rpds_py-0.30.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed"},
+    {file = "rpds_py-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85"},
+    {file = "rpds_py-0.30.0-cp311-cp311-win32.whl", hash = "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c"},
+    {file = "rpds_py-0.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825"},
+    {file = "rpds_py-0.30.0-cp311-cp311-win_arm64.whl", hash = "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229"},
+    {file = "rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad"},
+    {file = "rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05"},
+    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28"},
+    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd"},
+    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f"},
+    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1"},
+    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23"},
+    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6"},
+    {file = "rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51"},
+    {file = "rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5"},
+    {file = "rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e"},
+    {file = "rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394"},
+    {file = "rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf"},
+    {file = "rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b"},
+    {file = "rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e"},
+    {file = "rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2"},
+    {file = "rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8"},
+    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4"},
+    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136"},
+    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7"},
+    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2"},
+    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6"},
+    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e"},
+    {file = "rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d"},
+    {file = "rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7"},
+    {file = "rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31"},
+    {file = "rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95"},
+    {file = "rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d"},
+    {file = "rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15"},
+    {file = "rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6"},
+    {file = "rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d"},
+    {file = "rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0"},
+    {file = "rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be"},
+    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f"},
+    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f"},
+    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87"},
+    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18"},
+    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad"},
+    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07"},
+    {file = "rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f"},
+    {file = "rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65"},
+    {file = "rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f"},
+    {file = "rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53"},
+    {file = "rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed"},
+    {file = "rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950"},
+    {file = "rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0"},
+    {file = "rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4"},
+    {file = "rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e"},
+    {file = "rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84"},
+]
 
 [[package]]
 name = "ruff"
@@ -4392,4 +4571,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.15"
-content-hash = "e4ba2e8a187400ca86499c81292fcf57938b3a7a13494969bc11bd6d5f7d949e"
+content-hash = "e4022ab5bb923c24a5eec1868eb319f5f22b15aa41af8c111a1a91baaa37d3fe"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -39,6 +39,7 @@ structlog = "^24.4.0"
 
 # --- Utility ---
 httpx = ">=0.28.1,<1.0.0"
+jsonschema = "^4.26.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.0"

--- a/backend/tests/test_agent_task_schema.py
+++ b/backend/tests/test_agent_task_schema.py
@@ -1,6 +1,8 @@
 import json
-import pytest
+from copy import deepcopy
 from pathlib import Path
+
+import pytest
 from jsonschema import validate, ValidationError
 
 # Resolve paths relative to project root
@@ -40,5 +42,19 @@ def test_schema_validation_fails_invalid_id(schema, valid_example):
     invalid_data = valid_example.copy()
     invalid_data["agent"]["agent_id"] = "Invalid ID With Spaces"
     
+    with pytest.raises(ValidationError):
+        validate(instance=invalid_data, schema=schema)
+
+
+def test_schema_rejects_params_on_end_call(schema, valid_example):
+    """end_call tools must not carry params (additionalProperties=false)."""
+    invalid_data = deepcopy(valid_example)
+    for tool in invalid_data["agent"]["tools"]:
+        if tool.get("type") == "end_call":
+            tool["params"] = []
+            break
+    else:
+        pytest.fail("example must include an end_call tool")
+
     with pytest.raises(ValidationError):
         validate(instance=invalid_data, schema=schema)

--- a/backend/tests/test_agent_task_schema.py
+++ b/backend/tests/test_agent_task_schema.py
@@ -1,0 +1,44 @@
+import json
+import pytest
+from pathlib import Path
+from jsonschema import validate, ValidationError
+
+# Resolve paths relative to project root
+ROOT = Path(__file__).parent.parent.parent
+SCHEMA_PATH = ROOT / "schemas" / "agent-task.schema.json"
+EXAMPLE_PATH = ROOT / "schemas" / "examples" / "agent-task.example.json"
+
+@pytest.fixture
+def schema():
+    with open(SCHEMA_PATH, "r") as f:
+        return json.load(f)
+
+@pytest.fixture
+def valid_example():
+    with open(EXAMPLE_PATH, "r") as f:
+        return json.load(f)
+
+def test_schema_validation_success(schema, valid_example):
+    """Verifies that the canonical example passes the schema."""
+    try:
+        validate(instance=valid_example, schema=schema)
+    except ValidationError as e:
+        pytest.fail(f"Validation failed unexpectedly: {e.message}")
+
+def test_schema_validation_fails_missing_field(schema, valid_example):
+    """Verifies that missing a mandatory field (e.g., first_message) raises an error."""
+    invalid_data = valid_example.copy()
+    # Remove a mandatory field from the agent definition
+    del invalid_data["agent"]["first_message"]
+    
+    with pytest.raises(ValidationError) as excinfo:
+        validate(instance=invalid_data, schema=schema)
+    assert "'first_message' is a required property" in str(excinfo.value)
+
+def test_schema_validation_fails_invalid_id(schema, valid_example):
+    """Verifies that invalid ID patterns (e.g. spaces in agent_id) are rejected."""
+    invalid_data = valid_example.copy()
+    invalid_data["agent"]["agent_id"] = "Invalid ID With Spaces"
+    
+    with pytest.raises(ValidationError):
+        validate(instance=invalid_data, schema=schema)

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,27 @@
+# Schema Foundation
+
+This directory contains the initial JSON Schema contract for TaskOrbit task and agent configuration.
+
+## Files
+
+- `agent-task.schema.json`: Canonical schema definition for `task` + `agent` configuration.
+- `examples/agent-task.example.json`: Example payload that follows the schema.
+
+## Covered fields (issue #6)
+
+- Task definition:
+  - `name`, `description`
+  - `required_inputs`
+  - `workflow_steps`
+- Agent definition:
+  - metadata (`display_name`, `persona`, `description`)
+  - `instruction`
+  - `first_message`
+  - `variables` for session state
+  - technical provider configuration for `stt`, `tts`, `llm`
+  - tool definitions including parameter `name`, `type`, and `required`
+
+## Notes
+
+- This is the first schema iteration (`schema_version: 1.0.0`).
+- Runtime orchestration behavior and persistence logic are not part of this schema file.

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -19,7 +19,11 @@ This directory contains the initial JSON Schema contract for TaskOrbit task and 
   - `first_message`: object `{ "type": "text", "message", "prompt" }` (see `frontend/src/types/agentConfig.ts`)
   - `variables` for session state
   - technical provider configuration for `stt`, `tts`, `llm`
-  - tool definitions including parameter `variable_name`, `type`, and `required` (matches `ToolParam` in `frontend/src/types/agentConfig.ts`)
+  - tools as a discriminated union on `type`:
+    - `data_extraction` — `params[]` (`ToolParam`: `variable_name`, `description`, `type`, `required`)
+    - `end_call` — no `params` / `targets`
+    - `agent_transfer` — `targets[]` (non-empty)
+    - Aligns with `ToolDefinition` in `frontend/src/types/agentConfig.ts`
 
 ## Notes
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -16,7 +16,7 @@ This directory contains the initial JSON Schema contract for TaskOrbit task and 
 - Agent definition:
   - metadata (`display_name`, `persona`, `description`)
   - `instruction`
-  - `first_message`
+  - `first_message`: object `{ "type": "text", "message", "prompt" }` (see `frontend/src/types/agentConfig.ts`)
   - `variables` for session state
   - technical provider configuration for `stt`, `tts`, `llm`
   - tool definitions including parameter `name`, `type`, and `required`

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -19,7 +19,7 @@ This directory contains the initial JSON Schema contract for TaskOrbit task and 
   - `first_message`: object `{ "type": "text", "message", "prompt" }` (see `frontend/src/types/agentConfig.ts`)
   - `variables` for session state
   - technical provider configuration for `stt`, `tts`, `llm`
-  - tool definitions including parameter `name`, `type`, and `required`
+  - tool definitions including parameter `variable_name`, `type`, and `required` (matches `ToolParam` in `frontend/src/types/agentConfig.ts`)
 
 ## Notes
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -24,6 +24,10 @@ This directory contains the initial JSON Schema contract for TaskOrbit task and 
     - `end_call` — no `params` / `targets`
     - `agent_transfer` — `targets[]` (non-empty)
     - Aligns with `ToolDefinition` in `frontend/src/types/agentConfig.ts`
+  - **Optional** architecture / FE extensions (omit for strict Preet-minimal payloads):
+    - `confirmations` — `{ required, tools[] }` (`ConfirmationsConfig`)
+    - `language` — `{ default, auto_detect, supported[] }` (`LanguageConfig`)
+    - `vad` — `{ provider, silence_threshold_ms }` (`VadConfig`)
 
 ## Notes
 

--- a/schemas/agent-task.schema.json
+++ b/schemas/agent-task.schema.json
@@ -1,0 +1,316 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://taskorbit.dev/schemas/agent-task.schema.json",
+  "title": "TaskOrbit Agent Task Definition",
+  "description": "Schema foundation for defining a task and its conversational agent configuration.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "task",
+    "agent"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "pattern": "^1\\.0\\.0$",
+      "description": "Schema contract version."
+    },
+    "task": {
+      "$ref": "#/$defs/taskDefinition"
+    },
+    "agent": {
+      "$ref": "#/$defs/agentDefinition"
+    }
+  },
+  "$defs": {
+    "taskDefinition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "description",
+        "required_inputs",
+        "workflow_steps"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "required_inputs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/inputField"
+          }
+        },
+        "workflow_steps": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/workflowStep"
+          }
+        }
+      }
+    },
+    "agentDefinition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "agent_id",
+        "metadata",
+        "instruction",
+        "first_message",
+        "variables",
+        "pipeline",
+        "tools"
+      ],
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "pattern": "^[a-z0-9-]+$"
+        },
+        "metadata": {
+          "$ref": "#/$defs/agentMetadata"
+        },
+        "instruction": {
+          "type": "string",
+          "minLength": 1
+        },
+        "first_message": {
+          "type": "string",
+          "minLength": 1
+        },
+        "variables": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/variableField"
+          }
+        },
+        "pipeline": {
+          "$ref": "#/$defs/pipelineConfig"
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/toolDefinition"
+          }
+        }
+      }
+    },
+    "agentMetadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "display_name",
+        "persona"
+      ],
+      "properties": {
+        "display_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "persona": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "pipelineConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "stt",
+        "tts",
+        "llm"
+      ],
+      "properties": {
+        "stt": {
+          "$ref": "#/$defs/providerConfig"
+        },
+        "tts": {
+          "$ref": "#/$defs/providerConfig"
+        },
+        "llm": {
+          "$ref": "#/$defs/providerConfig"
+        }
+      }
+    },
+    "providerConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider",
+        "model"
+      ],
+      "properties": {
+        "provider": {
+          "type": "string",
+          "minLength": 1
+        },
+        "model": {
+          "type": "string",
+          "minLength": 1
+        },
+        "voice_id": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "toolDefinition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "description",
+        "parameters"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z_][a-z0-9_]*$"
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/toolParameter"
+          }
+        }
+      }
+    },
+    "toolParameter": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "type",
+        "required"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "boolean",
+            "integer",
+            "object",
+            "array"
+          ]
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "inputField": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "type",
+        "required"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "boolean",
+            "integer",
+            "date"
+          ]
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "workflowStep": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "action"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9-]+$"
+        },
+        "action": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string"
+        },
+        "tool": {
+          "type": "string",
+          "pattern": "^[a-z_][a-z0-9_]*$"
+        }
+      }
+    },
+    "variableField": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "type",
+        "default"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "boolean",
+            "integer",
+            "object",
+            "array"
+          ]
+        },
+        "default": {
+          "$comment": "Intentionally untyped to support polymorphic default values (string, boolean, object, etc.) as defined by the 'type' field.",
+          "description": "Default session value for this variable."
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/schemas/agent-task.schema.json
+++ b/schemas/agent-task.schema.json
@@ -100,6 +100,74 @@
             "$ref": "#/$defs/toolDefinition"
           },
           "description": "Discriminated union aligned with frontend ToolDefinition (agentConfig.ts)."
+        },
+        "confirmations": {
+          "$ref": "#/$defs/confirmationsConfig",
+          "description": "Optional — architecture §4.1 / FE AgentConfig.confirmations."
+        },
+        "language": {
+          "$ref": "#/$defs/languageConfig",
+          "description": "Optional — multilingual defaults; FE AgentConfig.language."
+        },
+        "vad": {
+          "$ref": "#/$defs/vadConfig",
+          "description": "Optional — voice activity detection; FE AgentConfig.vad."
+        }
+      }
+    },
+    "confirmationsConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "tools"],
+      "properties": {
+        "required": {
+          "type": "boolean",
+          "description": "Global switch: whether actions require explicit user confirmation."
+        },
+        "tools": {
+          "type": "array",
+          "description": "Allow-list of tool names that bypass confirmation when non-empty semantics apply per product rules.",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "languageConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["default", "auto_detect", "supported"],
+      "properties": {
+        "default": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Default language tag (e.g. BCP-47)."
+        },
+        "auto_detect": {
+          "type": "boolean"
+        },
+        "supported": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "vadConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider", "silence_threshold_ms"],
+      "properties": {
+        "provider": {
+          "type": "string",
+          "enum": ["cerebrio", "none"]
+        },
+        "silence_threshold_ms": {
+          "type": "integer",
+          "minimum": 0
         }
       }
     },

--- a/schemas/agent-task.schema.json
+++ b/schemas/agent-task.schema.json
@@ -98,7 +98,8 @@
           "type": "array",
           "items": {
             "$ref": "#/$defs/toolDefinition"
-          }
+          },
+          "description": "Discriminated union aligned with frontend ToolDefinition (agentConfig.ts)."
         }
       }
     },
@@ -186,14 +187,27 @@
       }
     },
     "toolDefinition": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/dataExtractionTool"
+        },
+        {
+          "$ref": "#/$defs/endCallTool"
+        },
+        {
+          "$ref": "#/$defs/agentTransferTool"
+        }
+      ]
+    },
+    "dataExtractionTool": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "name",
-        "description",
-        "parameters"
-      ],
+      "required": ["type", "name", "description", "params"],
       "properties": {
+        "type": {
+          "type": "string",
+          "const": "data_extraction"
+        },
         "name": {
           "type": "string",
           "pattern": "^[a-z_][a-z0-9_]*$"
@@ -202,10 +216,57 @@
           "type": "string",
           "minLength": 1
         },
-        "parameters": {
+        "params": {
           "type": "array",
+          "description": "Matches frontend DataExtractionTool.params (ToolParam[]).",
           "items": {
             "$ref": "#/$defs/toolParameter"
+          }
+        }
+      }
+    },
+    "endCallTool": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "name", "description"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "end_call"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "agentTransferTool": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "name", "description", "targets"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "agent_transfer"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "targets": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
           }
         }
       }
@@ -226,14 +287,8 @@
         },
         "type": {
           "type": "string",
-          "enum": [
-            "string",
-            "number",
-            "boolean",
-            "integer",
-            "object",
-            "array"
-          ]
+          "enum": ["string", "number", "boolean", "date"],
+          "description": "Matches frontend ParamType."
         },
         "required": {
           "type": "boolean"

--- a/schemas/agent-task.schema.json
+++ b/schemas/agent-task.schema.json
@@ -214,14 +214,15 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "name",
+        "variable_name",
         "type",
         "required"
       ],
       "properties": {
-        "name": {
+        "variable_name": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "description": "Aligned with frontend ToolParam.variable_name (Preet contract)."
         },
         "type": {
           "type": "string",

--- a/schemas/agent-task.schema.json
+++ b/schemas/agent-task.schema.json
@@ -83,8 +83,7 @@
           "minLength": 1
         },
         "first_message": {
-          "type": "string",
-          "minLength": 1
+          "$ref": "#/$defs/firstMessage"
         },
         "variables": {
           "type": "array",
@@ -100,6 +99,26 @@
           "items": {
             "$ref": "#/$defs/toolDefinition"
           }
+        }
+      }
+    },
+    "firstMessage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "message", "prompt"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "text",
+          "description": "Matches frontend FirstMessage.type — voice UI uses \"text\" today."
+        },
+        "message": {
+          "type": "string",
+          "description": "Primary greeting shown/spoken when the session starts."
+        },
+        "prompt": {
+          "type": "string",
+          "description": "Optional auxiliary prompt (may be empty)."
         }
       }
     },

--- a/schemas/examples/agent-task.example.json
+++ b/schemas/examples/agent-task.example.json
@@ -1,0 +1,118 @@
+{
+  "schema_version": "1.0.0",
+  "task": {
+    "name": "book_service_appointment",
+    "description": "Collect caller details and request a preferred appointment date for a plumbing service.",
+    "required_inputs": [
+      {
+        "name": "caller_name",
+        "type": "string",
+        "required": true,
+        "description": "Full name of the caller."
+      },
+      {
+        "name": "phone_number",
+        "type": "string",
+        "required": true,
+        "description": "Callback number."
+      },
+      {
+        "name": "preferred_date",
+        "type": "date",
+        "required": true,
+        "description": "Preferred appointment date."
+      }
+    ],
+    "workflow_steps": [
+      {
+        "id": "greet",
+        "action": "send_first_message",
+        "description": "Send greeting and explain the service flow."
+      },
+      {
+        "id": "collect-data",
+        "action": "extract_required_fields",
+        "description": "Collect name, phone, and preferred date.",
+        "tool": "extract_data"
+      },
+      {
+        "id": "confirm",
+        "action": "confirm_booking_details",
+        "description": "Read back details and ask for confirmation."
+      },
+      {
+        "id": "end",
+        "action": "end_call",
+        "description": "Close call after confirmation.",
+        "tool": "end_call"
+      }
+    ]
+  },
+  "agent": {
+    "agent_id": "front-desk-receptionist",
+    "metadata": {
+      "display_name": "Front Desk Receptionist",
+      "persona": "Friendly, concise, and professional service receptionist",
+      "description": "Handles appointment booking and hand-off for urgent support."
+    },
+    "instruction": "You are the receptionist for Mueller Plumbing. Gather required details, confirm them clearly, and keep responses short.",
+    "first_message": "Hi, thanks for calling Mueller Plumbing. How can I help you today?",
+    "variables": [
+      {
+        "name": "language",
+        "type": "string",
+        "default": "de",
+        "description": "Current conversation language."
+      },
+      {
+        "name": "is_urgent",
+        "type": "boolean",
+        "default": false,
+        "description": "Whether caller requests urgent help."
+      }
+    ],
+    "pipeline": {
+      "stt": {
+        "provider": "deepgram",
+        "model": "nova-3"
+      },
+      "tts": {
+        "provider": "elevenlabs",
+        "model": "eleven_multilingual_v2",
+        "voice_id": "21m00Tcm4TlvDq8ikWAM"
+      },
+      "llm": {
+        "provider": "openai",
+        "model": "gpt-4o-mini"
+      }
+    },
+    "tools": [
+      {
+        "name": "extract_data",
+        "description": "Extracts caller details from conversation turns.",
+        "parameters": [
+          {
+            "name": "caller_name",
+            "type": "string",
+            "required": true
+          },
+          {
+            "name": "phone_number",
+            "type": "string",
+            "required": true
+          },
+          {
+            "name": "preferred_date",
+            "type": "string",
+            "required": true
+          }
+        ]
+      },
+      {
+        "name": "end_call",
+        "description": "Ends the active voice call session.",
+        "parameters": []
+      }
+    ]
+  }
+}

--- a/schemas/examples/agent-task.example.json
+++ b/schemas/examples/agent-task.example.json
@@ -127,6 +127,19 @@
         "name": "end_call",
         "description": "Ends the active voice call session."
       }
-    ]
+    ],
+    "confirmations": {
+      "required": true,
+      "tools": []
+    },
+    "language": {
+      "default": "de",
+      "auto_detect": true,
+      "supported": ["de", "en"]
+    },
+    "vad": {
+      "provider": "cerebrio",
+      "silence_threshold_ms": 500
+    }
   }
 }

--- a/schemas/examples/agent-task.example.json
+++ b/schemas/examples/agent-task.example.json
@@ -92,9 +92,10 @@
     },
     "tools": [
       {
+        "type": "data_extraction",
         "name": "extract_data",
         "description": "Extracts caller details from conversation turns.",
-        "parameters": [
+        "params": [
           {
             "variable_name": "caller_name",
             "description": "Caller's full name.",
@@ -110,15 +111,21 @@
           {
             "variable_name": "preferred_date",
             "description": "Preferred appointment date.",
-            "type": "string",
+            "type": "date",
             "required": true
           }
         ]
       },
       {
+        "type": "agent_transfer",
+        "name": "transfer_to_emergency",
+        "description": "Hand off urgent callers to the emergency line agent.",
+        "targets": ["emergency-line-agent"]
+      },
+      {
+        "type": "end_call",
         "name": "end_call",
-        "description": "Ends the active voice call session.",
-        "parameters": []
+        "description": "Ends the active voice call session."
       }
     ]
   }

--- a/schemas/examples/agent-task.example.json
+++ b/schemas/examples/agent-task.example.json
@@ -96,17 +96,20 @@
         "description": "Extracts caller details from conversation turns.",
         "parameters": [
           {
-            "name": "caller_name",
+            "variable_name": "caller_name",
+            "description": "Caller's full name.",
             "type": "string",
             "required": true
           },
           {
-            "name": "phone_number",
+            "variable_name": "phone_number",
+            "description": "Callback number.",
             "type": "string",
             "required": true
           },
           {
-            "name": "preferred_date",
+            "variable_name": "preferred_date",
+            "description": "Preferred appointment date.",
             "type": "string",
             "required": true
           }

--- a/schemas/examples/agent-task.example.json
+++ b/schemas/examples/agent-task.example.json
@@ -56,7 +56,11 @@
       "description": "Handles appointment booking and hand-off for urgent support."
     },
     "instruction": "You are the receptionist for Mueller Plumbing. Gather required details, confirm them clearly, and keep responses short.",
-    "first_message": "Hi, thanks for calling Mueller Plumbing. How can I help you today?",
+    "first_message": {
+      "type": "text",
+      "message": "Hi, thanks for calling Mueller Plumbing. How can I help you today?",
+      "prompt": ""
+    },
     "variables": [
       {
         "name": "language",


### PR DESCRIPTION
Closes #6.

Adds the canonical agent-task JSON schema, a service-appointment-booking example, schema documentation, the `jsonschema` dependency, and automated validation tests covering the success path and two failure paths (missing required field, invalid id pattern).
