### PR TITLE
fix(orchestration): handle Unicode punctuation from STT transcriptions

### DIFF
--- a/backend/src/taskorbit/livekit_agent/llm.py
+++ b/backend/src/taskorbit/livekit_agent/llm.py
@@ -85,17 +85,35 @@ def _extract_text(item: Any) -> str:
     """
     content = getattr(item, "content", None)
     if isinstance(content, str):
-        return content.strip()
+        return _normalize_text(content)
     if isinstance(content, list):
         parts: list[str] = []
         for entry in content:
             if isinstance(entry, str):
                 parts.append(entry)
-        return " ".join(parts).strip()
+        return _normalize_text(" ".join(parts))
     text_attr = getattr(item, "text_content", None)
     if isinstance(text_attr, str):
-        return text_attr.strip()
+        return _normalize_text(text_attr)
     return ""
+
+
+def _normalize_text(text: str) -> str:
+    """Replace common Unicode punctuation variants with ASCII equivalents.
+
+    STT providers (e.g. Deepgram) can emit Unicode dashes and smart quotes
+    in transcriptions. Replacing them prevents UnicodeEncodeError when the
+    text is passed to LLM HTTP clients that use ASCII-only JSON serialisation.
+    """
+    return (
+        text.replace("—", "-")  # em dash
+        .replace("–", "-")  # en dash
+        .replace("‘", "'")  # left single quotation mark
+        .replace("’", "'")  # right single quotation mark
+        .replace("“", '"')  # left double quotation mark
+        .replace("”", '"')  # right double quotation mark
+        .strip()
+    )
 
 
 class OrchestratorAgent(Agent):

--- a/backend/src/taskorbit/orchestration/__init__.py
+++ b/backend/src/taskorbit/orchestration/__init__.py
@@ -106,6 +106,14 @@ class ConversationOrchestrator:
                 status="error",
                 error=f"LLM call timed out after {self._settings.llm_timeout_seconds} seconds.",
             )
+        except UnicodeEncodeError as exc:
+            logger.error("encoding_error", error=str(exc), conversation_id=request.conversation_id)
+            return ConversationResponse(
+                conversation_id=request.conversation_id,
+                reply=self._make_assistant_message("An unexpected error occurred."),
+                status="error",
+                error=str(exc),
+            )
         except ValueError as exc:
             logger.warning(
                 "invalid_runtime_input", error=str(exc), conversation_id=request.conversation_id
@@ -136,7 +144,7 @@ class ConversationOrchestrator:
             f"Persona: {agent_config.persona}",
         ]
         if active_tool:
-            lines.append(f"Current task: {active_tool.name} — {active_tool.description}")
+            lines.append(f"Current task: {active_tool.name} - {active_tool.description}")
             if active_tool.parameters:
                 lines.append(f"Available parameters: {active_tool.parameters}")
         return "\n".join(lines)


### PR DESCRIPTION
Deepgram can emit em dashes and smart quotes in transcriptions; these caused UnicodeEncodeError (a ValueError subclass) to be silently caught and misclassified as invalid_runtime_input in the orchestrator.

- Replace hardcoded em dash in _build_system_prompt with ASCII hyphen
- Add except UnicodeEncodeError before except ValueError so encoding failures surface as encoding_error (log error) not invalid_runtime_input
- Add _normalize_text() in livekit_agent/llm.py to replace common Unicode punctuation variants (em/en dashes, smart quotes) with ASCII equivalents before transcribed text reaches the LLM HTTP client