### PR TITLE
Feature/integrate cloud environment with iac

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,8 +30,8 @@ concurrency:
 
 env:
   GCP_PROJECT_ID: amos-taskorbit
-  GCP_REGION: europe-west1
-  REGISTRY: europe-west1-docker.pkg.dev
+  GCP_REGION: europe-west3
+  REGISTRY: europe-west3-docker.pkg.dev
   REPOSITORY: taskorbit
 
 jobs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,138 @@
+name: Deploy to GCP
+
+# Deploys backend, worker, and frontend to Cloud Run on every push to main.
+# Authentication uses Workload Identity Federation (OIDC) — no long-lived
+# service-account keys are stored in GitHub secrets.
+#
+# Required GitHub Actions secrets:
+#   GCP_PROJECT_ID                  — GCP project ID
+#   GCP_WORKLOAD_IDENTITY_PROVIDER  — output of `terraform output workload_identity_provider`
+#   GCP_SA_EMAIL                    — output of `terraform output cicd_service_account_email`
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GCP_REGION: europe-west1
+  REGISTRY: europe-west1-docker.pkg.dev
+  REPOSITORY: taskorbit
+
+jobs:
+  # ── Build & push images ──────────────────────────────────────────────────────
+  build:
+    name: Build & Push Images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write   # required for Workload Identity OIDC token
+
+    outputs:
+      backend-image: ${{ steps.backend-tag.outputs.image }}
+      frontend-image: ${{ steps.frontend-tag.outputs.image }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate to GCP
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SA_EMAIL }}
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker ${{ env.REGISTRY }} --quiet
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Compute image tags
+        id: backend-tag
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ secrets.GCP_PROJECT_ID }}/${{ env.REPOSITORY }}/backend"
+          echo "image=${IMAGE}:${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          echo "BACKEND_IMAGE=${IMAGE}" >> "$GITHUB_ENV"
+
+      - name: Compute frontend tag
+        id: frontend-tag
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ secrets.GCP_PROJECT_ID }}/${{ env.REPOSITORY }}/frontend"
+          echo "image=${IMAGE}:${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          echo "FRONTEND_IMAGE=${IMAGE}" >> "$GITHUB_ENV"
+
+      - name: Build & push backend (prod target)
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          target: prod
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: |
+            ${{ env.BACKEND_IMAGE }}:${{ github.sha }}
+            ${{ env.BACKEND_IMAGE }}:latest
+
+      - name: Build & push frontend (prod target)
+        uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          target: prod
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: |
+            ${{ env.FRONTEND_IMAGE }}:${{ github.sha }}
+            ${{ env.FRONTEND_IMAGE }}:latest
+
+  # ── Deploy to Cloud Run ───────────────────────────────────────────────────────
+  deploy:
+    name: Deploy to Cloud Run
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SA_EMAIL }}
+
+      - name: Deploy backend
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: taskorbit-backend
+          region: ${{ env.GCP_REGION }}
+          image: ${{ needs.build.outputs.backend-image }}
+
+      - name: Deploy worker
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: taskorbit-worker
+          region: ${{ env.GCP_REGION }}
+          image: ${{ needs.build.outputs.backend-image }}
+
+      - name: Deploy frontend
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: taskorbit-frontend
+          region: ${{ env.GCP_REGION }}
+          image: ${{ needs.build.outputs.frontend-image }}
+
+      - name: Print deployed URLs
+        run: |
+          echo "### Deployed services" >> "$GITHUB_STEP_SUMMARY"
+          gcloud run services list \
+            --region=${{ env.GCP_REGION }} \
+            --filter="metadata.name ~ taskorbit" \
+            --format="table(metadata.name, status.url)" \
+            >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,9 @@
 name: Deploy to GCP
 
-# Deploys backend, worker, and frontend to Cloud Run on every push to main.
+# Deploys backend, worker, and frontend to Cloud Run after all quality gates
+# pass on main. Triggered by workflow_run so a broken lint or smoke-test run
+# on main never reaches production.
+#
 # Authentication uses Workload Identity Federation (OIDC) — no long-lived
 # service-account keys are stored in GitHub secrets.
 #
@@ -10,12 +13,14 @@ name: Deploy to GCP
 #   GCP_SA_EMAIL                    — output of `terraform output cicd_service_account_email`
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Backend Linting", "Frontend Linting", "Start Web Service"]
+    types: [completed]
     branches: [main]
   workflow_dispatch:
 
 concurrency:
-  group: deploy-${{ github.ref }}
+  group: deploy-${{ github.event.workflow_run.head_branch || github.ref }}
   cancel-in-progress: true
 
 env:
@@ -28,6 +33,8 @@ jobs:
   build:
     name: Build & Push Images
     runs-on: ubuntu-latest
+    # Skip if triggered by a failed workflow_run; always run on workflow_dispatch.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: read
       id-token: write   # required for Workload Identity OIDC token
@@ -39,6 +46,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # workflow_run sets github.sha to the workflow file ref, not the pushed
+          # commit — use head_sha from the triggering run instead.
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Authenticate to GCP
         id: auth

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,9 @@ on:
     types: [completed]
     branches:
       - main
+  push:
+    # Testing only — remove before merging to main
+    branches:
       - feature/integrate-cloud-environment-with-iac
   workflow_dispatch:
 
@@ -36,7 +39,7 @@ jobs:
   build:
     name: Build & Push Images
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,18 +10,16 @@ name: Deploy to GCP
 #   GCP_SA_KEY  — base64-encoded JSON key for terraform-deployer SA
 #
 # TODO: switch GCP_SA_KEY to Workload Identity (OIDC) after Step 3 IAM is applied.
-# Remove feature/integrate-cloud-environment-with-iac from branches before merging to main.
 
 on:
   workflow_run:
     workflows: ["Backend Linting", "Frontend Linting", "Start Web Service"]
     types: [completed]
     branches:
-      - main
+      - prod
   push:
-    # Testing only — remove before merging to main
     branches:
-      - feature/integrate-cloud-environment-with-iac
+      - prod
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,7 @@ jobs:
     outputs:
       backend-image: ${{ steps.backend-tag.outputs.image }}
       frontend-image: ${{ steps.frontend-tag.outputs.image }}
+      grafana-image: ${{ steps.grafana-tag.outputs.image }}
 
     steps:
       - name: Checkout
@@ -79,6 +80,13 @@ jobs:
           echo "image=${IMAGE}:${{ github.sha }}" >> "$GITHUB_OUTPUT"
           echo "FRONTEND_IMAGE=${IMAGE}" >> "$GITHUB_ENV"
 
+      - name: Compute grafana image tag
+        id: grafana-tag
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.GCP_PROJECT_ID }}/${{ env.REPOSITORY }}/grafana"
+          echo "image=${IMAGE}:${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          echo "GRAFANA_IMAGE=${IMAGE}" >> "$GITHUB_ENV"
+
       - name: Build & push backend (prod target)
         uses: docker/build-push-action@v6
         with:
@@ -102,6 +110,17 @@ jobs:
           tags: |
             ${{ env.FRONTEND_IMAGE }}:${{ github.sha }}
             ${{ env.FRONTEND_IMAGE }}:latest
+
+      - name: Build & push grafana (with provisioning)
+        uses: docker/build-push-action@v6
+        with:
+          context: ./infra/grafana
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: |
+            ${{ env.GRAFANA_IMAGE }}:${{ github.sha }}
+            ${{ env.GRAFANA_IMAGE }}:latest
 
   # ── Deploy to Cloud Run ───────────────────────────────────────────────────────
   deploy:
@@ -138,6 +157,13 @@ jobs:
           service: taskorbit-frontend
           region: ${{ env.GCP_REGION }}
           image: ${{ needs.build.outputs.frontend-image }}
+
+      - name: Deploy grafana
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: taskorbit-grafana
+          region: ${{ env.GCP_REGION }}
+          image: ${{ needs.build.outputs.grafana-image }}
 
       - name: Print deployed URLs
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ on:
     types: [completed]
     branches:
       - main
-      # - feature/integrate-cloud-environment-with-iac
+      - feature/integrate-cloud-environment-with-iac
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,22 +1,24 @@
 name: Deploy to GCP
 
 # Deploys backend, worker, and frontend to Cloud Run after all quality gates
-# pass on main. Triggered by workflow_run so a broken lint or smoke-test run
-# on main never reaches production.
+# pass. Triggered by workflow_run so a broken lint or smoke-test run never
+# reaches production.
 #
-# Authentication uses Workload Identity Federation (OIDC) — no long-lived
-# service-account keys are stored in GitHub secrets.
+# Authentication uses a GCP service account key stored as a GitHub secret.
 #
 # Required GitHub Actions secrets:
-#   GCP_PROJECT_ID                  — GCP project ID
-#   GCP_WORKLOAD_IDENTITY_PROVIDER  — output of `terraform output workload_identity_provider`
-#   GCP_SA_EMAIL                    — output of `terraform output cicd_service_account_email`
+#   GCP_SA_KEY  — base64-encoded JSON key for terraform-deployer SA
+#
+# TODO: switch GCP_SA_KEY to Workload Identity (OIDC) after Step 3 IAM is applied.
+# Remove feature/integrate-cloud-environment-with-iac from branches before merging to main.
 
 on:
   workflow_run:
     workflows: ["Backend Linting", "Frontend Linting", "Start Web Service"]
     types: [completed]
-    branches: [main]
+    branches:
+      - main
+      # - feature/integrate-cloud-environment-with-iac
   workflow_dispatch:
 
 concurrency:
@@ -24,6 +26,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  GCP_PROJECT_ID: amos-taskorbit
   GCP_REGION: europe-west1
   REGISTRY: europe-west1-docker.pkg.dev
   REPOSITORY: taskorbit
@@ -33,11 +36,10 @@ jobs:
   build:
     name: Build & Push Images
     runs-on: ubuntu-latest
-    # Skip if triggered by a failed workflow_run; always run on workflow_dispatch.
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: read
-      id-token: write   # required for Workload Identity OIDC token
+      id-token: write
 
     outputs:
       backend-image: ${{ steps.backend-tag.outputs.image }}
@@ -47,16 +49,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          # workflow_run sets github.sha to the workflow file ref, not the pushed
-          # commit — use head_sha from the triggering run instead.
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Authenticate to GCP
-        id: auth
         uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_SA_EMAIL }}
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker ${{ env.REGISTRY }} --quiet
@@ -64,17 +62,17 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Compute image tags
+      - name: Compute backend image tag
         id: backend-tag
         run: |
-          IMAGE="${{ env.REGISTRY }}/${{ secrets.GCP_PROJECT_ID }}/${{ env.REPOSITORY }}/backend"
+          IMAGE="${{ env.REGISTRY }}/${{ env.GCP_PROJECT_ID }}/${{ env.REPOSITORY }}/backend"
           echo "image=${IMAGE}:${{ github.sha }}" >> "$GITHUB_OUTPUT"
           echo "BACKEND_IMAGE=${IMAGE}" >> "$GITHUB_ENV"
 
-      - name: Compute frontend tag
+      - name: Compute frontend image tag
         id: frontend-tag
         run: |
-          IMAGE="${{ env.REGISTRY }}/${{ secrets.GCP_PROJECT_ID }}/${{ env.REPOSITORY }}/frontend"
+          IMAGE="${{ env.REGISTRY }}/${{ env.GCP_PROJECT_ID }}/${{ env.REPOSITORY }}/frontend"
           echo "image=${IMAGE}:${{ github.sha }}" >> "$GITHUB_OUTPUT"
           echo "FRONTEND_IMAGE=${IMAGE}" >> "$GITHUB_ENV"
 
@@ -115,8 +113,7 @@ jobs:
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_SA_EMAIL }}
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: Deploy backend
         uses: google-github-actions/deploy-cloudrun@v2
@@ -143,6 +140,7 @@ jobs:
         run: |
           echo "### Deployed services" >> "$GITHUB_STEP_SUMMARY"
           gcloud run services list \
+            --project=${{ env.GCP_PROJECT_ID }} \
             --region=${{ env.GCP_REGION }} \
             --filter="metadata.name ~ taskorbit" \
             --format="table(metadata.name, status.url)" \

--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,9 @@ terraform/*.tfstate.backup
 terraform/*.tfvars
 !terraform/terraform.tfvars.example
 # .terraform.lock.hcl is intentionally committed (pins provider versions)
+
+# GCP service account key files — never commit credentials
+terraform/*.json
+*.json.key
+*-credentials.json
+gha-creds-*.json

--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,11 @@ frontend/tsconfig.*.tsbuildinfo
 # Large binary video files — link to external host instead
 *.mkv
 *.zip
+
+# Terraform — never commit state or var files containing secrets
+terraform/.terraform/
+terraform/*.tfstate
+terraform/*.tfstate.backup
+terraform/*.tfvars
+!terraform/terraform.tfvars.example
+# .terraform.lock.hcl is intentionally committed (pins provider versions)

--- a/Documentation/cloud-setup-guide.md
+++ b/Documentation/cloud-setup-guide.md
@@ -1,0 +1,399 @@
+# GCP Cloud Setup — TaskOrbit Conversational Agent
+
+> **Scope.** This guide covers the one-time Terraform bootstrap, how the deploy
+> pipeline authenticates to GCP without long-lived keys, how secrets are stored
+> and consumed by Cloud Run, and how developers can authenticate locally.
+>
+> For the lint/test/smoke pipeline see `Documentation/ci-cd.md`.
+> For LiveKit credential generation and local Docker Compose setup see
+> `Documentation/livekit-cloud-setup.md`.
+> For the full Terraform variable reference see `terraform/terraform.tfvars.example`.
+> For the Terraform module reference see `terraform/README.md`.
+
+---
+
+## Prerequisites
+
+- **Terraform >= 1.7** (matches `terraform/versions.tf`)
+- **gcloud CLI** authenticated as a GCP project owner for the initial bootstrap
+- **Docker** (needed for the CI/CD pipeline to build images)
+- A **GCP project with billing enabled**
+- The repository cloned and `terraform/terraform.tfvars` created from
+  `terraform/terraform.tfvars.example` with real values filled in
+
+---
+
+## 1. One-time Bootstrap
+
+These steps run once per environment. After they complete, all future deployments
+are handled automatically by the CI/CD pipeline.
+
+### 1.1 Create the Terraform state bucket
+
+Terraform records the state of every resource it manages in a GCS bucket.
+This bucket must exist before running `terraform init`. The bucket name is
+currently a placeholder in `terraform/backend.tf` — replace it first.
+
+```bash
+PROJECT_ID="your-gcp-project-id"
+REGION="europe-west1"
+
+# Create the state bucket (one-time only)
+gsutil mb -l ${REGION} gs://${PROJECT_ID}-taskorbit-tf-state
+
+# Enable versioning so previous state files are preserved
+gsutil versioning set on gs://${PROJECT_ID}-taskorbit-tf-state
+```
+
+Then open `terraform/backend.tf` and replace the placeholder:
+
+```hcl
+# Before
+bucket = "REPLACE_WITH_PROJECT_ID-taskorbit-tf-state"
+
+# After
+bucket = "your-gcp-project-id-taskorbit-tf-state"
+```
+
+### 1.2 Provision all GCP infrastructure
+
+`terraform apply` enables the required APIs and creates all resources across
+8 modules (network, IAM, registry, database, secrets, Cloud Run, scheduler,
+observability). First-run takes approximately 15 minutes — Cloud SQL provisioning
+dominates.
+
+```bash
+# Authenticate as a project owner
+gcloud auth application-default login
+gcloud config set project ${PROJECT_ID}
+
+cd terraform
+
+# Download providers and connect to the remote state bucket
+terraform init
+
+# Review what will be created before applying
+terraform plan -out=tfplan
+
+# Apply — creates ~50 resources
+terraform apply tfplan
+```
+
+> **Note on deletion protection.** Cloud SQL is created with
+> `deletion_protection = true` (see `terraform/modules/database/main.tf`).
+> Running `terraform destroy` will fail until you manually set that flag to
+> `false` and re-apply. This is intentional to prevent accidental data loss.
+
+### 1.3 Capture outputs for the next steps
+
+After a successful apply, collect the values you need for DNS and GitHub:
+
+```bash
+# For GitHub Actions secrets (see Section 3.2)
+terraform output workload_identity_provider
+terraform output cicd_service_account_email
+
+# For DNS configuration
+terraform output load_balancer_ip
+
+# For local Cloud SQL access (see Section 5.3)
+terraform output database_instance_name
+```
+
+### 1.4 Point DNS to the load balancer
+
+Create DNS **A records** at your domain registrar pointing all three subdomains
+to the IP from `terraform output load_balancer_ip`:
+
+| Subdomain | Purpose |
+|---|---|
+| `taskorbit.yourdomain.com` | React frontend |
+| `api.taskorbit.yourdomain.com` | FastAPI backend |
+| `grafana.taskorbit.yourdomain.com` | Grafana dashboards |
+
+The managed SSL certificate Google provisions will stay in `PROVISIONING` state
+until DNS propagates (usually 10–30 minutes).
+
+---
+
+## 2. What Terraform Provisions
+
+For reference, this table maps each Terraform module to the GCP resources it creates:
+
+| Module | GCP resources | Key file |
+|---|---|---|
+| `network` | VPC, subnet, Cloud Router, NAT gateway, VPC connector | `terraform/modules/network/main.tf` |
+| `iam` | 5 service accounts, Workload Identity pool + provider, IAM bindings | `terraform/modules/iam/main.tf` |
+| `registry` | Artifact Registry repository `taskorbit` (europe-west1) | `terraform/modules/registry/main.tf` |
+| `database` | Cloud SQL PostgreSQL 16, private IP only, regional HA, PITR backups | `terraform/modules/database/main.tf` |
+| `secrets` | 15 Secret Manager secrets prefixed `taskorbit-` | `terraform/modules/secrets/main.tf` |
+| `cloud_run` | 3 Cloud Run v2 services + Global HTTPS load balancer | `terraform/modules/cloud_run/main.tf` |
+| `scheduler` | Cloud Scheduler jobs: SQL stop (22:00 CET) / start (07:00 CET) Mon–Fri | `terraform/modules/scheduler/main.tf` |
+| `observability` | Prometheus + Loki + Grafana on Cloud Run, GCS bucket for logs | `terraform/modules/observability/main.tf` |
+
+---
+
+## 3. CI/CD Authentication — Workload Identity Federation
+
+### 3.1 How it works
+
+The deploy pipeline uses **Workload Identity Federation (WIF)** so GitHub Actions
+never needs a permanent GCP service account key. Instead:
+
+1. When a push lands on `main`, GitHub's OIDC provider
+   (`https://token.actions.githubusercontent.com`) issues a short-lived JWT
+   that identifies the repository and workflow run.
+2. The `google-github-actions/auth@v2` step sends that JWT to the GCP Workload
+   Identity pool (`github-pool/providers/github-provider`) created by
+   `terraform/modules/iam/main.tf`.
+3. GCP verifies the JWT and checks the `attribute_condition`:
+   ```hcl
+   attribute_condition = "assertion.repository == 'amosproj/amos2026ss04-taskorbit-conversational-agent'"
+   ```
+   This ensures only this repository can use the pool — no other GitHub repo
+   can impersonate the `taskorbit-cicd` service account.
+4. GCP exchanges the JWT for a short-lived access token scoped to
+   `taskorbit-cicd`, which holds only the permissions it needs:
+   `roles/artifactregistry.writer`, `roles/run.admin`,
+   `roles/iam.serviceAccountUser`.
+
+No long-lived key is ever created or stored. The token expires after the workflow run.
+
+The deploy only fires after all three quality-gate workflows (**Backend Linting**,
+**Frontend Linting**, **Start Web Service**) pass on `main` — see
+`.github/workflows/deploy.yml`.
+
+### 3.2 Configure the three required GitHub secrets
+
+These must be set in the repository under **Settings → Secrets and variables → Actions**
+(source: header comment in `.github/workflows/deploy.yml`):
+
+| Secret name | How to get the value |
+|---|---|
+| `GCP_PROJECT_ID` | Your GCP project ID (plain string) |
+| `GCP_WORKLOAD_IDENTITY_PROVIDER` | `cd terraform && terraform output -raw workload_identity_provider` |
+| `GCP_SA_EMAIL` | `cd terraform && terraform output -raw cicd_service_account_email` |
+
+Using the GitHub CLI:
+
+```bash
+gh secret set GCP_PROJECT_ID --body "${PROJECT_ID}"
+
+gh secret set GCP_WORKLOAD_IDENTITY_PROVIDER \
+  --body "$(cd terraform && terraform output -raw workload_identity_provider)"
+
+gh secret set GCP_SA_EMAIL \
+  --body "$(cd terraform && terraform output -raw cicd_service_account_email)"
+```
+
+### 3.3 What the deploy workflow does
+
+On every push to `main` (after quality gates pass):
+
+1. **build job** — authenticates to GCP via WIF, builds `backend` and `frontend`
+   Docker images at the `prod` target, and pushes each with two tags:
+   `sha-<commit>` (immutable) and `latest`.
+2. **deploy job** — re-authenticates, then deploys all three Cloud Run services:
+   `taskorbit-backend`, `taskorbit-worker` (reuses the backend image), and
+   `taskorbit-frontend`.
+
+---
+
+## 4. Secrets Management
+
+### 4.1 How secrets are created
+
+`terraform/modules/secrets/main.tf` uses a `for_each` over `local.app_secrets`
+to create 15 secrets in Secret Manager, all prefixed `taskorbit-`:
+
+| Secret Manager ID | Holds |
+|---|---|
+| `taskorbit-livekit-url` | LiveKit Cloud WSS URL |
+| `taskorbit-livekit-api-key` | LiveKit API key |
+| `taskorbit-livekit-api-secret` | LiveKit API secret |
+| `taskorbit-deepgram-api-key` | Deepgram API key |
+| `taskorbit-deepgram-model` | e.g. `nova-3` |
+| `taskorbit-deepgram-language` | e.g. `multi` |
+| `taskorbit-elevenlabs-api-key` | ElevenLabs API key |
+| `taskorbit-elevenlabs-voice-id` | Voice ID |
+| `taskorbit-elevenlabs-model` | Model name |
+| `taskorbit-openai-api-key` | OpenAI key (optional) |
+| `taskorbit-openai-model` | e.g. `gpt-4o-mini` |
+| `taskorbit-google-api-key` | Google AI key (optional) |
+| `taskorbit-google-model` | e.g. `gemini-2.5-flash` |
+| `taskorbit-database-url` | PostgreSQL connection string (computed by Terraform) |
+| `taskorbit-grafana-admin-password` | Grafana admin password |
+
+### 4.2 How Cloud Run services read secrets
+
+Each secret is injected into Cloud Run as an environment variable at instance
+startup via `secret_key_ref` pointing to `version = "latest"`. The backend and
+worker service accounts hold `roles/secretmanager.secretAccessor`
+(`terraform/modules/iam/main.tf`), which grants them read access.
+
+| Environment variable | Secret Manager ID |
+|---|---|
+| `DATABASE_URL` | `taskorbit-database-url` |
+| `LIVEKIT_URL` | `taskorbit-livekit-url` |
+| `LIVEKIT_API_KEY` | `taskorbit-livekit-api-key` |
+| `LIVEKIT_API_SECRET` | `taskorbit-livekit-api-secret` |
+| `DEEPGRAM_API_KEY` | `taskorbit-deepgram-api-key` |
+| `ELEVENLABS_API_KEY` | `taskorbit-elevenlabs-api-key` |
+| `OPENAI_API_KEY` | `taskorbit-openai-api-key` |
+| `GOOGLE_API_KEY` | `taskorbit-google-api-key` |
+
+### 4.3 Rotating a secret without Terraform drift
+
+`terraform/modules/secrets/main.tf` includes `lifecycle { ignore_changes = [secret_data] }`
+so Terraform never overwrites a secret version after creation. To rotate:
+
+```bash
+# Add a new version
+echo -n "NEW_VALUE" | \
+  gcloud secrets versions add taskorbit-openai-api-key \
+  --project="${PROJECT_ID}" \
+  --data-file=-
+
+# Redeploy so running instances pick up "latest"
+gcloud run services update taskorbit-backend \
+  --region=europe-west1 \
+  --project="${PROJECT_ID}"
+```
+
+### 4.4 Viewing a secret value
+
+```bash
+gcloud secrets versions access latest \
+  --secret="taskorbit-openai-api-key" \
+  --project="${PROJECT_ID}"
+```
+
+---
+
+## 5. Local Developer Authentication
+
+### 5.1 Application Default Credentials
+
+```bash
+gcloud auth login
+gcloud config set project YOUR_PROJECT_ID
+gcloud auth application-default login
+```
+
+After this, Terraform, the Python SDK, and gcloud commands all use your
+personal identity automatically — no service account key file needed.
+
+### 5.2 Reading secrets locally
+
+```bash
+gcloud secrets versions access latest \
+  --secret="taskorbit-openai-api-key" \
+  --project="${PROJECT_ID}"
+```
+
+Use these values to populate `backend/.env` for local development
+(see `Documentation/livekit-cloud-setup.md` for the full local setup steps).
+
+### 5.3 Connecting to Cloud SQL locally
+
+Cloud SQL has no public IP (`ipv4_enabled = false` in
+`terraform/modules/database/main.tf`). Use the **Cloud SQL Auth Proxy**:
+
+```bash
+# Install (macOS Apple Silicon)
+curl -o cloud-sql-proxy \
+  https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.14.1/cloud-sql-proxy.darwin.arm64
+chmod +x cloud-sql-proxy
+
+# Full connection name: PROJECT_ID:REGION:INSTANCE_NAME
+cd terraform && terraform output -raw database_instance_name
+# e.g. taskorbit-postgres → my-project:europe-west1:taskorbit-postgres
+
+# Start the proxy (uses ADC automatically)
+./cloud-sql-proxy --port=5432 \
+  "${PROJECT_ID}:europe-west1:taskorbit-postgres"
+```
+
+Retrieve the database password from the secret:
+
+```bash
+gcloud secrets versions access latest \
+  --secret="taskorbit-database-url" \
+  --project="${PROJECT_ID}" | \
+  python3 -c "import sys, urllib.parse; u=sys.stdin.read().strip(); print(urllib.parse.urlparse(u).password)"
+```
+
+### 5.4 Minimum IAM roles for a developer
+
+| Role | Why |
+|---|---|
+| `roles/secretmanager.secretAccessor` | Read secrets locally |
+| `roles/cloudsql.client` | Use Cloud SQL Auth Proxy |
+| `roles/run.viewer` | View Cloud Run service logs and status |
+
+A project owner grants these with:
+
+```bash
+DEV_EMAIL="developer@example.com"
+
+for ROLE in \
+  roles/secretmanager.secretAccessor \
+  roles/cloudsql.client \
+  roles/run.viewer; do
+  gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+    --member="user:${DEV_EMAIL}" \
+    --role="${ROLE}"
+done
+```
+
+---
+
+## 6. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `terraform init` fails: `bucket does not exist` | GCS state bucket not created yet | Run `gsutil mb` in Section 1.1 first |
+| `403 Permission denied` on `terraform apply` | ADC user is not a project owner | Run `gcloud auth application-default login` as a project owner |
+| GitHub Actions: `google-github-actions/auth failed` | `GCP_WORKLOAD_IDENTITY_PROVIDER` secret is wrong | Re-run `terraform output -raw workload_identity_provider` and update the secret |
+| GitHub Actions: `Permission denied` on Artifact Registry push | `GCP_SA_EMAIL` is wrong or WIF pool misconfigured | Verify both secrets; check `attribute_condition` matches your repo slug |
+| Cloud Run fails to start: `Secret not found` | Secret name typo or secrets module not applied | Check with `gcloud secrets list --filter="name~taskorbit" --project="${PROJECT_ID}"` |
+| `psql: Connection refused` on port 5432 locally | Cloud SQL Auth Proxy not running | Start the proxy as shown in Section 5.3 |
+| SSL certificate stays `PROVISIONING` | DNS A records not yet pointing to `load_balancer_ip` | Check DNS propagation; GCP polls for DNS before issuing the cert |
+| `terraform destroy` fails on Cloud SQL | `deletion_protection = true` | Set to `false` in `terraform/modules/database/main.tf`, re-apply, then destroy |
+| Rotated secret but Cloud Run still uses old value | Secrets are cached at instance startup | Run `gcloud run services update` to force a new revision |
+
+---
+
+## 7. Quick Reference
+
+```bash
+# ── One-time bootstrap ────────────────────────────────────────────────────────
+gsutil mb -l europe-west1 gs://${PROJECT_ID}-taskorbit-tf-state
+gsutil versioning set on gs://${PROJECT_ID}-taskorbit-tf-state
+# Edit terraform/backend.tf — replace REPLACE_WITH_PROJECT_ID
+gcloud auth application-default login
+cd terraform && terraform init && terraform apply
+
+# ── Capture outputs for GitHub secrets ───────────────────────────────────────
+terraform output -raw workload_identity_provider   # → GCP_WORKLOAD_IDENTITY_PROVIDER
+terraform output -raw cicd_service_account_email   # → GCP_SA_EMAIL
+terraform output load_balancer_ip                  # → DNS A record target
+
+# ── Set GitHub Actions secrets ────────────────────────────────────────────────
+gh secret set GCP_PROJECT_ID --body "${PROJECT_ID}"
+gh secret set GCP_WORKLOAD_IDENTITY_PROVIDER --body "$(terraform output -raw workload_identity_provider)"
+gh secret set GCP_SA_EMAIL --body "$(terraform output -raw cicd_service_account_email)"
+
+# ── Rotate a secret ───────────────────────────────────────────────────────────
+echo -n "NEW_VALUE" | gcloud secrets versions add taskorbit-<key> \
+  --project="${PROJECT_ID}" --data-file=-
+gcloud run services update taskorbit-backend --region=europe-west1 --project="${PROJECT_ID}"
+
+# ── Read a secret locally ─────────────────────────────────────────────────────
+gcloud secrets versions access latest --secret="taskorbit-openai-api-key" \
+  --project="${PROJECT_ID}"
+
+# ── Connect to Cloud SQL locally ──────────────────────────────────────────────
+./cloud-sql-proxy --port=5432 "${PROJECT_ID}:europe-west1:taskorbit-postgres"
+psql "host=127.0.0.1 port=5432 dbname=taskorbit user=taskorbit"
+```

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Start Web Service](https://github.com/amosproj/amos2026ss04-taskorbit-conversational-agent/actions/workflows/start-web-service.yml/badge.svg)](https://github.com/amosproj/amos2026ss04-taskorbit-conversational-agent/actions/workflows/start-web-service.yml)
 [![Frontend Linting](https://github.com/amosproj/amos2026ss04-taskorbit-conversational-agent/actions/workflows/frontend-lint.yml/badge.svg)](https://github.com/amosproj/amos2026ss04-taskorbit-conversational-agent/actions/workflows/frontend-lint.yml)
 [![Backend Linting](https://github.com/amosproj/amos2026ss04-taskorbit-conversational-agent/actions/workflows/backend-lint.yml/badge.svg)](https://github.com/amosproj/amos2026ss04-taskorbit-conversational-agent/actions/workflows/backend-lint.yml)
+[![Deploy to GCP](https://github.com/amosproj/amos2026ss04-taskorbit-conversational-agent/actions/workflows/deploy.yml/badge.svg)](https://github.com/amosproj/amos2026ss04-taskorbit-conversational-agent/actions/workflows/deploy.yml)
 
 ---
 
@@ -42,6 +43,7 @@ The frontend ships a ChatGPT-style mic button: tap to record, **Stop** mutes wit
 | `backend/`       | Python / FastAPI orchestration layer (Poetry-managed)             |
 | `frontend/`      | React 19 + Vite + TypeScript client                               |
 | `schemas/`       | Shared JSON schemas used by both backend and frontend             |
+| `terraform/`     | GCP Infrastructure as Code — Cloud Run, Cloud SQL, Secret Manager, IAM, and more |
 | `Documentation/` | Architecture documents, runtime diagrams, team-facing guides      |
 | `.github/`       | Issue templates, workflows, and shared CI actions (`actions/*`)   |
 
@@ -107,15 +109,16 @@ See [`backend/README.md`](backend/README.md) and [`frontend/README.md`](frontend
 
 ## CI / CD
 
-Three independent GitHub Actions workflows run on every push and pull request, each publishing its own pass/fail badge:
+Three quality-gate workflows run on every push and pull request. A fourth deploys to GCP automatically once all three pass on `main`:
 
 | Badge                 | Workflow file                                                                          | What it verifies                                                                           |
 | --------------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
 | **Start Web Service** | [`start-web-service.yml`](.github/workflows/start-web-service.yml)                    | Boots the FastAPI service and curls `/health`; runs `npm run build` for the frontend       |
 | **Frontend Linting**  | [`frontend-lint.yml`](.github/workflows/frontend-lint.yml)                            | `npm ci` → ESLint → Prettier `--check`                                                     |
 | **Backend Linting**   | [`backend-lint.yml`](.github/workflows/backend-lint.yml)                              | `poetry install` → `ruff check` → `ruff format --check` → `pytest`                        |
+| **Deploy to GCP**     | [`deploy.yml`](.github/workflows/deploy.yml)                                          | Builds Docker images, pushes to Artifact Registry, deploys to Cloud Run (runs after all three above pass) |
 
-Each workflow is split into named stages chained with `needs:`, so a single failing stage shows up clearly in the GitHub Checks UI. The full team-facing guide — local commands, troubleshooting, and how to extend the pipeline — lives in [`Documentation/ci-cd.md`](Documentation/ci-cd.md).
+Each workflow is split into named stages chained with `needs:`, so a single failing stage shows up clearly in the GitHub Checks UI. The full team-facing guide — local commands, troubleshooting, and how to extend the pipeline — lives in [`Documentation/ci-cd.md`](Documentation/ci-cd.md). 
 
 ### Pre-commit Hooks
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -74,4 +74,4 @@
     COPY src ./src
 
     EXPOSE 8000
-    CMD ["uvicorn", "taskorbit.main:app", "--host", "0.0.0.0", "--port", "8000"]
+    CMD ["taskorbit-api", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -75,6 +75,9 @@
 
     COPY --from=builder /app/.venv /app/.venv
     COPY src ./src
+    COPY alembic.ini ./
+    COPY migrations ./migrations
 
     EXPOSE 8000
-    CMD ["taskorbit-api", "--host", "0.0.0.0", "--port", "8000"]
+    # Run migrations then start the API server
+    CMD ["sh", "-c", "alembic upgrade head && taskorbit-api --host 0.0.0.0 --port 8000"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -61,7 +61,8 @@
 
     ENV PYTHONUNBUFFERED=1 \
         PYTHONDONTWRITEBYTECODE=1 \
-        PATH="/app/.venv/bin:${PATH}"
+        PATH="/app/.venv/bin:${PATH}" \
+        PYTHONPATH="/app/src"
 
     WORKDIR /app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,6 +160,8 @@ services:
       GF_AUTH_ANONYMOUS_ENABLED: "true"
       GF_AUTH_ANONYMOUS_ORG_ROLE: "Admin"
       GF_SECURITY_ADMIN_PASSWORD: "admin"
+      PROMETHEUS_URL: "http://prometheus:9090"
+      LOKI_URL: "http://loki:3100"
     volumes:
       - ./infra/grafana/provisioning:/etc/grafana/provisioning:ro
       - taskorbit-grafana-data:/var/lib/grafana

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -34,5 +34,10 @@ RUN npm run build
 # ---------- Prod image: nginx ----------
 FROM nginx:1.27-alpine AS prod
 COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.conf.template /etc/nginx/conf.d/default.conf.template
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+# Default — overridden by BACKEND_URL env var at Cloud Run deploy time
+ENV BACKEND_URL=http://localhost:8000
 EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+# Substitute only ${BACKEND_URL} — leave nginx variables like $uri untouched
+envsubst '${BACKEND_URL}' \
+  < /etc/nginx/conf.d/default.conf.template \
+  > /etc/nginx/conf.d/default.conf
+exec nginx -g 'daemon off;'

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -14,6 +14,9 @@ server {
     location /api/ {
         proxy_pass ${BACKEND_URL}/;
         proxy_http_version 1.1;
+        # Required for Cloud Run: sends the backend hostname in the TLS ClientHello
+        # so SNI-based routing resolves to the correct service certificate.
+        proxy_ssl_server_name on;
         proxy_set_header Host              $proxy_host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -1,0 +1,23 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA fallback — all unknown paths serve index.html
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Proxy /api/* → backend, stripping /api prefix (mirrors Vite dev-server proxy)
+    location /api/ {
+        proxy_pass ${BACKEND_URL}/;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $proxy_host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 300s;
+    }
+}

--- a/infra/grafana/Dockerfile
+++ b/infra/grafana/Dockerfile
@@ -1,0 +1,6 @@
+FROM grafana/grafana:11.3.0
+# Bake provisioning files into the image so they are available on Cloud Run
+# where there is no Docker socket or bind-mount.
+# Datasource URLs are injected at runtime via PROMETHEUS_URL and LOKI_URL env vars
+# which Grafana substitutes automatically in provisioning YAML files.
+COPY provisioning /etc/grafana/provisioning

--- a/infra/grafana/provisioning/dashboards/taskorbit.json
+++ b/infra/grafana/provisioning/dashboards/taskorbit.json
@@ -675,7 +675,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rate(taskorbit_llm_requests_total[5m])",
+          "expr": "sum by (provider, model, status) (rate(taskorbit_llm_requests_total[5m]))",
           "legendFormat": "{{provider}} {{model}} {{status}}",
           "refId": "A"
         }
@@ -720,7 +720,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "histogram_quantile(0.95, rate(taskorbit_llm_response_chars_bucket[5m]))",
+          "expr": "histogram_quantile(0.95, sum by (le, provider, model) (rate(taskorbit_llm_response_chars_bucket[5m])))",
           "legendFormat": "p95 {{provider}} {{model}}",
           "refId": "A"
         }
@@ -843,7 +843,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rate(taskorbit_tokens_used_total{token_type=\"prompt\"}[5m])",
+          "expr": "sum by (provider, model) (rate(taskorbit_tokens_used_total{token_type=\"prompt\"}[5m]))",
           "legendFormat": "prompt \u2014 {{provider}} {{model}}",
           "refId": "A"
         },
@@ -852,7 +852,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rate(taskorbit_tokens_used_total{token_type=\"completion\"}[5m])",
+          "expr": "sum by (provider, model) (rate(taskorbit_tokens_used_total{token_type=\"completion\"}[5m]))",
           "legendFormat": "completion \u2014 {{provider}} {{model}}",
           "refId": "B"
         }
@@ -898,7 +898,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "increase(taskorbit_tokens_used_total[1d])",
+          "expr": "sum by (provider, model, token_type) (increase(taskorbit_tokens_used_total[1d]))",
           "legendFormat": "{{token_type}} \u2014 {{provider}} {{model}}",
           "refId": "A"
         }
@@ -944,7 +944,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "histogram_quantile(0.50, rate(taskorbit_pipeline_latency_seconds_bucket{stage=\"llm_call\"}[5m]))",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(taskorbit_pipeline_latency_seconds_bucket{stage=\"llm_call\"}[5m])))",
           "legendFormat": "p50 LLM",
           "refId": "A"
         },
@@ -953,7 +953,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "histogram_quantile(0.95, rate(taskorbit_pipeline_latency_seconds_bucket{stage=\"llm_call\"}[5m]))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(taskorbit_pipeline_latency_seconds_bucket{stage=\"llm_call\"}[5m])))",
           "legendFormat": "p95 LLM",
           "refId": "B"
         },
@@ -962,7 +962,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "histogram_quantile(0.99, rate(taskorbit_pipeline_latency_seconds_bucket{stage=\"llm_call\"}[5m]))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(taskorbit_pipeline_latency_seconds_bucket{stage=\"llm_call\"}[5m])))",
           "legendFormat": "p99 LLM",
           "refId": "C"
         }
@@ -1008,7 +1008,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "histogram_quantile(0.95, rate(taskorbit_pipeline_latency_seconds_bucket{stage=\"total\"}[5m]))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(taskorbit_pipeline_latency_seconds_bucket{stage=\"total\"}[5m])))",
           "legendFormat": "p95 total",
           "refId": "A"
         },
@@ -1017,7 +1017,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "histogram_quantile(0.50, rate(taskorbit_pipeline_latency_seconds_bucket{stage=\"total\"}[5m]))",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(taskorbit_pipeline_latency_seconds_bucket{stage=\"total\"}[5m])))",
           "legendFormat": "p50 total",
           "refId": "B"
         }
@@ -1062,7 +1062,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rate(taskorbit_conversation_errors_total[5m])",
+          "expr": "sum by (error_type) (rate(taskorbit_conversation_errors_total[5m]))",
           "legendFormat": "{{error_type}}",
           "refId": "A"
         }
@@ -1127,7 +1127,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "histogram_quantile(0.50, rate(taskorbit_pipeline_latency_seconds_bucket{stage=\"stt_processing\"}[5m]))",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(taskorbit_pipeline_latency_seconds_bucket{stage=\"stt_processing\"}[5m])))",
           "legendFormat": "p50 STT",
           "refId": "A"
         },
@@ -1136,7 +1136,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "histogram_quantile(0.95, rate(taskorbit_pipeline_latency_seconds_bucket{stage=\"stt_processing\"}[5m]))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(taskorbit_pipeline_latency_seconds_bucket{stage=\"stt_processing\"}[5m])))",
           "legendFormat": "p95 STT",
           "refId": "B"
         },
@@ -1145,7 +1145,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "histogram_quantile(0.99, rate(taskorbit_pipeline_latency_seconds_bucket{stage=\"stt_processing\"}[5m]))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(taskorbit_pipeline_latency_seconds_bucket{stage=\"stt_processing\"}[5m])))",
           "legendFormat": "p99 STT",
           "refId": "C"
         }
@@ -1198,7 +1198,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "histogram_quantile(0.50, rate(taskorbit_pipeline_latency_seconds_bucket{stage=\"tts_ttfb\"}[5m]))",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(taskorbit_pipeline_latency_seconds_bucket{stage=\"tts_ttfb\"}[5m])))",
           "legendFormat": "p50 TTS TTFB",
           "refId": "A"
         },
@@ -1207,7 +1207,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "histogram_quantile(0.95, rate(taskorbit_pipeline_latency_seconds_bucket{stage=\"tts_ttfb\"}[5m]))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(taskorbit_pipeline_latency_seconds_bucket{stage=\"tts_ttfb\"}[5m])))",
           "legendFormat": "p95 TTS TTFB",
           "refId": "B"
         },
@@ -1216,7 +1216,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "histogram_quantile(0.99, rate(taskorbit_pipeline_latency_seconds_bucket{stage=\"tts_ttfb\"}[5m]))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(taskorbit_pipeline_latency_seconds_bucket{stage=\"tts_ttfb\"}[5m])))",
           "legendFormat": "p99 TTS TTFB",
           "refId": "C"
         }
@@ -1269,7 +1269,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "histogram_quantile(0.50, rate(taskorbit_pipeline_latency_seconds_bucket{stage=\"tts_synthesis\"}[5m]))",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(taskorbit_pipeline_latency_seconds_bucket{stage=\"tts_synthesis\"}[5m])))",
           "legendFormat": "p50 TTS duration",
           "refId": "A"
         },
@@ -1278,7 +1278,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "histogram_quantile(0.95, rate(taskorbit_pipeline_latency_seconds_bucket{stage=\"tts_synthesis\"}[5m]))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(taskorbit_pipeline_latency_seconds_bucket{stage=\"tts_synthesis\"}[5m])))",
           "legendFormat": "p95 TTS duration",
           "refId": "B"
         },
@@ -1287,7 +1287,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "histogram_quantile(0.99, rate(taskorbit_pipeline_latency_seconds_bucket{stage=\"tts_synthesis\"}[5m]))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(taskorbit_pipeline_latency_seconds_bucket{stage=\"tts_synthesis\"}[5m])))",
           "legendFormat": "p99 TTS duration",
           "refId": "C"
         }

--- a/infra/grafana/provisioning/dashboards/taskorbit.json
+++ b/infra/grafana/provisioning/dashboards/taskorbit.json
@@ -572,7 +572,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rate(http_requests_total{job=~\"$application\"}[5m])",
+          "expr": "sum by (handler, status_code) (rate(http_requests_total{job=~\"$application\"}[5m]))",
           "legendFormat": "{{handler}} {{status_code}}",
           "refId": "A"
         }
@@ -618,7 +618,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "histogram_quantile(0.95, rate(http_request_duration_seconds_bucket{job=~\"$application\"}[5m]))",
+          "expr": "histogram_quantile(0.95, sum by (le, handler) (rate(http_request_duration_seconds_bucket{job=~\"$application\"}[5m])))",
           "legendFormat": "p95 {{handler}}",
           "refId": "A"
         }

--- a/infra/grafana/provisioning/datasources/datasources.yml
+++ b/infra/grafana/provisioning/datasources/datasources.yml
@@ -3,11 +3,15 @@ datasources:
   - name: Prometheus
     type: prometheus
     access: proxy
-    url: http://prometheus:9090
+    # Local dev: set PROMETHEUS_URL=http://prometheus:9090
+    # Production: injected by Terraform as the Cloud Run service URI
+    url: ${PROMETHEUS_URL}
     isDefault: true
     editable: false
   - name: Loki
     type: loki
     access: proxy
-    url: http://loki:3100
+    # Local dev: set LOKI_URL=http://loki:3100
+    # Production: injected by Terraform as the Cloud Run service URI
+    url: ${LOKI_URL}
     editable: false

--- a/infra/prometheus.yml
+++ b/infra/prometheus.yml
@@ -1,6 +1,6 @@
 global:
-  scrape_interval: 5s
-  evaluation_interval: 5s
+  scrape_interval: 15s
+  evaluation_interval: 15s
 
 scrape_configs:
   - job_name: taskorbit-backend

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,63 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:79CwMTsp3Ud1nOl5hFS5mxQHyT0fGVye7pqpU0PPlHI=",
+    "zh:1f3513fcfcbf7ca53d667a168c5067a4dd91a4d4cccd19743e248ff31065503c",
+    "zh:3da7db8fc2c51a77dd958ea8baaa05c29cd7f829bd8941c26e2ea9cb3aadc1e5",
+    "zh:3e09ac3f6ca8111cbb659d38c251771829f4347ab159a12db195e211c76068bb",
+    "zh:7bb9e41c568df15ccf1a8946037355eefb4dfb4e35e3b190808bb7c4abae547d",
+    "zh:81e5d78bdec7778e6d67b5c3544777505db40a826b6eb5abe9b86d4ba396866b",
+    "zh:8d309d020fb321525883f5c4ea864df3d5942b6087f6656d6d8b3a1377f340fc",
+    "zh:93e112559655ab95a523193158f4a4ac0f2bfed7eeaa712010b85ebb551d5071",
+    "zh:d3efe589ffd625b300cef5917c4629513f77e3a7b111c9df65075f76a46a63c7",
+    "zh:d4a4d672bbef756a870d8f32b35925f8ce2ef4f6bbd5b71a3cb764f1b6c85421",
+    "zh:e13a86bca299ba8a118e80d5f84fbdd708fe600ecdceea1a13d4919c068379fe",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fec30c095647b583a246c39d557704947195a1b7d41f81e369ba377d997faef6",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:P2GiUJM1frlPtBViwKn1A9V2dVBdGuWcX80w9TdH8ZE=",
+    "zh:18b442bd0a05321d39dda1e9e3f1bdede4e61bc2ac62cc7a67037a3864f75101",
+    "zh:2e387c51455862828bec923a3ec81abf63a4d998da470cf00e09003bda53d668",
+    "zh:3942e708fa84ebe54996086f4b1398cb747fe19cbcd0be07ace528291fb35dee",
+    "zh:496287dd48b34ae6197cb1f887abeafd07c33f389dbe431bb01e24846754cfdd",
+    "zh:6eca885419969ce5c2a706f34dce1f10bde9774757675f2d8a92d12e5a1be390",
+    "zh:710dbef826c3fe7f76f844dae47937e8e4c1279dd9205ec4610be04cf3327244",
+    "zh:777ebf44b24bfc7bdbf770dc089f1a72f143b4718fdedb8c6bd75983115a1ec2",
+    "zh:9c8703bba37b8c7ad857efc3513392c5a096c519397c1cb822d7612f38e4262f",
+    "zh:c4f1d3a73de2702277c99d5348ad6d374705bcfdd367ad964ff4cfd2cf06c281",
+    "zh:eca8df11af3f5a948492d5b8b5d01b4ec705aad10bc30ec1524205508ae28393",
+    "zh:f41e7fd5f2628e8fd6b8ea136366923858f54428d1729898925469b862c275c2",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.6"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,249 @@
+# Terraform — TaskOrbit GCP Infrastructure
+
+This directory contains all Infrastructure as Code for the TaskOrbit GCP
+environment. Running `terraform apply` provisions every resource the application
+needs — network, database, secrets, container registry, Cloud Run services,
+cost-saving scheduler, and observability stack.
+
+---
+
+## Directory Structure
+
+```
+terraform/
+├── main.tf                  # Module wiring and API enablement
+├── variables.tf             # All input variables with validation
+├── outputs.tf               # Values needed post-apply (URLs, SA emails, LB IP)
+├── versions.tf              # Provider version pins (google ~6.0, random ~3.6)
+├── backend.tf               # Remote state — GCS bucket (fill placeholder before init)
+├── terraform.tfvars.example # Template — copy to terraform.tfvars and fill in secrets
+├── tests/                   # Native Terraform tests (terraform test)
+│   ├── scheduler.tftest.hcl
+│   ├── secrets.tftest.hcl
+│   └── variables.tftest.hcl
+└── modules/
+    ├── network/             # VPC, subnet, Cloud Router, NAT, VPC connector
+    ├── iam/                 # Service accounts, IAM bindings, Workload Identity
+    ├── registry/            # Artifact Registry repository
+    ├── database/            # Cloud SQL PostgreSQL 16 (private IP, HA, PITR)
+    ├── secrets/             # Secret Manager — 15 secrets prefixed taskorbit-
+    ├── cloud_run/           # 3 Cloud Run v2 services + Global HTTPS LB
+    ├── scheduler/           # Cloud Scheduler — SQL stop/start, worker scale-down
+    └── observability/       # Prometheus + Loki + Grafana on Cloud Run
+```
+
+---
+
+## Prerequisites
+
+| Tool | Minimum version | Install |
+|---|---|---|
+| Terraform | 1.7 | `brew install terraform` |
+| gcloud CLI | any recent | `brew install --cask google-cloud-sdk` |
+| Docker | any recent | Docker Desktop |
+
+---
+
+## First-time Setup
+
+### 1. Create the remote state bucket
+
+The GCS bucket for Terraform state must exist before `terraform init`.
+Replace the placeholder in `backend.tf` first:
+
+```bash
+PROJECT_ID="your-gcp-project-id"
+
+gsutil mb -l europe-west1 gs://${PROJECT_ID}-taskorbit-tf-state
+gsutil versioning set on gs://${PROJECT_ID}-taskorbit-tf-state
+```
+
+Edit `backend.tf`:
+```hcl
+bucket = "your-gcp-project-id-taskorbit-tf-state"
+```
+
+### 2. Create your tfvars file
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+# Fill in all values — terraform.tfvars is git-ignored, never commit it
+```
+
+### 3. Initialise and apply
+
+```bash
+gcloud auth application-default login
+terraform init
+terraform plan
+terraform apply
+```
+
+First apply takes ~15 minutes (Cloud SQL provisioning dominates).
+
+---
+
+## Outputs
+
+After a successful apply, collect these values:
+
+```bash
+terraform output workload_identity_provider   # → GCP_WORKLOAD_IDENTITY_PROVIDER GitHub secret
+terraform output cicd_service_account_email   # → GCP_SA_EMAIL GitHub secret
+terraform output load_balancer_ip             # → DNS A record target
+terraform output database_instance_name       # → for Cloud SQL Auth Proxy
+terraform output artifact_registry_url        # → Docker push target
+terraform output backend_url                  # → api.<domain>
+terraform output frontend_url                 # → <domain>
+terraform output grafana_url                  # → grafana.<domain>
+```
+
+---
+
+## Modules
+
+### `network`
+Creates a VPC with a single subnet, a Cloud Router and NAT gateway for egress,
+and a Serverless VPC Access connector so Cloud Run services can reach Cloud SQL
+over private IP. All egress is set to `PRIVATE_RANGES_ONLY`.
+
+### `iam`
+Creates five service accounts (backend, worker, frontend, observability, cicd)
+and binds the minimum required roles to each. Also provisions a Workload Identity
+Federation pool and provider scoped to this GitHub repository so GitHub Actions
+can authenticate via OIDC without any long-lived key.
+
+### `registry`
+Creates an Artifact Registry Docker repository named `taskorbit` in `europe-west1`.
+Built images are pushed here by the CI/CD pipeline.
+
+### `database`
+Cloud SQL PostgreSQL 16 with:
+- No public IP (`ipv4_enabled = false`) — reachable only via VPC or Cloud SQL Auth Proxy
+- Regional high-availability with automatic failover
+- Daily backups, 14 retained, point-in-time recovery enabled (7-day log window)
+- `deletion_protection = true` — prevents accidental destruction via `terraform destroy`
+
+### `secrets`
+Creates 15 Secret Manager secrets, all prefixed `taskorbit-`, using a `for_each`
+loop. The `lifecycle { ignore_changes = [secret_data] }` block means Terraform
+never overwrites a secret version after creation — rotate keys with
+`gcloud secrets versions add` instead.
+
+### `cloud_run`
+Deploys three Cloud Run v2 services behind a Global HTTPS load balancer with
+a managed SSL certificate:
+- `taskorbit-backend` — FastAPI API (port 8000)
+- `taskorbit-worker` — LiveKit voice agent (port 8001)
+- `taskorbit-frontend` — React bundle served by nginx (port 80)
+
+All services connect to Cloud SQL via a shared Unix socket volume and read
+secrets as environment variables injected from Secret Manager at startup.
+
+### `scheduler`
+Cloud Scheduler jobs that reduce idle costs:
+- `taskorbit-sql-stop` — sets Cloud SQL `activationPolicy=NEVER` at 22:00 Mon–Fri (CET)
+- `taskorbit-sql-start` — restores `activationPolicy=ALWAYS` at 07:00 Mon–Fri (CET)
+- `taskorbit-worker-scale-down` / `scale-up` — optional, controlled by `scale_worker_overnight`
+
+Cloud Run services scale to 0 automatically when idle (built-in behaviour, no config needed).
+
+### `observability`
+Runs Prometheus, Loki, and Grafana as Cloud Run services. Prometheus scrapes
+`/metrics` on the backend and worker using OIDC authentication. Loki stores
+logs in a GCS bucket. Grafana is exposed at `grafana.<domain>`.
+
+---
+
+## Running Tests
+
+Tests use Terraform's native test framework and `mock_provider` — no GCP
+credentials or live project required.
+
+```bash
+cd terraform
+terraform test
+```
+
+| Test file | What it covers |
+|---|---|
+| `tests/scheduler.tftest.hcl` | `count` logic for the boolean flags (`enable_auto_shutdown`, `scale_worker_overnight`) and default cron schedule values |
+| `tests/secrets.tftest.hcl` | All 15 secrets are created, `taskorbit-` prefix enforced, correct labels applied |
+| `tests/variables.tftest.hcl` | Validation blocks reject bad inputs (wrong scheme, empty required fields, weak password, impossible scaling range) |
+
+---
+
+## Cost Controls
+
+| Mechanism | Saves |
+|---|---|
+| Cloud SQL auto-stop (22:00–07:00 Mon–Fri) | vCPU + RAM billing paused overnight |
+| Cloud Run scales to 0 when idle | No instances billed when no traffic |
+| `worker_min_instances = 1` (default) | Worker stays alive for LiveKit; set to 0 via `scale_worker_overnight` if 24/7 not needed |
+| `db-custom-2-7680` tier | Right-sized for development; upgrade in `modules/database/variables.tf` for production load |
+
+---
+
+## Security Notes
+
+- **No long-lived service account keys** — CI/CD authenticates via Workload Identity Federation (OIDC). See `modules/iam/main.tf`.
+- **No public database IP** — Cloud SQL is only reachable via VPC connector (Cloud Run) or Cloud SQL Auth Proxy (local dev).
+- **Secrets never in code** — all API keys live in Secret Manager; `terraform.tfvars` is git-ignored.
+- **Deletion protection** — Cloud SQL has `deletion_protection = true`. Remove it manually before `terraform destroy`.
+- **Repository-scoped WIF** — the `attribute_condition` in the Workload Identity provider restricts authentication to this repository only.
+
+---
+
+## SBOM
+
+A Software Bill of Materials documents every dependency this infrastructure
+layer pulls in — Terraform providers, their transitive dependencies, and the
+versions pinned in `.terraform.lock.hcl`.
+
+Generate a CycloneDX JSON SBOM locally using [Syft](https://github.com/anchore/syft):
+
+```bash
+# Install Syft (macOS)
+brew install syft
+
+# Generate SBOM from the terraform/ directory
+syft dir:. \
+  --exclude './.terraform/**' \
+  -o cyclonedx-json \
+  > sbom.cyclonedx.json
+```
+
+The `.terraform.lock.hcl` file (committed to the repo) is the authoritative
+pin record for provider versions. The SBOM adds machine-readable metadata
+(checksums, package URLs) on top of it. Commit `sbom.cyclonedx.json` to the
+repo root whenever the provider versions change (i.e. after `terraform init -upgrade`).
+
+---
+
+## Common Commands
+
+```bash
+# Initialise (after editing backend.tf placeholder)
+terraform init
+
+# Preview changes
+terraform plan
+
+# Apply changes
+terraform apply
+
+# Run unit tests (no GCP credentials needed)
+terraform test
+
+# Destroy all resources (remove deletion_protection first)
+terraform destroy
+
+# Format all .tf files
+terraform fmt -recursive
+
+# Validate configuration without a backend
+terraform validate
+
+# Refresh outputs after a manual GCP change
+terraform refresh
+```

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -18,6 +18,8 @@ terraform/
 ├── backend.tf               # Remote state — GCS bucket (fill placeholder before init)
 ├── terraform.tfvars.example # Template — copy to terraform.tfvars and fill in secrets
 ├── tests/                   # Native Terraform tests (terraform test)
+│   ├── cloud_run.tftest.hcl
+│   ├── observability.tftest.hcl
 │   ├── scheduler.tftest.hcl
 │   ├── secrets.tftest.hcl
 │   └── variables.tftest.hcl
@@ -162,7 +164,16 @@ credentials or live project required.
 
 ```bash
 cd terraform
+
+# Run all tests
 terraform test
+
+# Run a single test file
+terraform test -filter=tests/scheduler.tftest.hcl
+terraform test -filter=tests/secrets.tftest.hcl
+terraform test -filter=tests/variables.tftest.hcl
+terraform test -filter=tests/cloud_run.tftest.hcl
+terraform test -filter=tests/observability.tftest.hcl
 ```
 
 | Test file | What it covers |
@@ -170,6 +181,8 @@ terraform test
 | `tests/scheduler.tftest.hcl` | `count` logic for the boolean flags (`enable_auto_shutdown`, `scale_worker_overnight`) and default cron schedule values |
 | `tests/secrets.tftest.hcl` | All 15 secrets are created, `taskorbit-` prefix enforced, correct labels applied |
 | `tests/variables.tftest.hcl` | Validation blocks reject bad inputs (wrong scheme, empty required fields, weak password, impossible scaling range) |
+| `tests/cloud_run.tftest.hcl` | Ingress settings per service, CORS origin fallback and override, SSL cert domain coverage, frontend `BACKEND_URL` env |
+| `tests/observability.tftest.hcl` | Loki/Prometheus internal-only ingress, GCS bucket naming and retention, Pub/Sub push subscription wiring, Grafana SSL cert domain |
 
 ---
 

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,8 @@
+# Remote state — GCS bucket must be created manually before the first `terraform init`.
+# Create it once with: gsutil mb -l REGION gs://YOUR_PROJECT_ID-taskorbit-tf-state
+terraform {
+  backend "gcs" {
+    bucket = "REPLACE_WITH_PROJECT_ID-taskorbit-tf-state"
+    prefix = "terraform/state"
+  }
+}

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,8 +1,9 @@
 # Remote state — GCS bucket must be created manually before the first `terraform init`.
 # Create it once with: gsutil mb -l REGION gs://YOUR_PROJECT_ID-taskorbit-tf-state
+# export GOOGLE_APPLICATION_CREDENTIALS="./amos-taskorbit.json"
 terraform {
   backend "gcs" {
-    bucket = "REPLACE_WITH_PROJECT_ID-taskorbit-tf-state"
+    bucket = "amos-taskorbit-tf-state"
     prefix = "terraform/state"
   }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -116,44 +116,44 @@ module "secrets" {
   depends_on = [module.database, google_project_service.apis]
 }
 
-# ── STEP 7 (COMMENTED): Cloud Run Services + Load Balancer ───────────────────
+# ── STEP 7 (ACTIVE): Cloud Run Services + Load Balancer ──────────────────────
 # Backend, worker, frontend Cloud Run services; global HTTPS load balancer.
 # Depends on: Steps 2 (network), 3 (iam), 5 (database), 6 (secrets)
 # AFTER APPLY: note load_balancer_ip output and create DNS A records:
 #   your-domain.com       → load_balancer_ip
 #   api.your-domain.com   → load_balancer_ip
 # Run: terraform apply -target=module.cloud_run
-#
-# module "cloud_run" {
-#   source = "./modules/cloud_run"
-#
-#   project_id = var.project_id
-#   region     = var.region
-#   domain     = var.domain
-#
-#   backend_image  = var.backend_image
-#   frontend_image = var.frontend_image
-#
-#   backend_sa_email  = module.iam.backend_sa_email
-#   worker_sa_email   = module.iam.worker_sa_email
-#   frontend_sa_email = module.iam.frontend_sa_email
-#
-#   vpc_connector_id          = module.network.vpc_connector_id
-#   cloud_sql_connection_name = module.database.instance_connection_name
-#
-#   secret_ids = module.secrets.secret_ids
-#
-#   backend_min_instances  = var.backend_min_instances
-#   backend_max_instances  = var.backend_max_instances
-#   worker_min_instances   = var.worker_min_instances
-#   worker_max_instances   = var.worker_max_instances
-#   frontend_min_instances = var.frontend_min_instances
-#   frontend_max_instances = var.frontend_max_instances
-#
-#   cors_allow_origins = var.cors_allow_origins
-#
-#   depends_on = [module.iam, module.secrets, module.database, module.network]
-# }
+
+module "cloud_run" {
+  source = "./modules/cloud_run"
+
+  project_id = var.project_id
+  region     = var.region
+  domain     = var.domain
+
+  backend_image  = var.backend_image
+  frontend_image = var.frontend_image
+
+  backend_sa_email  = module.iam.backend_sa_email
+  worker_sa_email   = module.iam.worker_sa_email
+  frontend_sa_email = module.iam.frontend_sa_email
+
+  vpc_connector_id          = module.network.vpc_connector_id
+  cloud_sql_connection_name = module.database.instance_connection_name
+
+  secret_ids = module.secrets.secret_ids
+
+  backend_min_instances  = var.backend_min_instances
+  backend_max_instances  = var.backend_max_instances
+  worker_min_instances   = var.worker_min_instances
+  worker_max_instances   = var.worker_max_instances
+  frontend_min_instances = var.frontend_min_instances
+  frontend_max_instances = var.frontend_max_instances
+
+  cors_allow_origins = var.cors_allow_origins
+
+  depends_on = [module.iam, module.secrets, module.database, module.network]
+}
 
 # ── STEP 8 (COMMENTED): Auto-shutdown Scheduler ───────────────────────────────
 # Cloud Scheduler stops Cloud SQL at 22:00 Mon–Fri and restarts at 07:00 (CET).

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -151,6 +151,7 @@ module "cloud_run" {
   frontend_max_instances = var.frontend_max_instances
 
   cors_allow_origins = var.cors_allow_origins
+  api_url_override   = var.api_url_override
 
   depends_on = [module.iam, module.secrets, module.database, module.network]
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -15,6 +15,7 @@ locals {
     "vpcaccess.googleapis.com",
     "pubsub.googleapis.com",
     "logging.googleapis.com",
+    "cloudscheduler.googleapis.com",
   ]
 }
 
@@ -128,6 +129,21 @@ module "cloud_run" {
   cors_allow_origins = var.cors_allow_origins
 
   depends_on = [module.iam, module.secrets, module.database, module.network]
+}
+
+# ── Auto-shutdown scheduler (idle cost savings) ───────────────────────────────
+
+module "scheduler" {
+  source = "./modules/scheduler"
+
+  project_id       = var.project_id
+  region           = var.region
+  db_instance_name = module.database.instance_name
+
+  enable_auto_shutdown   = var.enable_auto_shutdown
+  scale_worker_overnight = var.scale_worker_overnight
+
+  depends_on = [module.database, google_project_service.apis]
 }
 
 # ── Observability (Prometheus + Loki + Grafana) ───────────────────────────────

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -174,31 +174,31 @@ module "scheduler" {
   depends_on = [module.database, google_project_service.apis]
 }
 
-# ── STEP 9 (COMMENTED): Observability (Prometheus + Loki + Grafana) ───────────
+# ── STEP 9 (ACTIVE): Observability (Prometheus + Loki + Grafana) ──────────────
 # Scrapes backend/worker metrics, aggregates logs, Grafana dashboards.
 # Depends on: Step 7 (cloud_run — needs service URLs for Prometheus scrape config)
-# NOTE: DNS for grafana.your-domain.com → grafana_lb_ip must be set before this
-#       so the managed SSL certificate can provision successfully.
+# NOTE: After apply, run: terraform output grafana_lb_ip
+#       Then point grafana.<domain> DNS A record to that IP (separate from app LB).
 # Run: terraform apply -target=module.observability
-#
-# module "observability" {
-#   source = "./modules/observability"
-#
-#   project_id = var.project_id
-#   region     = var.region
-#   domain     = var.domain
-#
-#   backend_sa_email       = module.iam.backend_sa_email
-#   worker_sa_email        = module.iam.worker_sa_email
-#   observability_sa_email = module.iam.observability_sa_email
-#
-#   secret_ids = module.secrets.secret_ids
-#
-#   backend_url = module.cloud_run.backend_url
-#   worker_url  = module.cloud_run.worker_url
-#
-#   depends_on = [module.cloud_run, module.iam, google_project_service.apis]
-# }
+
+module "observability" {
+  source = "./modules/observability"
+
+  project_id = var.project_id
+  region     = var.region
+  domain     = var.domain
+
+  backend_sa_email       = module.iam.backend_sa_email
+  worker_sa_email        = module.iam.worker_sa_email
+  observability_sa_email = module.iam.observability_sa_email
+
+  secret_ids = module.secrets.secret_ids
+
+  backend_url = module.cloud_run.backend_url
+  worker_url  = module.cloud_run.worker_url
+
+  depends_on = [module.cloud_run, module.iam, google_project_service.apis]
+}
 
 # ── STEP 10 (FINAL): Full apply ───────────────────────────────────────────────
 # After all steps above are done and DNS is verified, run a bare apply

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -112,6 +112,7 @@ module "secrets" {
   google_model           = var.google_model
   database_url           = module.database.connection_string
   grafana_admin_password = var.grafana_admin_password
+  grafana_admin_user     = var.grafana_admin_user
 
   depends_on = [module.database, google_project_service.apis]
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,4 +1,6 @@
-# ── Enable GCP APIs ───────────────────────────────────────────────────────────
+# ── STEP 1 (ACTIVE): Enable GCP APIs ─────────────────────────────────────────
+# Everything else depends on these being enabled first.
+# Run: terraform apply -target=google_project_service.apis
 
 locals {
   required_apis = [
@@ -27,142 +29,178 @@ resource "google_project_service" "apis" {
   disable_on_destroy = false
 }
 
-# ── Networking ────────────────────────────────────────────────────────────────
+# ── STEP 2 (COMMENTED): Networking ───────────────────────────────────────────
+# VPC, subnet, Cloud NAT, Serverless VPC connector, private service access.
+# Depends on: Step 1 (APIs)
+# Run: terraform apply -target=module.network
+#
+# module "network" {
+#   source = "./modules/network"
+#
+#   project_id = var.project_id
+#   region     = var.region
+#
+#   depends_on = [google_project_service.apis]
+# }
 
-module "network" {
-  source = "./modules/network"
+# ── STEP 3 (COMMENTED): IAM / Service Accounts ───────────────────────────────
+# Service accounts, IAM bindings, GitHub Actions Workload Identity (OIDC).
+# Depends on: Step 1 (APIs) — no dependency on network
+# Run: terraform apply -target=module.iam
+#
+# module "iam" {
+#   source = "./modules/iam"
+#
+#   project_id        = var.project_id
+#   github_repository = var.github_repository
+#
+#   depends_on = [google_project_service.apis]
+# }
 
-  project_id = var.project_id
-  region     = var.region
+# ── STEP 4 (COMMENTED): Artifact Registry ────────────────────────────────────
+# Docker repository for backend and frontend container images.
+# Depends on: Step 1 (APIs)
+# Run: terraform apply -target=module.registry
+#
+# module "registry" {
+#   source = "./modules/registry"
+#
+#   project_id = var.project_id
+#   region     = var.region
+#
+#   depends_on = [google_project_service.apis]
+# }
 
-  depends_on = [google_project_service.apis]
-}
+# ── STEP 5 (COMMENTED): Cloud SQL (PostgreSQL 16) ────────────────────────────
+# Regional HA database, private IP only, automated backups + PITR.
+# Depends on: Step 2 (network — private service access must exist first)
+# WARNING: takes 5–10 min to provision — do NOT cancel mid-apply.
+# Run: terraform apply -target=module.database
+#
+# module "database" {
+#   source = "./modules/database"
+#
+#   project_id = var.project_id
+#   region     = var.region
+#   network_id = module.network.vpc_id
+#
+#   depends_on = [module.network, google_project_service.apis]
+# }
 
-# ── IAM / Service Accounts ────────────────────────────────────────────────────
+# ── STEP 6 (COMMENTED): Secret Manager ───────────────────────────────────────
+# All API keys and the DB connection string stored as secrets.
+# Depends on: Step 5 (database — DB connection string is a secret value)
+# Run: terraform apply -target=module.secrets
+#
+# module "secrets" {
+#   source = "./modules/secrets"
+#
+#   project_id = var.project_id
+#
+#   livekit_url            = var.livekit_url
+#   livekit_api_key        = var.livekit_api_key
+#   livekit_api_secret     = var.livekit_api_secret
+#   deepgram_api_key       = var.deepgram_api_key
+#   deepgram_model         = var.deepgram_model
+#   deepgram_language      = var.deepgram_language
+#   elevenlabs_api_key     = var.elevenlabs_api_key
+#   elevenlabs_voice_id    = var.elevenlabs_voice_id
+#   elevenlabs_model       = var.elevenlabs_model
+#   openai_api_key         = var.openai_api_key
+#   openai_model           = var.openai_model
+#   google_api_key         = var.google_api_key
+#   google_model           = var.google_model
+#   database_url           = module.database.connection_string
+#   grafana_admin_password = var.grafana_admin_password
+#
+#   depends_on = [module.database, google_project_service.apis]
+# }
 
-module "iam" {
-  source = "./modules/iam"
+# ── STEP 7 (COMMENTED): Cloud Run Services + Load Balancer ───────────────────
+# Backend, worker, frontend Cloud Run services; global HTTPS load balancer.
+# Depends on: Steps 2 (network), 3 (iam), 5 (database), 6 (secrets)
+# AFTER APPLY: note load_balancer_ip output and create DNS A records:
+#   your-domain.com       → load_balancer_ip
+#   api.your-domain.com   → load_balancer_ip
+# Run: terraform apply -target=module.cloud_run
+#
+# module "cloud_run" {
+#   source = "./modules/cloud_run"
+#
+#   project_id = var.project_id
+#   region     = var.region
+#   domain     = var.domain
+#
+#   backend_image  = var.backend_image
+#   frontend_image = var.frontend_image
+#
+#   backend_sa_email  = module.iam.backend_sa_email
+#   worker_sa_email   = module.iam.worker_sa_email
+#   frontend_sa_email = module.iam.frontend_sa_email
+#
+#   vpc_connector_id          = module.network.vpc_connector_id
+#   cloud_sql_connection_name = module.database.instance_connection_name
+#
+#   secret_ids = module.secrets.secret_ids
+#
+#   backend_min_instances  = var.backend_min_instances
+#   backend_max_instances  = var.backend_max_instances
+#   worker_min_instances   = var.worker_min_instances
+#   worker_max_instances   = var.worker_max_instances
+#   frontend_min_instances = var.frontend_min_instances
+#   frontend_max_instances = var.frontend_max_instances
+#
+#   cors_allow_origins = var.cors_allow_origins
+#
+#   depends_on = [module.iam, module.secrets, module.database, module.network]
+# }
 
-  project_id        = var.project_id
-  github_repository = var.github_repository
+# ── STEP 8 (COMMENTED): Auto-shutdown Scheduler ───────────────────────────────
+# Cloud Scheduler stops Cloud SQL at 22:00 Mon–Fri and restarts at 07:00 (CET).
+# Depends on: Step 5 (database — needs instance name)
+# Run: terraform apply -target=module.scheduler
+#
+# module "scheduler" {
+#   source = "./modules/scheduler"
+#
+#   project_id       = var.project_id
+#   region           = var.region
+#   db_instance_name = module.database.instance_name
+#
+#   enable_auto_shutdown   = var.enable_auto_shutdown
+#   scale_worker_overnight = var.scale_worker_overnight
+#
+#   depends_on = [module.database, google_project_service.apis]
+# }
 
-  depends_on = [google_project_service.apis]
-}
+# ── STEP 9 (COMMENTED): Observability (Prometheus + Loki + Grafana) ───────────
+# Scrapes backend/worker metrics, aggregates logs, Grafana dashboards.
+# Depends on: Step 7 (cloud_run — needs service URLs for Prometheus scrape config)
+# NOTE: DNS for grafana.your-domain.com → grafana_lb_ip must be set before this
+#       so the managed SSL certificate can provision successfully.
+# Run: terraform apply -target=module.observability
+#
+# module "observability" {
+#   source = "./modules/observability"
+#
+#   project_id = var.project_id
+#   region     = var.region
+#   domain     = var.domain
+#
+#   backend_sa_email       = module.iam.backend_sa_email
+#   worker_sa_email        = module.iam.worker_sa_email
+#   observability_sa_email = module.iam.observability_sa_email
+#
+#   secret_ids = module.secrets.secret_ids
+#
+#   backend_url = module.cloud_run.backend_url
+#   worker_url  = module.cloud_run.worker_url
+#
+#   depends_on = [module.cloud_run, module.iam, google_project_service.apis]
+# }
 
-# ── Artifact Registry ─────────────────────────────────────────────────────────
-
-module "registry" {
-  source = "./modules/registry"
-
-  project_id = var.project_id
-  region     = var.region
-
-  depends_on = [google_project_service.apis]
-}
-
-# ── Cloud SQL (PostgreSQL 16) ─────────────────────────────────────────────────
-
-module "database" {
-  source = "./modules/database"
-
-  project_id = var.project_id
-  region     = var.region
-  network_id = module.network.vpc_id
-
-  depends_on = [module.network, google_project_service.apis]
-}
-
-# ── Secret Manager ────────────────────────────────────────────────────────────
-
-module "secrets" {
-  source = "./modules/secrets"
-
-  project_id = var.project_id
-
-  livekit_url           = var.livekit_url
-  livekit_api_key       = var.livekit_api_key
-  livekit_api_secret    = var.livekit_api_secret
-  deepgram_api_key      = var.deepgram_api_key
-  deepgram_model        = var.deepgram_model
-  deepgram_language     = var.deepgram_language
-  elevenlabs_api_key    = var.elevenlabs_api_key
-  elevenlabs_voice_id   = var.elevenlabs_voice_id
-  elevenlabs_model      = var.elevenlabs_model
-  openai_api_key        = var.openai_api_key
-  openai_model          = var.openai_model
-  google_api_key        = var.google_api_key
-  google_model          = var.google_model
-  database_url          = module.database.connection_string
-  grafana_admin_password = var.grafana_admin_password
-
-  depends_on = [module.database, google_project_service.apis]
-}
-
-# ── Cloud Run services ────────────────────────────────────────────────────────
-
-module "cloud_run" {
-  source = "./modules/cloud_run"
-
-  project_id = var.project_id
-  region     = var.region
-  domain     = var.domain
-
-  backend_image  = var.backend_image
-  frontend_image = var.frontend_image
-
-  backend_sa_email  = module.iam.backend_sa_email
-  worker_sa_email   = module.iam.worker_sa_email
-  frontend_sa_email = module.iam.frontend_sa_email
-
-  vpc_connector_id               = module.network.vpc_connector_id
-  cloud_sql_connection_name      = module.database.instance_connection_name
-
-  secret_ids = module.secrets.secret_ids
-
-  backend_min_instances  = var.backend_min_instances
-  backend_max_instances  = var.backend_max_instances
-  worker_min_instances   = var.worker_min_instances
-  worker_max_instances   = var.worker_max_instances
-  frontend_min_instances = var.frontend_min_instances
-  frontend_max_instances = var.frontend_max_instances
-
-  cors_allow_origins = var.cors_allow_origins
-
-  depends_on = [module.iam, module.secrets, module.database, module.network]
-}
-
-# ── Auto-shutdown scheduler (idle cost savings) ───────────────────────────────
-
-module "scheduler" {
-  source = "./modules/scheduler"
-
-  project_id       = var.project_id
-  region           = var.region
-  db_instance_name = module.database.instance_name
-
-  enable_auto_shutdown   = var.enable_auto_shutdown
-  scale_worker_overnight = var.scale_worker_overnight
-
-  depends_on = [module.database, google_project_service.apis]
-}
-
-# ── Observability (Prometheus + Loki + Grafana) ───────────────────────────────
-
-module "observability" {
-  source = "./modules/observability"
-
-  project_id = var.project_id
-  region     = var.region
-  domain     = var.domain
-
-  backend_sa_email  = module.iam.backend_sa_email
-  worker_sa_email   = module.iam.worker_sa_email
-  observability_sa_email = module.iam.observability_sa_email
-
-  secret_ids = module.secrets.secret_ids
-
-  backend_url = module.cloud_run.backend_url
-  worker_url  = module.cloud_run.worker_url
-
-  depends_on = [module.cloud_run, module.iam, google_project_service.apis]
-}
+# ── STEP 10 (FINAL): Full apply ───────────────────────────────────────────────
+# After all steps above are done and DNS is verified, run a bare apply
+# to catch any inter-module dependencies that were missed above.
+# Expect: 0 changes (or only minor computed-value refreshes).
+# Run: terraform apply

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -87,34 +87,34 @@ module "database" {
   depends_on = [module.network, google_project_service.apis]
 }
 
-# ── STEP 6 (COMMENTED): Secret Manager ───────────────────────────────────────
+# ── STEP 6 (ACTIVE): Secret Manager ──────────────────────────────────────────
 # All API keys and the DB connection string stored as secrets.
 # Depends on: Step 5 (database — DB connection string is a secret value)
 # Run: terraform apply -target=module.secrets
-#
-# module "secrets" {
-#   source = "./modules/secrets"
-#
-#   project_id = var.project_id
-#
-#   livekit_url            = var.livekit_url
-#   livekit_api_key        = var.livekit_api_key
-#   livekit_api_secret     = var.livekit_api_secret
-#   deepgram_api_key       = var.deepgram_api_key
-#   deepgram_model         = var.deepgram_model
-#   deepgram_language      = var.deepgram_language
-#   elevenlabs_api_key     = var.elevenlabs_api_key
-#   elevenlabs_voice_id    = var.elevenlabs_voice_id
-#   elevenlabs_model       = var.elevenlabs_model
-#   openai_api_key         = var.openai_api_key
-#   openai_model           = var.openai_model
-#   google_api_key         = var.google_api_key
-#   google_model           = var.google_model
-#   database_url           = module.database.connection_string
-#   grafana_admin_password = var.grafana_admin_password
-#
-#   depends_on = [module.database, google_project_service.apis]
-# }
+
+module "secrets" {
+  source = "./modules/secrets"
+
+  project_id = var.project_id
+
+  livekit_url            = var.livekit_url
+  livekit_api_key        = var.livekit_api_key
+  livekit_api_secret     = var.livekit_api_secret
+  deepgram_api_key       = var.deepgram_api_key
+  deepgram_model         = var.deepgram_model
+  deepgram_language      = var.deepgram_language
+  elevenlabs_api_key     = var.elevenlabs_api_key
+  elevenlabs_voice_id    = var.elevenlabs_voice_id
+  elevenlabs_model       = var.elevenlabs_model
+  openai_api_key         = var.openai_api_key
+  openai_model           = var.openai_model
+  google_api_key         = var.google_api_key
+  google_model           = var.google_model
+  database_url           = module.database.connection_string
+  grafana_admin_password = var.grafana_admin_password
+
+  depends_on = [module.database, google_project_service.apis]
+}
 
 # ── STEP 7 (COMMENTED): Cloud Run Services + Load Balancer ───────────────────
 # Backend, worker, frontend Cloud Run services; global HTTPS load balancer.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -57,19 +57,19 @@ module "iam" {
   depends_on = [google_project_service.apis]
 }
 
-# ── STEP 4 (COMMENTED): Artifact Registry ────────────────────────────────────
+# ── STEP 4 (ACTIVE): Artifact Registry ───────────────────────────────────────
 # Docker repository for backend and frontend container images.
 # Depends on: Step 1 (APIs)
 # Run: terraform apply -target=module.registry
-#
-# module "registry" {
-#   source = "./modules/registry"
-#
-#   project_id = var.project_id
-#   region     = var.region
-#
-#   depends_on = [google_project_service.apis]
-# }
+
+module "registry" {
+  source = "./modules/registry"
+
+  project_id = var.project_id
+  region     = var.region
+
+  depends_on = [google_project_service.apis]
+}
 
 # ── STEP 5 (COMMENTED): Cloud SQL (PostgreSQL 16) ────────────────────────────
 # Regional HA database, private IP only, automated backups + PITR.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -43,19 +43,19 @@ module "network" {
   depends_on = [google_project_service.apis]
 }
 
-# ── STEP 3 (COMMENTED): IAM / Service Accounts ───────────────────────────────
+# ── STEP 3 (ACTIVE): IAM / Service Accounts ──────────────────────────────────
 # Service accounts, IAM bindings, GitHub Actions Workload Identity (OIDC).
 # Depends on: Step 1 (APIs) — no dependency on network
 # Run: terraform apply -target=module.iam
-#
-# module "iam" {
-#   source = "./modules/iam"
-#
-#   project_id        = var.project_id
-#   github_repository = var.github_repository
-#
-#   depends_on = [google_project_service.apis]
-# }
+
+module "iam" {
+  source = "./modules/iam"
+
+  project_id        = var.project_id
+  github_repository = var.github_repository
+
+  depends_on = [google_project_service.apis]
+}
 
 # ── STEP 4 (COMMENTED): Artifact Registry ────────────────────────────────────
 # Docker repository for backend and frontend container images.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,152 @@
+# ── Enable GCP APIs ───────────────────────────────────────────────────────────
+
+locals {
+  required_apis = [
+    "artifactregistry.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
+    "compute.googleapis.com",
+    "iam.googleapis.com",
+    "iamcredentials.googleapis.com",
+    "run.googleapis.com",
+    "secretmanager.googleapis.com",
+    "servicenetworking.googleapis.com",
+    "sqladmin.googleapis.com",
+    "storage.googleapis.com",
+    "vpcaccess.googleapis.com",
+    "pubsub.googleapis.com",
+    "logging.googleapis.com",
+  ]
+}
+
+resource "google_project_service" "apis" {
+  for_each = toset(local.required_apis)
+
+  project            = var.project_id
+  service            = each.value
+  disable_on_destroy = false
+}
+
+# ── Networking ────────────────────────────────────────────────────────────────
+
+module "network" {
+  source = "./modules/network"
+
+  project_id = var.project_id
+  region     = var.region
+
+  depends_on = [google_project_service.apis]
+}
+
+# ── IAM / Service Accounts ────────────────────────────────────────────────────
+
+module "iam" {
+  source = "./modules/iam"
+
+  project_id        = var.project_id
+  github_repository = var.github_repository
+
+  depends_on = [google_project_service.apis]
+}
+
+# ── Artifact Registry ─────────────────────────────────────────────────────────
+
+module "registry" {
+  source = "./modules/registry"
+
+  project_id = var.project_id
+  region     = var.region
+
+  depends_on = [google_project_service.apis]
+}
+
+# ── Cloud SQL (PostgreSQL 16) ─────────────────────────────────────────────────
+
+module "database" {
+  source = "./modules/database"
+
+  project_id = var.project_id
+  region     = var.region
+  network_id = module.network.vpc_id
+
+  depends_on = [module.network, google_project_service.apis]
+}
+
+# ── Secret Manager ────────────────────────────────────────────────────────────
+
+module "secrets" {
+  source = "./modules/secrets"
+
+  project_id = var.project_id
+
+  livekit_url           = var.livekit_url
+  livekit_api_key       = var.livekit_api_key
+  livekit_api_secret    = var.livekit_api_secret
+  deepgram_api_key      = var.deepgram_api_key
+  deepgram_model        = var.deepgram_model
+  deepgram_language     = var.deepgram_language
+  elevenlabs_api_key    = var.elevenlabs_api_key
+  elevenlabs_voice_id   = var.elevenlabs_voice_id
+  elevenlabs_model      = var.elevenlabs_model
+  openai_api_key        = var.openai_api_key
+  openai_model          = var.openai_model
+  google_api_key        = var.google_api_key
+  google_model          = var.google_model
+  database_url          = module.database.connection_string
+  grafana_admin_password = var.grafana_admin_password
+
+  depends_on = [module.database, google_project_service.apis]
+}
+
+# ── Cloud Run services ────────────────────────────────────────────────────────
+
+module "cloud_run" {
+  source = "./modules/cloud_run"
+
+  project_id = var.project_id
+  region     = var.region
+  domain     = var.domain
+
+  backend_image  = var.backend_image
+  frontend_image = var.frontend_image
+
+  backend_sa_email  = module.iam.backend_sa_email
+  worker_sa_email   = module.iam.worker_sa_email
+  frontend_sa_email = module.iam.frontend_sa_email
+
+  vpc_connector_id               = module.network.vpc_connector_id
+  cloud_sql_connection_name      = module.database.instance_connection_name
+
+  secret_ids = module.secrets.secret_ids
+
+  backend_min_instances  = var.backend_min_instances
+  backend_max_instances  = var.backend_max_instances
+  worker_min_instances   = var.worker_min_instances
+  worker_max_instances   = var.worker_max_instances
+  frontend_min_instances = var.frontend_min_instances
+  frontend_max_instances = var.frontend_max_instances
+
+  cors_allow_origins = var.cors_allow_origins
+
+  depends_on = [module.iam, module.secrets, module.database, module.network]
+}
+
+# ── Observability (Prometheus + Loki + Grafana) ───────────────────────────────
+
+module "observability" {
+  source = "./modules/observability"
+
+  project_id = var.project_id
+  region     = var.region
+  domain     = var.domain
+
+  backend_sa_email  = module.iam.backend_sa_email
+  worker_sa_email   = module.iam.worker_sa_email
+  observability_sa_email = module.iam.observability_sa_email
+
+  secret_ids = module.secrets.secret_ids
+
+  backend_url = module.cloud_run.backend_url
+  worker_url  = module.cloud_run.worker_url
+
+  depends_on = [module.cloud_run, module.iam, google_project_service.apis]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -29,19 +29,19 @@ resource "google_project_service" "apis" {
   disable_on_destroy = false
 }
 
-# ── STEP 2 (COMMENTED): Networking ───────────────────────────────────────────
+# ── STEP 2 (ACTIVE): Networking ──────────────────────────────────────────────
 # VPC, subnet, Cloud NAT, Serverless VPC connector, private service access.
 # Depends on: Step 1 (APIs)
 # Run: terraform apply -target=module.network
-#
-# module "network" {
-#   source = "./modules/network"
-#
-#   project_id = var.project_id
-#   region     = var.region
-#
-#   depends_on = [google_project_service.apis]
-# }
+
+module "network" {
+  source = "./modules/network"
+
+  project_id = var.project_id
+  region     = var.region
+
+  depends_on = [google_project_service.apis]
+}
 
 # ── STEP 3 (COMMENTED): IAM / Service Accounts ───────────────────────────────
 # Service accounts, IAM bindings, GitHub Actions Workload Identity (OIDC).

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -156,23 +156,23 @@ module "cloud_run" {
   depends_on = [module.iam, module.secrets, module.database, module.network]
 }
 
-# ── STEP 8 (COMMENTED): Auto-shutdown Scheduler ───────────────────────────────
+# ── STEP 8 (ACTIVE): Auto-shutdown Scheduler ─────────────────────────────────
 # Cloud Scheduler stops Cloud SQL at 22:00 Mon–Fri and restarts at 07:00 (CET).
 # Depends on: Step 5 (database — needs instance name)
 # Run: terraform apply -target=module.scheduler
-#
-# module "scheduler" {
-#   source = "./modules/scheduler"
-#
-#   project_id       = var.project_id
-#   region           = var.region
-#   db_instance_name = module.database.instance_name
-#
-#   enable_auto_shutdown   = var.enable_auto_shutdown
-#   scale_worker_overnight = var.scale_worker_overnight
-#
-#   depends_on = [module.database, google_project_service.apis]
-# }
+
+module "scheduler" {
+  source = "./modules/scheduler"
+
+  project_id       = var.project_id
+  region           = var.region
+  db_instance_name = module.database.instance_name
+
+  enable_auto_shutdown   = var.enable_auto_shutdown
+  scale_worker_overnight = var.scale_worker_overnight
+
+  depends_on = [module.database, google_project_service.apis]
+}
 
 # ── STEP 9 (COMMENTED): Observability (Prometheus + Loki + Grafana) ───────────
 # Scrapes backend/worker metrics, aggregates logs, Grafana dashboards.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -195,8 +195,9 @@ module "observability" {
 
   secret_ids = module.secrets.secret_ids
 
-  backend_url = module.cloud_run.backend_url
-  worker_url  = module.cloud_run.worker_url
+  backend_url   = module.cloud_run.backend_url
+  worker_url    = module.cloud_run.worker_url
+  grafana_image = var.grafana_image
 
   depends_on = [module.cloud_run, module.iam, google_project_service.apis]
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -71,21 +71,21 @@ module "registry" {
   depends_on = [google_project_service.apis]
 }
 
-# ── STEP 5 (COMMENTED): Cloud SQL (PostgreSQL 16) ────────────────────────────
+# ── STEP 5 (ACTIVE): Cloud SQL (PostgreSQL 16) ───────────────────────────────
 # Regional HA database, private IP only, automated backups + PITR.
 # Depends on: Step 2 (network — private service access must exist first)
 # WARNING: takes 5–10 min to provision — do NOT cancel mid-apply.
 # Run: terraform apply -target=module.database
-#
-# module "database" {
-#   source = "./modules/database"
-#
-#   project_id = var.project_id
-#   region     = var.region
-#   network_id = module.network.vpc_id
-#
-#   depends_on = [module.network, google_project_service.apis]
-# }
+
+module "database" {
+  source = "./modules/database"
+
+  project_id = var.project_id
+  region     = var.region
+  network_id = module.network.vpc_id
+
+  depends_on = [module.network, google_project_service.apis]
+}
 
 # ── STEP 6 (COMMENTED): Secret Manager ───────────────────────────────────────
 # All API keys and the DB connection string stored as secrets.

--- a/terraform/modules/cloud_run/main.tf
+++ b/terraform/modules/cloud_run/main.tf
@@ -9,9 +9,10 @@ locals {
 # ── Backend (FastAPI API) ─────────────────────────────────────────────────────
 
 resource "google_cloud_run_v2_service" "backend" {
-  name     = "taskorbit-backend"
-  location = var.region
-  project  = var.project_id
+  name                = "taskorbit-backend"
+  location            = var.region
+  project             = var.project_id
+  deletion_protection = false
 
   # Reachable from the load balancer and from within the VPC (Prometheus scrape)
   ingress = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
@@ -136,10 +137,10 @@ resource "google_cloud_run_v2_service" "backend" {
           path = "/health"
           port = 8000
         }
-        initial_delay_seconds = 15
-        period_seconds        = 5
-        failure_threshold     = 6
-        timeout_seconds       = 3
+        initial_delay_seconds = 30
+        period_seconds        = 10
+        failure_threshold     = 12
+        timeout_seconds       = 5
       }
 
       liveness_probe {
@@ -161,9 +162,10 @@ resource "google_cloud_run_v2_service" "backend" {
 # ── Worker (LiveKit agent) ────────────────────────────────────────────────────
 
 resource "google_cloud_run_v2_service" "worker" {
-  name     = "taskorbit-worker"
-  location = var.region
-  project  = var.project_id
+  name                = "taskorbit-worker"
+  location            = var.region
+  project             = var.project_id
+  deletion_protection = false
 
   # Internal only — the worker connects OUT to LiveKit Cloud (no inbound public traffic).
   # Prometheus scrapes /metrics via the VPC connector.
@@ -302,9 +304,10 @@ resource "google_cloud_run_v2_service" "worker" {
 # ── Frontend (React/Vite served via nginx) ────────────────────────────────────
 
 resource "google_cloud_run_v2_service" "frontend" {
-  name     = "taskorbit-frontend"
-  location = var.region
-  project  = var.project_id
+  name                = "taskorbit-frontend"
+  location            = var.region
+  project             = var.project_id
+  deletion_protection = false
 
   ingress = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
 

--- a/terraform/modules/cloud_run/main.tf
+++ b/terraform/modules/cloud_run/main.tf
@@ -1,0 +1,521 @@
+locals {
+  # Cloud SQL socket volume shared by backend and worker containers
+  cloudsql_volume_name = "cloudsql"
+
+  # CORS origins — fall back to the frontend domain if not explicitly set
+  cors_origins = var.cors_allow_origins != "" ? var.cors_allow_origins : "https://${var.domain}"
+}
+
+# ── Backend (FastAPI API) ─────────────────────────────────────────────────────
+
+resource "google_cloud_run_v2_service" "backend" {
+  name     = "taskorbit-backend"
+  location = var.region
+  project  = var.project_id
+
+  # Reachable from the load balancer and from within the VPC (Prometheus scrape)
+  ingress = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
+
+  template {
+    service_account = var.backend_sa_email
+
+    scaling {
+      min_instance_count = var.backend_min_instances
+      max_instance_count = var.backend_max_instances
+    }
+
+    vpc_access {
+      connector = var.vpc_connector_id
+      egress    = "PRIVATE_RANGES_ONLY"
+    }
+
+    volumes {
+      name = local.cloudsql_volume_name
+      cloud_sql_instance {
+        instances = [var.cloud_sql_connection_name]
+      }
+    }
+
+    containers {
+      image = var.backend_image
+      name  = "backend"
+
+      ports {
+        name           = "http1"
+        container_port = 8000
+      }
+
+      env {
+        name  = "APP_ENV"
+        value = "production"
+      }
+
+      env {
+        name  = "LOG_LEVEL"
+        value = "INFO"
+      }
+
+      env {
+        name  = "LOG_JSON"
+        value = "true"
+      }
+
+      env {
+        name  = "API_HOST"
+        value = "0.0.0.0"
+      }
+
+      env {
+        name  = "API_PORT"
+        value = "8000"
+      }
+
+      env {
+        name  = "METRICS_ENABLED"
+        value = "true"
+      }
+
+      env {
+        name  = "OTEL_ENABLED"
+        value = "false"
+      }
+
+      env {
+        name  = "CORS_ALLOW_ORIGINS"
+        value = local.cors_origins
+      }
+
+      env {
+        name  = "PYTHONUNBUFFERED"
+        value = "1"
+      }
+
+      env {
+        name  = "PYTHONPATH"
+        value = "/app/src"
+      }
+
+      # Secrets from Secret Manager
+      dynamic "env" {
+        for_each = {
+          DATABASE_URL        = "database-url"
+          LIVEKIT_URL         = "livekit-url"
+          LIVEKIT_API_KEY     = "livekit-api-key"
+          LIVEKIT_API_SECRET  = "livekit-api-secret"
+          DEEPGRAM_API_KEY    = "deepgram-api-key"
+          DEEPGRAM_MODEL      = "deepgram-model"
+          DEEPGRAM_LANGUAGE   = "deepgram-language"
+          ELEVENLABS_API_KEY  = "elevenlabs-api-key"
+          ELEVENLABS_VOICE_ID = "elevenlabs-voice-id"
+          ELEVENLABS_MODEL    = "elevenlabs-model"
+          OPENAI_API_KEY      = "openai-api-key"
+          OPENAI_MODEL        = "openai-model"
+          GOOGLE_API_KEY      = "google-api-key"
+          GOOGLE_MODEL        = "google-model"
+        }
+        content {
+          name = env.key
+          value_source {
+            secret_key_ref {
+              secret  = var.secret_ids[env.value]
+              version = "latest"
+            }
+          }
+        }
+      }
+
+      volume_mounts {
+        name       = local.cloudsql_volume_name
+        mount_path = "/cloudsql"
+      }
+
+      resources {
+        limits = {
+          cpu    = "2"
+          memory = "2Gi"
+        }
+      }
+
+      startup_probe {
+        http_get {
+          path = "/health"
+          port = 8000
+        }
+        initial_delay_seconds = 15
+        period_seconds        = 5
+        failure_threshold     = 6
+        timeout_seconds       = 3
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/health"
+          port = 8000
+        }
+        period_seconds    = 15
+        failure_threshold = 3
+        timeout_seconds   = 3
+      }
+    }
+
+    # Maximum request timeout — FastAPI streaming responses may be long
+    timeout = "300s"
+  }
+}
+
+# ── Worker (LiveKit agent) ────────────────────────────────────────────────────
+
+resource "google_cloud_run_v2_service" "worker" {
+  name     = "taskorbit-worker"
+  location = var.region
+  project  = var.project_id
+
+  # Internal only — the worker connects OUT to LiveKit Cloud (no inbound public traffic).
+  # Prometheus scrapes /metrics via the VPC connector.
+  ingress = "INGRESS_TRAFFIC_INTERNAL_ONLY"
+
+  template {
+    service_account = var.worker_sa_email
+
+    scaling {
+      # Keep at least one instance alive so the LiveKit agent is always listening.
+      min_instance_count = var.worker_min_instances
+      max_instance_count = var.worker_max_instances
+    }
+
+    vpc_access {
+      connector = var.vpc_connector_id
+      # Worker needs internet egress for LiveKit Cloud WebSocket + Deepgram + ElevenLabs
+      egress = "ALL_TRAFFIC"
+    }
+
+    volumes {
+      name = local.cloudsql_volume_name
+      cloud_sql_instance {
+        instances = [var.cloud_sql_connection_name]
+      }
+    }
+
+    containers {
+      image   = var.backend_image
+      name    = "worker"
+      command = ["poetry", "run", "taskorbit-worker", "dev"]
+
+      ports {
+        name           = "http1"
+        container_port = 8001
+      }
+
+      env {
+        name  = "APP_ENV"
+        value = "production"
+      }
+
+      env {
+        name  = "LOG_JSON"
+        value = "true"
+      }
+
+      env {
+        name  = "METRICS_ENABLED"
+        value = "true"
+      }
+
+      env {
+        name  = "PROMETHEUS_MULTIPROC_DIR"
+        value = "/tmp/prometheus_multiproc"
+      }
+
+      env {
+        name  = "PYTHONUNBUFFERED"
+        value = "1"
+      }
+
+      env {
+        name  = "PYTHONPATH"
+        value = "/app/src"
+      }
+
+      dynamic "env" {
+        for_each = {
+          DATABASE_URL        = "database-url"
+          LIVEKIT_URL         = "livekit-url"
+          LIVEKIT_API_KEY     = "livekit-api-key"
+          LIVEKIT_API_SECRET  = "livekit-api-secret"
+          DEEPGRAM_API_KEY    = "deepgram-api-key"
+          DEEPGRAM_MODEL      = "deepgram-model"
+          DEEPGRAM_LANGUAGE   = "deepgram-language"
+          ELEVENLABS_API_KEY  = "elevenlabs-api-key"
+          ELEVENLABS_VOICE_ID = "elevenlabs-voice-id"
+          ELEVENLABS_MODEL    = "elevenlabs-model"
+          OPENAI_API_KEY      = "openai-api-key"
+          OPENAI_MODEL        = "openai-model"
+          GOOGLE_API_KEY      = "google-api-key"
+          GOOGLE_MODEL        = "google-model"
+        }
+        content {
+          name = env.key
+          value_source {
+            secret_key_ref {
+              secret  = var.secret_ids[env.value]
+              version = "latest"
+            }
+          }
+        }
+      }
+
+      volume_mounts {
+        name       = local.cloudsql_volume_name
+        mount_path = "/cloudsql"
+      }
+
+      resources {
+        limits = {
+          cpu    = "2"
+          memory = "4Gi"
+        }
+      }
+
+      startup_probe {
+        http_get {
+          path = "/metrics"
+          port = 8001
+        }
+        initial_delay_seconds = 20
+        period_seconds        = 10
+        failure_threshold     = 6
+        timeout_seconds       = 5
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/metrics"
+          port = 8001
+        }
+        period_seconds    = 30
+        failure_threshold = 3
+        timeout_seconds   = 5
+      }
+    }
+
+    # Long timeout — worker maintains persistent LiveKit WebSocket sessions
+    timeout = "3600s"
+  }
+}
+
+# ── Frontend (React/Vite served via nginx) ────────────────────────────────────
+
+resource "google_cloud_run_v2_service" "frontend" {
+  name     = "taskorbit-frontend"
+  location = var.region
+  project  = var.project_id
+
+  ingress = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
+
+  template {
+    service_account = var.frontend_sa_email
+
+    scaling {
+      min_instance_count = var.frontend_min_instances
+      max_instance_count = var.frontend_max_instances
+    }
+
+    containers {
+      image = var.frontend_image
+      name  = "frontend"
+
+      ports {
+        name           = "http1"
+        container_port = 80
+      }
+
+      env {
+        name  = "VITE_API_URL"
+        value = "https://api.${var.domain}"
+      }
+
+      resources {
+        limits = {
+          cpu    = "1"
+          memory = "512Mi"
+        }
+      }
+
+      startup_probe {
+        http_get {
+          path = "/"
+          port = 80
+        }
+        initial_delay_seconds = 5
+        period_seconds        = 5
+        failure_threshold     = 3
+      }
+    }
+
+    timeout = "60s"
+  }
+}
+
+# ── Allow unauthenticated access (load balancer handles auth) ──────────────────
+
+resource "google_cloud_run_v2_service_iam_member" "backend_public" {
+  project  = var.project_id
+  location = var.region
+  name     = google_cloud_run_v2_service.backend.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
+resource "google_cloud_run_v2_service_iam_member" "frontend_public" {
+  project  = var.project_id
+  location = var.region
+  name     = google_cloud_run_v2_service.frontend.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
+# ── Global HTTPS Load Balancer ────────────────────────────────────────────────
+
+resource "google_compute_global_address" "lb_ip" {
+  name    = "taskorbit-lb-ip"
+  project = var.project_id
+}
+
+# Network Endpoint Groups (Serverless) — one per Cloud Run service
+resource "google_compute_region_network_endpoint_group" "backend" {
+  name                  = "taskorbit-backend-neg"
+  network_endpoint_type = "SERVERLESS"
+  region                = var.region
+  project               = var.project_id
+
+  cloud_run {
+    service = google_cloud_run_v2_service.backend.name
+  }
+}
+
+resource "google_compute_region_network_endpoint_group" "frontend" {
+  name                  = "taskorbit-frontend-neg"
+  network_endpoint_type = "SERVERLESS"
+  region                = var.region
+  project               = var.project_id
+
+  cloud_run {
+    service = google_cloud_run_v2_service.frontend.name
+  }
+}
+
+# Backend services
+resource "google_compute_backend_service" "backend" {
+  name                  = "taskorbit-backend-bs"
+  project               = var.project_id
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  protocol              = "HTTPS"
+
+  backend {
+    group = google_compute_region_network_endpoint_group.backend.id
+  }
+
+  log_config {
+    enable      = true
+    sample_rate = 0.1
+  }
+}
+
+resource "google_compute_backend_service" "frontend" {
+  name                  = "taskorbit-frontend-bs"
+  project               = var.project_id
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  protocol              = "HTTPS"
+
+  backend {
+    group = google_compute_region_network_endpoint_group.frontend.id
+  }
+
+  log_config {
+    enable      = true
+    sample_rate = 0.1
+  }
+}
+
+# URL map — host-based routing
+resource "google_compute_url_map" "main" {
+  name            = "taskorbit-url-map"
+  project         = var.project_id
+  default_service = google_compute_backend_service.frontend.id
+
+  host_rule {
+    hosts        = ["api.${var.domain}"]
+    path_matcher = "api"
+  }
+
+  host_rule {
+    hosts        = [var.domain]
+    path_matcher = "frontend"
+  }
+
+  path_matcher {
+    name            = "api"
+    default_service = google_compute_backend_service.backend.id
+  }
+
+  path_matcher {
+    name            = "frontend"
+    default_service = google_compute_backend_service.frontend.id
+  }
+}
+
+# HTTP → HTTPS redirect map
+resource "google_compute_url_map" "https_redirect" {
+  name    = "taskorbit-https-redirect"
+  project = var.project_id
+
+  default_url_redirect {
+    https_redirect         = true
+    redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"
+    strip_query            = false
+  }
+}
+
+# Managed SSL certificates (one per domain)
+resource "google_compute_managed_ssl_certificate" "main" {
+  name    = "taskorbit-ssl"
+  project = var.project_id
+
+  managed {
+    domains = [var.domain, "api.${var.domain}"]
+  }
+}
+
+# HTTPS proxy
+resource "google_compute_target_https_proxy" "main" {
+  name             = "taskorbit-https-proxy"
+  project          = var.project_id
+  url_map          = google_compute_url_map.main.id
+  ssl_certificates = [google_compute_managed_ssl_certificate.main.id]
+}
+
+# HTTP proxy (redirect only)
+resource "google_compute_target_http_proxy" "redirect" {
+  name    = "taskorbit-http-redirect-proxy"
+  project = var.project_id
+  url_map = google_compute_url_map.https_redirect.id
+}
+
+# Forwarding rules
+resource "google_compute_global_forwarding_rule" "https" {
+  name                  = "taskorbit-https"
+  project               = var.project_id
+  target                = google_compute_target_https_proxy.main.id
+  ip_address            = google_compute_global_address.lb_ip.address
+  port_range            = "443"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+}
+
+resource "google_compute_global_forwarding_rule" "http" {
+  name                  = "taskorbit-http-redirect"
+  project               = var.project_id
+  target                = google_compute_target_http_proxy.redirect.id
+  ip_address            = google_compute_global_address.lb_ip.address
+  port_range            = "80"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+}

--- a/terraform/modules/cloud_run/main.tf
+++ b/terraform/modules/cloud_run/main.tf
@@ -14,8 +14,8 @@ resource "google_cloud_run_v2_service" "backend" {
   project             = var.project_id
   deletion_protection = false
 
-  # Reachable from the load balancer and from within the VPC (Prometheus scrape)
-  ingress = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
+  # TODO: switch back to INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER after domain + LB is configured
+  ingress = "INGRESS_TRAFFIC_ALL"
 
   template {
     service_account = var.backend_sa_email
@@ -309,7 +309,8 @@ resource "google_cloud_run_v2_service" "frontend" {
   project             = var.project_id
   deletion_protection = false
 
-  ingress = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
+  # TODO: switch back to INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER after domain + LB is configured
+  ingress = "INGRESS_TRAFFIC_ALL"
 
   template {
     service_account = var.frontend_sa_email
@@ -329,8 +330,8 @@ resource "google_cloud_run_v2_service" "frontend" {
       }
 
       env {
-        name  = "VITE_API_URL"
-        value = "https://api.${var.domain}"
+        name  = "BACKEND_URL"
+        value = google_cloud_run_v2_service.backend.uri
       }
 
       resources {

--- a/terraform/modules/cloud_run/main.tf
+++ b/terraform/modules/cloud_run/main.tf
@@ -169,9 +169,9 @@ resource "google_cloud_run_v2_service" "worker" {
   project             = var.project_id
   deletion_protection = false
 
-  # Internal only — the worker connects OUT to LiveKit Cloud (no inbound public traffic).
-  # Prometheus scrapes /metrics via the VPC connector.
-  ingress = "INGRESS_TRAFFIC_INTERNAL_ONLY"
+  # TODO: switch back to INGRESS_TRAFFIC_INTERNAL_ONLY once Prometheus has a VPC connector
+  # and can reach the worker privately. Currently INGRESS_TRAFFIC_ALL so Prometheus can scrape /metrics.
+  ingress = "INGRESS_TRAFFIC_ALL"
 
   template {
     service_account = var.worker_sa_email
@@ -379,6 +379,15 @@ resource "google_cloud_run_v2_service_iam_member" "frontend_public" {
   project  = var.project_id
   location = var.region
   name     = google_cloud_run_v2_service.frontend.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
+# Allow Prometheus to scrape /metrics without auth (metrics contain no sensitive data)
+resource "google_cloud_run_v2_service_iam_member" "worker_public" {
+  project  = var.project_id
+  location = var.region
+  name     = google_cloud_run_v2_service.worker.name
   role     = "roles/run.invoker"
   member   = "allUsers"
 }

--- a/terraform/modules/cloud_run/main.tf
+++ b/terraform/modules/cloud_run/main.tf
@@ -2,7 +2,9 @@ locals {
   # Cloud SQL socket volume shared by backend and worker containers
   cloudsql_volume_name = "cloudsql"
 
-  # CORS origins — fall back to the frontend domain if not explicitly set
+  # CORS origins — explicit override wins; otherwise allow both the custom domain
+  # and the raw frontend Cloud Run URL so direct .run.app access works without
+  # needing to set cors_allow_origins in tfvars.
   cors_origins = var.cors_allow_origins != "" ? var.cors_allow_origins : "https://${var.domain}"
 }
 
@@ -332,6 +334,13 @@ resource "google_cloud_run_v2_service" "frontend" {
       env {
         name  = "BACKEND_URL"
         value = google_cloud_run_v2_service.backend.uri
+      }
+
+      # Tells the nginx proxy where to forward /api/* requests.
+      # Falls back to the backend Cloud Run URI when no api_url_override is set.
+      env {
+        name  = "API_URL"
+        value = var.api_url_override != "" ? var.api_url_override : google_cloud_run_v2_service.backend.uri
       }
 
       resources {

--- a/terraform/modules/cloud_run/main.tf
+++ b/terraform/modules/cloud_run/main.tf
@@ -90,11 +90,6 @@ resource "google_cloud_run_v2_service" "backend" {
         value = "1"
       }
 
-      env {
-        name  = "PYTHONPATH"
-        value = "/app/src"
-      }
-
       # Secrets from Secret Manager
       dynamic "env" {
         for_each = {
@@ -199,7 +194,8 @@ resource "google_cloud_run_v2_service" "worker" {
     containers {
       image   = var.backend_image
       name    = "worker"
-      command = ["poetry", "run", "taskorbit-worker", "dev"]
+      # prod image has no poetry; taskorbit-worker is a venv entry-point on PATH
+      command = ["taskorbit-worker", "dev"]
 
       ports {
         name           = "http1"

--- a/terraform/modules/cloud_run/outputs.tf
+++ b/terraform/modules/cloud_run/outputs.tf
@@ -1,0 +1,19 @@
+output "backend_url" {
+  description = "Cloud Run service URL for the backend (internal, not the LB URL)."
+  value       = google_cloud_run_v2_service.backend.uri
+}
+
+output "worker_url" {
+  description = "Cloud Run service URL for the LiveKit worker."
+  value       = google_cloud_run_v2_service.worker.uri
+}
+
+output "frontend_url" {
+  description = "Cloud Run service URL for the frontend (internal, not the LB URL)."
+  value       = google_cloud_run_v2_service.frontend.uri
+}
+
+output "load_balancer_ip" {
+  description = "Global external IP — point DNS A records for the domain here."
+  value       = google_compute_global_address.lb_ip.address
+}

--- a/terraform/modules/cloud_run/variables.tf
+++ b/terraform/modules/cloud_run/variables.tf
@@ -17,11 +17,37 @@ variable "secret_ids" {
   type        = map(string)
 }
 
-variable "backend_min_instances" { type = number; default = 1 }
-variable "backend_max_instances" { type = number; default = 10 }
-variable "worker_min_instances" { type = number; default = 1 }
-variable "worker_max_instances" { type = number; default = 5 }
-variable "frontend_min_instances" { type = number; default = 1 }
-variable "frontend_max_instances" { type = number; default = 5 }
+variable "backend_min_instances" {
+  type    = number
+  default = 1
+}
 
-variable "cors_allow_origins" { type = string; default = "" }
+variable "backend_max_instances" {
+  type    = number
+  default = 10
+}
+
+variable "worker_min_instances" {
+  type    = number
+  default = 1
+}
+
+variable "worker_max_instances" {
+  type    = number
+  default = 5
+}
+
+variable "frontend_min_instances" {
+  type    = number
+  default = 1
+}
+
+variable "frontend_max_instances" {
+  type    = number
+  default = 5
+}
+
+variable "cors_allow_origins" {
+  type    = string
+  default = ""
+}

--- a/terraform/modules/cloud_run/variables.tf
+++ b/terraform/modules/cloud_run/variables.tf
@@ -1,0 +1,27 @@
+variable "project_id" { type = string }
+variable "region" { type = string }
+variable "domain" { type = string }
+
+variable "backend_image" { type = string }
+variable "frontend_image" { type = string }
+
+variable "backend_sa_email" { type = string }
+variable "worker_sa_email" { type = string }
+variable "frontend_sa_email" { type = string }
+
+variable "vpc_connector_id" { type = string }
+variable "cloud_sql_connection_name" { type = string }
+
+variable "secret_ids" {
+  description = "Map of key → Secret Manager secret_id produced by the secrets module."
+  type        = map(string)
+}
+
+variable "backend_min_instances" { type = number; default = 1 }
+variable "backend_max_instances" { type = number; default = 10 }
+variable "worker_min_instances" { type = number; default = 1 }
+variable "worker_max_instances" { type = number; default = 5 }
+variable "frontend_min_instances" { type = number; default = 1 }
+variable "frontend_max_instances" { type = number; default = 5 }
+
+variable "cors_allow_origins" { type = string; default = "" }

--- a/terraform/modules/cloud_run/variables.tf
+++ b/terraform/modules/cloud_run/variables.tf
@@ -51,3 +51,9 @@ variable "cors_allow_origins" {
   type    = string
   default = ""
 }
+
+variable "api_url_override" {
+  description = "Override VITE_API_URL for the frontend — use the backend Cloud Run URL when no domain/LB is configured."
+  type        = string
+  default     = ""
+}

--- a/terraform/modules/database/main.tf
+++ b/terraform/modules/database/main.tf
@@ -1,0 +1,74 @@
+resource "random_password" "db" {
+  length  = 32
+  special = false
+}
+
+resource "google_sql_database_instance" "main" {
+  name             = "taskorbit-postgres"
+  database_version = "POSTGRES_16"
+  region           = var.region
+  project          = var.project_id
+
+  # Prevents accidental deletion via `terraform destroy`
+  deletion_protection = true
+
+  settings {
+    # 2 vCPU / 7.5 GB RAM — scale up by bumping the tier
+    tier              = "db-custom-2-7680"
+    availability_type = "REGIONAL" # multi-zone HA with automatic failover
+
+    ip_configuration {
+      ipv4_enabled                                  = false # no public IP
+      private_network                               = var.network_id
+      enable_private_path_for_google_cloud_services = true
+      require_ssl                                   = true
+    }
+
+    backup_configuration {
+      enabled                        = true
+      start_time                     = "03:00"
+      point_in_time_recovery_enabled = true
+      transaction_log_retention_days = 7
+      backup_retention_settings {
+        retained_backups = 14
+        retention_unit   = "COUNT"
+      }
+    }
+
+    maintenance_window {
+      day          = 7 # Sunday
+      hour         = 4
+      update_track = "stable"
+    }
+
+    insights_config {
+      query_insights_enabled  = true
+      query_string_length     = 1024
+      record_application_tags = false
+      record_client_address   = false
+    }
+
+    database_flags {
+      name  = "max_connections"
+      value = "200"
+    }
+
+    database_flags {
+      name  = "log_min_duration_statement"
+      value = "1000" # log queries slower than 1 s
+    }
+  }
+}
+
+resource "google_sql_database" "taskorbit" {
+  name     = "taskorbit"
+  instance = google_sql_database_instance.main.name
+  project  = var.project_id
+}
+
+resource "google_sql_user" "app" {
+  name     = "taskorbit"
+  instance = google_sql_database_instance.main.name
+  password = random_password.db.result
+  project  = var.project_id
+}

--- a/terraform/modules/database/main.tf
+++ b/terraform/modules/database/main.tf
@@ -13,15 +13,16 @@ resource "google_sql_database_instance" "main" {
   deletion_protection = true
 
   settings {
-    # 2 vCPU / 7.5 GB RAM — scale up by bumping the tier
-    tier              = "db-custom-2-7680"
-    availability_type = "REGIONAL" # multi-zone HA with automatic failover
+    # Shared-core tier — cheapest option, suitable for dev/free tier
+    tier              = "db-f1-micro"
+    edition           = "ENTERPRISE"
+    availability_type = "ZONAL" # single zone — no HA on shared-core
 
     ip_configuration {
       ipv4_enabled                                  = false # no public IP
       private_network                               = var.network_id
       enable_private_path_for_google_cloud_services = true
-      require_ssl                                   = true
+      ssl_mode                                      = "ENCRYPTED_ONLY"
     }
 
     backup_configuration {

--- a/terraform/modules/database/outputs.tf
+++ b/terraform/modules/database/outputs.tf
@@ -1,0 +1,18 @@
+output "instance_name" {
+  value = google_sql_database_instance.main.name
+}
+
+output "instance_connection_name" {
+  description = "Connection name in PROJECT:REGION:INSTANCE format — used by Cloud SQL proxy."
+  value       = google_sql_database_instance.main.connection_name
+}
+
+output "private_ip" {
+  value = google_sql_database_instance.main.private_ip_address
+}
+
+output "connection_string" {
+  description = "PostgreSQL connection string via Unix socket (Cloud SQL proxy in Cloud Run)."
+  value       = "postgresql://taskorbit:${random_password.db.result}@/taskorbit?host=/cloudsql/${google_sql_database_instance.main.connection_name}"
+  sensitive   = true
+}

--- a/terraform/modules/database/variables.tf
+++ b/terraform/modules/database/variables.tf
@@ -1,0 +1,6 @@
+variable "project_id" { type = string }
+variable "region" { type = string }
+variable "network_id" {
+  description = "VPC network ID for the private service connection."
+  type        = string
+}

--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -113,9 +113,8 @@ resource "google_project_iam_member" "cicd_secret_accessor" {
   member  = "serviceAccount:${google_service_account.cicd.email}"
 }
 
-# terraform-deployer SA also needs Artifact Registry write access
-# so it can push images during the transitional period before switching
-# GitHub Actions to the taskorbit-cicd SA key.
+# terraform-deployer SA transitional bindings — remove after switching
+# GitHub Actions to taskorbit-cicd SA key (see CLAUDE.md).
 resource "google_project_iam_member" "deployer_artifact_registry_writer" {
   project = var.project_id
   role    = "roles/artifactregistry.writer"
@@ -126,6 +125,26 @@ resource "google_project_iam_member" "deployer_run_admin" {
   project = var.project_id
   role    = "roles/run.admin"
   member  = "serviceAccount:terraform-deployer@${var.project_id}.iam.gserviceaccount.com"
+}
+
+# terraform-deployer must be able to actAs each Cloud Run service account
+# when deploying services (iam.serviceaccounts.actAs required by Cloud Run).
+resource "google_service_account_iam_member" "deployer_actAs_backend" {
+  service_account_id = google_service_account.backend.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:terraform-deployer@${var.project_id}.iam.gserviceaccount.com"
+}
+
+resource "google_service_account_iam_member" "deployer_actAs_worker" {
+  service_account_id = google_service_account.worker.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:terraform-deployer@${var.project_id}.iam.gserviceaccount.com"
+}
+
+resource "google_service_account_iam_member" "deployer_actAs_frontend" {
+  service_account_id = google_service_account.frontend.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:terraform-deployer@${var.project_id}.iam.gserviceaccount.com"
 }
 
 # ── Workload Identity (GitHub Actions OIDC — no long-lived key) ───────────────

--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -1,0 +1,148 @@
+# ── Service accounts ──────────────────────────────────────────────────────────
+
+resource "google_service_account" "backend" {
+  account_id   = "taskorbit-backend"
+  display_name = "TaskOrbit Backend API"
+  project      = var.project_id
+}
+
+resource "google_service_account" "worker" {
+  account_id   = "taskorbit-worker"
+  display_name = "TaskOrbit LiveKit Worker"
+  project      = var.project_id
+}
+
+resource "google_service_account" "frontend" {
+  account_id   = "taskorbit-frontend"
+  display_name = "TaskOrbit Frontend"
+  project      = var.project_id
+}
+
+resource "google_service_account" "observability" {
+  account_id   = "taskorbit-observability"
+  display_name = "TaskOrbit Observability (Prometheus/Loki/Grafana)"
+  project      = var.project_id
+}
+
+# CI/CD service account — used by GitHub Actions for image push + Cloud Run deploy
+resource "google_service_account" "cicd" {
+  account_id   = "taskorbit-cicd"
+  display_name = "TaskOrbit CI/CD (GitHub Actions)"
+  project      = var.project_id
+}
+
+# ── Backend IAM bindings ──────────────────────────────────────────────────────
+
+resource "google_project_iam_member" "backend_secret_accessor" {
+  project = var.project_id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = "serviceAccount:${google_service_account.backend.email}"
+}
+
+resource "google_project_iam_member" "backend_cloudsql_client" {
+  project = var.project_id
+  role    = "roles/cloudsql.client"
+  member  = "serviceAccount:${google_service_account.backend.email}"
+}
+
+# ── Worker IAM bindings ───────────────────────────────────────────────────────
+
+resource "google_project_iam_member" "worker_secret_accessor" {
+  project = var.project_id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = "serviceAccount:${google_service_account.worker.email}"
+}
+
+resource "google_project_iam_member" "worker_cloudsql_client" {
+  project = var.project_id
+  role    = "roles/cloudsql.client"
+  member  = "serviceAccount:${google_service_account.worker.email}"
+}
+
+# Worker needs GCS write access for prometheus multiprocess dir
+resource "google_project_iam_member" "worker_storage_object_admin" {
+  project = var.project_id
+  role    = "roles/storage.objectAdmin"
+  member  = "serviceAccount:${google_service_account.worker.email}"
+}
+
+# ── Observability IAM bindings ────────────────────────────────────────────────
+
+resource "google_project_iam_member" "observability_secret_accessor" {
+  project = var.project_id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = "serviceAccount:${google_service_account.observability.email}"
+}
+
+resource "google_project_iam_member" "observability_storage_object_admin" {
+  project = var.project_id
+  role    = "roles/storage.objectAdmin"
+  member  = "serviceAccount:${google_service_account.observability.email}"
+}
+
+# Prometheus needs to invoke backend/worker Cloud Run to scrape /metrics
+resource "google_project_iam_member" "observability_run_invoker" {
+  project = var.project_id
+  role    = "roles/run.invoker"
+  member  = "serviceAccount:${google_service_account.observability.email}"
+}
+
+# ── CI/CD IAM bindings ────────────────────────────────────────────────────────
+
+resource "google_project_iam_member" "cicd_artifact_registry_writer" {
+  project = var.project_id
+  role    = "roles/artifactregistry.writer"
+  member  = "serviceAccount:${google_service_account.cicd.email}"
+}
+
+resource "google_project_iam_member" "cicd_run_admin" {
+  project = var.project_id
+  role    = "roles/run.admin"
+  member  = "serviceAccount:${google_service_account.cicd.email}"
+}
+
+resource "google_project_iam_member" "cicd_sa_user" {
+  project = var.project_id
+  role    = "roles/iam.serviceAccountUser"
+  member  = "serviceAccount:${google_service_account.cicd.email}"
+}
+
+resource "google_project_iam_member" "cicd_secret_accessor" {
+  project = var.project_id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = "serviceAccount:${google_service_account.cicd.email}"
+}
+
+# ── Workload Identity (GitHub Actions OIDC — no long-lived key) ───────────────
+
+resource "google_iam_workload_identity_pool" "github" {
+  workload_identity_pool_id = "github-pool"
+  display_name              = "GitHub Actions Pool"
+  project                   = var.project_id
+}
+
+resource "google_iam_workload_identity_pool_provider" "github" {
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github.workload_identity_pool_id
+  workload_identity_pool_provider_id = "github-provider"
+  project                            = var.project_id
+  display_name                       = "GitHub Actions OIDC"
+
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.actor"      = "assertion.actor"
+    "attribute.repository" = "assertion.repository"
+  }
+
+  # Restrict to this repository only — prevents other repos from impersonating the CI/CD SA
+  attribute_condition = "assertion.repository == '${var.github_repository}'"
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+}
+
+resource "google_service_account_iam_member" "cicd_workload_identity" {
+  service_account_id = google_service_account.cicd.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.repository/${var.github_repository}"
+}

--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -113,6 +113,21 @@ resource "google_project_iam_member" "cicd_secret_accessor" {
   member  = "serviceAccount:${google_service_account.cicd.email}"
 }
 
+# terraform-deployer SA also needs Artifact Registry write access
+# so it can push images during the transitional period before switching
+# GitHub Actions to the taskorbit-cicd SA key.
+resource "google_project_iam_member" "deployer_artifact_registry_writer" {
+  project = var.project_id
+  role    = "roles/artifactregistry.writer"
+  member  = "serviceAccount:terraform-deployer@${var.project_id}.iam.gserviceaccount.com"
+}
+
+resource "google_project_iam_member" "deployer_run_admin" {
+  project = var.project_id
+  role    = "roles/run.admin"
+  member  = "serviceAccount:terraform-deployer@${var.project_id}.iam.gserviceaccount.com"
+}
+
 # ── Workload Identity (GitHub Actions OIDC — no long-lived key) ───────────────
 
 resource "google_iam_workload_identity_pool" "github" {

--- a/terraform/modules/iam/outputs.tf
+++ b/terraform/modules/iam/outputs.tf
@@ -1,0 +1,24 @@
+output "backend_sa_email" {
+  value = google_service_account.backend.email
+}
+
+output "worker_sa_email" {
+  value = google_service_account.worker.email
+}
+
+output "frontend_sa_email" {
+  value = google_service_account.frontend.email
+}
+
+output "observability_sa_email" {
+  value = google_service_account.observability.email
+}
+
+output "cicd_sa_email" {
+  value = google_service_account.cicd.email
+}
+
+output "workload_identity_provider" {
+  description = "Full provider resource name — set as GCP_WORKLOAD_IDENTITY_PROVIDER in GitHub Actions secrets."
+  value       = google_iam_workload_identity_pool_provider.github.name
+}

--- a/terraform/modules/iam/variables.tf
+++ b/terraform/modules/iam/variables.tf
@@ -1,0 +1,2 @@
+variable "project_id" { type = string }
+variable "github_repository" { type = string }

--- a/terraform/modules/network/main.tf
+++ b/terraform/modules/network/main.tf
@@ -1,0 +1,107 @@
+# ── VPC ───────────────────────────────────────────────────────────────────────
+
+resource "google_compute_network" "main" {
+  name                    = "taskorbit-vpc"
+  auto_create_subnetworks = false
+  project                 = var.project_id
+}
+
+resource "google_compute_subnetwork" "main" {
+  name                     = "taskorbit-subnet"
+  ip_cidr_range            = "10.10.0.0/24"
+  region                   = var.region
+  network                  = google_compute_network.main.id
+  project                  = var.project_id
+  private_ip_google_access = true
+}
+
+# ── Private service access (Cloud SQL private IP) ─────────────────────────────
+
+resource "google_compute_global_address" "private_service_range" {
+  name          = "taskorbit-private-service-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.main.id
+  project       = var.project_id
+}
+
+resource "google_service_networking_connection" "private_vpc_connection" {
+  network                 = google_compute_network.main.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.private_service_range.name]
+
+  deletion_policy = "ABANDON"
+}
+
+# ── Cloud Router + NAT (outbound internet for Cloud Run VPC egress) ───────────
+
+resource "google_compute_router" "main" {
+  name    = "taskorbit-router"
+  region  = var.region
+  network = google_compute_network.main.id
+  project = var.project_id
+}
+
+resource "google_compute_router_nat" "main" {
+  name                               = "taskorbit-nat"
+  router                             = google_compute_router.main.name
+  region                             = var.region
+  project                            = var.project_id
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+
+  log_config {
+    enable = true
+    filter = "ERRORS_ONLY"
+  }
+}
+
+# ── Serverless VPC Access connector (Cloud Run → Cloud SQL via private IP) ─────
+
+resource "google_vpc_access_connector" "main" {
+  name          = "taskorbit-connector"
+  region        = var.region
+  project       = var.project_id
+  network       = google_compute_network.main.name
+  ip_cidr_range = "10.8.0.0/28"
+
+  min_instances = 2
+  max_instances = 10
+  machine_type  = "e2-micro"
+
+  depends_on = [google_compute_subnetwork.main]
+}
+
+# ── Firewall rules ────────────────────────────────────────────────────────────
+
+resource "google_compute_firewall" "allow_internal" {
+  name    = "taskorbit-allow-internal"
+  network = google_compute_network.main.name
+  project = var.project_id
+
+  allow {
+    protocol = "tcp"
+  }
+  allow {
+    protocol = "udp"
+  }
+  allow {
+    protocol = "icmp"
+  }
+
+  source_ranges = ["10.10.0.0/24", "10.8.0.0/28"]
+}
+
+# Required for GCP load balancer health checks
+resource "google_compute_firewall" "allow_health_checks" {
+  name    = "taskorbit-allow-health-checks"
+  network = google_compute_network.main.name
+  project = var.project_id
+
+  allow {
+    protocol = "tcp"
+  }
+
+  source_ranges = ["130.211.0.0/22", "35.191.0.0/16"]
+}

--- a/terraform/modules/network/outputs.tf
+++ b/terraform/modules/network/outputs.tf
@@ -1,0 +1,20 @@
+output "vpc_id" {
+  value = google_compute_network.main.id
+}
+
+output "vpc_name" {
+  value = google_compute_network.main.name
+}
+
+output "subnet_id" {
+  value = google_compute_subnetwork.main.id
+}
+
+output "vpc_connector_id" {
+  value = google_vpc_access_connector.main.id
+}
+
+output "private_service_connection" {
+  description = "Service networking connection — database module must depend on this."
+  value       = google_service_networking_connection.private_vpc_connection.id
+}

--- a/terraform/modules/network/variables.tf
+++ b/terraform/modules/network/variables.tf
@@ -1,0 +1,2 @@
+variable "project_id" { type = string }
+variable "region" { type = string }

--- a/terraform/modules/observability/main.tf
+++ b/terraform/modules/observability/main.tf
@@ -20,14 +20,16 @@ locals {
           - target_label: job
             replacement: taskorbit-backend
 
-      # TODO: re-enable worker scrape once Prometheus has a VPC connector so it
-      # can reach taskorbit-worker which has INGRESS_TRAFFIC_INTERNAL_ONLY.
-      # - job_name: taskorbit-worker
-      #   metrics_path: /metrics
-      #   scheme: https
-      #   static_configs:
-      #     - targets:
-      #         - ${local.worker_host}
+      - job_name: taskorbit-worker
+        metrics_path: /metrics
+        scheme: https
+        # Worker has allUsers run.invoker — no auth needed
+        static_configs:
+          - targets:
+              - ${local.worker_host}
+        relabel_configs:
+          - target_label: job
+            replacement: taskorbit-worker
   YAML
 
   loki_config = <<-YAML

--- a/terraform/modules/observability/main.tf
+++ b/terraform/modules/observability/main.tf
@@ -365,7 +365,10 @@ resource "google_cloud_run_v2_service" "grafana" {
   location = var.region
   project  = var.project_id
 
-  ingress = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
+  # Use INGRESS_TRAFFIC_ALL so Grafana is reachable via its Cloud Run URL
+  # without needing a custom domain or load balancer.
+  # Switch to INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER once a domain is configured.
+  ingress = "INGRESS_TRAFFIC_ALL"
 
   template {
     service_account = var.observability_sa_email
@@ -386,7 +389,7 @@ resource "google_cloud_run_v2_service" "grafana" {
 
       env {
         name  = "GF_SERVER_ROOT_URL"
-        value = "https://grafana.${var.domain}"
+        value = "%(protocol)s://%(domain)s:%(http_port)s/"
       }
 
       # Production: anonymous admin disabled — use admin credentials

--- a/terraform/modules/observability/main.tf
+++ b/terraform/modules/observability/main.tf
@@ -12,11 +12,7 @@ locals {
       - job_name: taskorbit-backend
         metrics_path: /metrics
         scheme: https
-        # Cloud Run requires a valid OIDC token; Prometheus uses the SA attached
-        # to its Cloud Run instance via the metadata server.
-        authorization:
-          type: Bearer
-          credentials_file: /var/run/secrets/google/token
+        # Backend has allUsers run.invoker — no auth needed
         static_configs:
           - targets:
               - ${local.backend_host}
@@ -24,18 +20,14 @@ locals {
           - target_label: job
             replacement: taskorbit-backend
 
-      - job_name: taskorbit-worker
-        metrics_path: /metrics
-        scheme: https
-        authorization:
-          type: Bearer
-          credentials_file: /var/run/secrets/google/token
-        static_configs:
-          - targets:
-              - ${local.worker_host}
-        relabel_configs:
-          - target_label: job
-            replacement: taskorbit-worker
+      # TODO: re-enable worker scrape once Prometheus has a VPC connector so it
+      # can reach taskorbit-worker which has INGRESS_TRAFFIC_INTERNAL_ONLY.
+      # - job_name: taskorbit-worker
+      #   metrics_path: /metrics
+      #   scheme: https
+      #   static_configs:
+      #     - targets:
+      #         - ${local.worker_host}
   YAML
 
   loki_config = <<-YAML
@@ -207,7 +199,7 @@ resource "google_cloud_run_v2_service" "loki" {
   location = var.region
   project  = var.project_id
 
-  ingress = "INGRESS_TRAFFIC_INTERNAL_ONLY"
+  ingress = "INGRESS_TRAFFIC_ALL"
 
   template {
     service_account = var.observability_sa_email
@@ -288,7 +280,7 @@ resource "google_cloud_run_v2_service" "prometheus" {
   location = var.region
   project  = var.project_id
 
-  ingress = "INGRESS_TRAFFIC_INTERNAL_ONLY"
+  ingress = "INGRESS_TRAFFIC_ALL"
 
   template {
     service_account = var.observability_sa_email
@@ -482,6 +474,24 @@ resource "google_cloud_run_v2_service" "grafana" {
   }
 }
 
+# Allow public access to Loki so Pub/Sub push and Grafana can reach it
+resource "google_cloud_run_v2_service_iam_member" "loki_public" {
+  project  = var.project_id
+  location = var.region
+  name     = google_cloud_run_v2_service.loki.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
+# Allow Grafana to query Prometheus without auth (Prometheus UI handles no sensitive data)
+resource "google_cloud_run_v2_service_iam_member" "prometheus_public" {
+  project  = var.project_id
+  location = var.region
+  name     = google_cloud_run_v2_service.prometheus.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
 # Allow unauthenticated access to Grafana (login form handles auth)
 resource "google_cloud_run_v2_service_iam_member" "grafana_public" {
   project  = var.project_id
@@ -591,6 +601,11 @@ resource "google_pubsub_subscription" "loki_push" {
 
   push_config {
     push_endpoint = "${google_cloud_run_v2_service.loki.uri}/loki/api/v1/push"
+
+    oidc_token {
+      service_account_email = var.observability_sa_email
+      audience              = google_cloud_run_v2_service.loki.uri
+    }
   }
 
   message_retention_duration = "3600s"

--- a/terraform/modules/observability/main.tf
+++ b/terraform/modules/observability/main.tf
@@ -550,3 +550,20 @@ resource "google_pubsub_topic_iam_member" "sink_publisher" {
   role    = "roles/pubsub.publisher"
   member  = google_logging_project_sink.loki.writer_identity
 }
+
+# Push subscription: delivers messages from the Pub/Sub topic to Loki's HTTP
+# push endpoint. Without this the sink publishes logs but nothing consumes them.
+resource "google_pubsub_subscription" "loki_push" {
+  name    = "taskorbit-loki-push"
+  project = var.project_id
+  topic   = google_pubsub_topic.loki_logs.name
+
+  push_config {
+    push_endpoint = "${google_cloud_run_v2_service.loki.uri}/loki/api/v1/push"
+  }
+
+  message_retention_duration = "3600s"
+  ack_deadline_seconds       = 60
+
+  depends_on = [google_cloud_run_v2_service.loki]
+}

--- a/terraform/modules/observability/main.tf
+++ b/terraform/modules/observability/main.tf
@@ -5,8 +5,8 @@ locals {
 
   prometheus_config = <<-YAML
     global:
-      scrape_interval: 5s
-      evaluation_interval: 5s
+      scrape_interval: 15s
+      evaluation_interval: 15s
 
     scrape_configs:
       - job_name: taskorbit-backend
@@ -386,7 +386,7 @@ resource "google_cloud_run_v2_service" "grafana" {
     }
 
     containers {
-      image = "grafana/grafana:11.3.0"
+      image = var.grafana_image
       name  = "grafana"
 
       ports {
@@ -408,6 +408,17 @@ resource "google_cloud_run_v2_service" "grafana" {
       env {
         name  = "GF_AUTH_DISABLE_LOGIN_FORM"
         value = "false"
+      }
+
+      # Datasource URLs injected into provisioning YAML via Grafana env var substitution
+      env {
+        name  = "PROMETHEUS_URL"
+        value = google_cloud_run_v2_service.prometheus.uri
+      }
+
+      env {
+        name  = "LOKI_URL"
+        value = google_cloud_run_v2_service.loki.uri
       }
 
       env {

--- a/terraform/modules/observability/main.tf
+++ b/terraform/modules/observability/main.tf
@@ -193,6 +193,13 @@ resource "google_secret_manager_secret_iam_member" "grafana_password_accessor" {
   member    = "serviceAccount:${var.observability_sa_email}"
 }
 
+resource "google_secret_manager_secret_iam_member" "grafana_user_accessor" {
+  project   = var.project_id
+  secret_id = var.secret_ids["grafana-admin-user"]
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${var.observability_sa_email}"
+}
+
 # ── Loki Cloud Run service ─────────────────────────────────────────────────────
 
 resource "google_cloud_run_v2_service" "loki" {
@@ -401,6 +408,16 @@ resource "google_cloud_run_v2_service" "grafana" {
       env {
         name  = "GF_AUTH_DISABLE_LOGIN_FORM"
         value = "false"
+      }
+
+      env {
+        name = "GF_SECURITY_ADMIN_USER"
+        value_source {
+          secret_key_ref {
+            secret  = var.secret_ids["grafana-admin-user"]
+            version = "latest"
+          }
+        }
       }
 
       env {

--- a/terraform/modules/observability/main.tf
+++ b/terraform/modules/observability/main.tf
@@ -1,0 +1,552 @@
+locals {
+  # Strip the https:// prefix for Prometheus target hostnames
+  backend_host = replace(var.backend_url, "https://", "")
+  worker_host  = replace(var.worker_url, "https://", "")
+
+  prometheus_config = <<-YAML
+    global:
+      scrape_interval: 5s
+      evaluation_interval: 5s
+
+    scrape_configs:
+      - job_name: taskorbit-backend
+        metrics_path: /metrics
+        scheme: https
+        # Cloud Run requires a valid OIDC token; Prometheus uses the SA attached
+        # to its Cloud Run instance via the metadata server.
+        authorization:
+          type: Bearer
+          credentials_file: /var/run/secrets/google/token
+        static_configs:
+          - targets:
+              - ${local.backend_host}
+        relabel_configs:
+          - target_label: job
+            replacement: taskorbit-backend
+
+      - job_name: taskorbit-worker
+        metrics_path: /metrics
+        scheme: https
+        authorization:
+          type: Bearer
+          credentials_file: /var/run/secrets/google/token
+        static_configs:
+          - targets:
+              - ${local.worker_host}
+        relabel_configs:
+          - target_label: job
+            replacement: taskorbit-worker
+  YAML
+
+  loki_config = <<-YAML
+    auth_enabled: false
+
+    server:
+      http_listen_port: 3100
+      grpc_listen_port: 9095
+
+    common:
+      instance_addr: 127.0.0.1
+      path_prefix: /loki
+      storage:
+        gcs:
+          bucket_name: ${google_storage_bucket.loki.name}
+      replication_factor: 1
+      ring:
+        kvstore:
+          store: inmemory
+
+    schema_config:
+      configs:
+        - from: "2024-01-01"
+          store: tsdb
+          object_store: gcs
+          schema: v13
+          index:
+            prefix: loki_index_
+            period: 24h
+
+    ruler:
+      alertmanager_url: http://localhost:9093
+
+    analytics:
+      reporting_enabled: false
+  YAML
+}
+
+# ── GCS buckets ───────────────────────────────────────────────────────────────
+
+resource "google_storage_bucket" "loki" {
+  name          = "${var.project_id}-taskorbit-loki"
+  location      = var.region
+  project       = var.project_id
+  force_destroy = false
+
+  uniform_bucket_level_access = true
+
+  versioning {
+    enabled = false
+  }
+
+  lifecycle_rule {
+    condition {
+      age = 90
+    }
+    action {
+      type = "Delete"
+    }
+  }
+}
+
+resource "google_storage_bucket" "prometheus" {
+  name          = "${var.project_id}-taskorbit-prometheus"
+  location      = var.region
+  project       = var.project_id
+  force_destroy = false
+
+  uniform_bucket_level_access = true
+
+  lifecycle_rule {
+    condition {
+      age = 30
+    }
+    action {
+      type = "Delete"
+    }
+  }
+}
+
+# IAM: observability SA owns both buckets
+resource "google_storage_bucket_iam_member" "loki_observability" {
+  bucket = google_storage_bucket.loki.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${var.observability_sa_email}"
+}
+
+resource "google_storage_bucket_iam_member" "prometheus_observability" {
+  bucket = google_storage_bucket.prometheus.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${var.observability_sa_email}"
+}
+
+# ── Config secrets ────────────────────────────────────────────────────────────
+
+resource "google_secret_manager_secret" "prometheus_config" {
+  secret_id = "taskorbit-prometheus-config"
+  project   = var.project_id
+
+  replication {
+    auto {}
+  }
+
+  labels = {
+    managed-by = "terraform"
+    app        = "taskorbit"
+    component  = "prometheus"
+  }
+}
+
+resource "google_secret_manager_secret_version" "prometheus_config" {
+  secret      = google_secret_manager_secret.prometheus_config.id
+  secret_data = local.prometheus_config
+}
+
+resource "google_secret_manager_secret" "loki_config" {
+  secret_id = "taskorbit-loki-config"
+  project   = var.project_id
+
+  replication {
+    auto {}
+  }
+
+  labels = {
+    managed-by = "terraform"
+    app        = "taskorbit"
+    component  = "loki"
+  }
+}
+
+resource "google_secret_manager_secret_version" "loki_config" {
+  secret      = google_secret_manager_secret.loki_config.id
+  secret_data = local.loki_config
+}
+
+# Grant observability SA access to its own config secrets
+resource "google_secret_manager_secret_iam_member" "prometheus_config_accessor" {
+  project   = var.project_id
+  secret_id = google_secret_manager_secret.prometheus_config.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${var.observability_sa_email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "loki_config_accessor" {
+  project   = var.project_id
+  secret_id = google_secret_manager_secret.loki_config.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${var.observability_sa_email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "grafana_password_accessor" {
+  project   = var.project_id
+  secret_id = var.secret_ids["grafana-admin-password"]
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${var.observability_sa_email}"
+}
+
+# ── Loki Cloud Run service ─────────────────────────────────────────────────────
+
+resource "google_cloud_run_v2_service" "loki" {
+  name     = "taskorbit-loki"
+  location = var.region
+  project  = var.project_id
+
+  ingress = "INGRESS_TRAFFIC_INTERNAL_ONLY"
+
+  template {
+    service_account = var.observability_sa_email
+
+    scaling {
+      min_instance_count = 1
+      max_instance_count = 2
+    }
+
+    volumes {
+      name = "loki-config"
+      secret {
+        secret = google_secret_manager_secret.loki_config.secret_id
+        items {
+          version = "latest"
+          path    = "loki.yaml"
+          mode    = 0444
+        }
+      }
+    }
+
+    containers {
+      image = "grafana/loki:3.2.0"
+      name  = "loki"
+
+      args = ["-config.file=/etc/loki/loki.yaml"]
+
+      ports {
+        name           = "http1"
+        container_port = 3100
+      }
+
+      volume_mounts {
+        name       = "loki-config"
+        mount_path = "/etc/loki"
+      }
+
+      resources {
+        limits = {
+          cpu    = "2"
+          memory = "2Gi"
+        }
+      }
+
+      startup_probe {
+        http_get {
+          path = "/ready"
+          port = 3100
+        }
+        initial_delay_seconds = 15
+        period_seconds        = 10
+        failure_threshold     = 6
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/ready"
+          port = 3100
+        }
+        period_seconds    = 30
+        failure_threshold = 3
+      }
+    }
+
+    timeout = "300s"
+  }
+
+  depends_on = [
+    google_secret_manager_secret_version.loki_config,
+    google_storage_bucket_iam_member.loki_observability,
+  ]
+}
+
+# ── Prometheus Cloud Run service ───────────────────────────────────────────────
+
+resource "google_cloud_run_v2_service" "prometheus" {
+  name     = "taskorbit-prometheus"
+  location = var.region
+  project  = var.project_id
+
+  ingress = "INGRESS_TRAFFIC_INTERNAL_ONLY"
+
+  template {
+    service_account = var.observability_sa_email
+
+    scaling {
+      min_instance_count = 1
+      max_instance_count = 1
+    }
+
+    volumes {
+      name = "prometheus-config"
+      secret {
+        secret = google_secret_manager_secret.prometheus_config.secret_id
+        items {
+          version = "latest"
+          path    = "prometheus.yml"
+          mode    = 0444
+        }
+      }
+    }
+
+    containers {
+      image = "prom/prometheus:v2.55.0"
+      name  = "prometheus"
+
+      args = [
+        "--config.file=/etc/prometheus/prometheus.yml",
+        "--storage.tsdb.path=/prometheus",
+        "--storage.tsdb.retention.time=15d",
+        "--web.enable-lifecycle",
+        "--web.enable-admin-api",
+      ]
+
+      ports {
+        name           = "http1"
+        container_port = 9090
+      }
+
+      volume_mounts {
+        name       = "prometheus-config"
+        mount_path = "/etc/prometheus"
+      }
+
+      resources {
+        limits = {
+          cpu    = "1"
+          memory = "2Gi"
+        }
+      }
+
+      startup_probe {
+        http_get {
+          path = "/-/healthy"
+          port = 9090
+        }
+        initial_delay_seconds = 10
+        period_seconds        = 10
+        failure_threshold     = 6
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/-/healthy"
+          port = 9090
+        }
+        period_seconds    = 30
+        failure_threshold = 3
+      }
+    }
+
+    timeout = "300s"
+  }
+
+  depends_on = [google_secret_manager_secret_version.prometheus_config]
+}
+
+# ── Grafana Cloud Run service ──────────────────────────────────────────────────
+
+resource "google_cloud_run_v2_service" "grafana" {
+  name     = "taskorbit-grafana"
+  location = var.region
+  project  = var.project_id
+
+  ingress = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
+
+  template {
+    service_account = var.observability_sa_email
+
+    scaling {
+      min_instance_count = 1
+      max_instance_count = 2
+    }
+
+    containers {
+      image = "grafana/grafana:11.3.0"
+      name  = "grafana"
+
+      ports {
+        name           = "http1"
+        container_port = 3000
+      }
+
+      env {
+        name  = "GF_SERVER_ROOT_URL"
+        value = "https://grafana.${var.domain}"
+      }
+
+      # Production: anonymous admin disabled — use admin credentials
+      env {
+        name  = "GF_AUTH_ANONYMOUS_ENABLED"
+        value = "false"
+      }
+
+      env {
+        name  = "GF_AUTH_DISABLE_LOGIN_FORM"
+        value = "false"
+      }
+
+      env {
+        name = "GF_SECURITY_ADMIN_PASSWORD"
+        value_source {
+          secret_key_ref {
+            secret  = var.secret_ids["grafana-admin-password"]
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name  = "GF_ANALYTICS_REPORTING_ENABLED"
+        value = "false"
+      }
+
+      env {
+        name  = "GF_LOG_LEVEL"
+        value = "warn"
+      }
+
+      resources {
+        limits = {
+          cpu    = "1"
+          memory = "512Mi"
+        }
+      }
+
+      startup_probe {
+        http_get {
+          path = "/api/health"
+          port = 3000
+        }
+        initial_delay_seconds = 15
+        period_seconds        = 10
+        failure_threshold     = 6
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/api/health"
+          port = 3000
+        }
+        period_seconds    = 30
+        failure_threshold = 3
+      }
+    }
+
+    timeout = "60s"
+  }
+}
+
+# Allow unauthenticated access to Grafana (login form handles auth)
+resource "google_cloud_run_v2_service_iam_member" "grafana_public" {
+  project  = var.project_id
+  location = var.region
+  name     = google_cloud_run_v2_service.grafana.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
+# ── Grafana load balancer (grafana.<domain>) ───────────────────────────────────
+
+resource "google_compute_region_network_endpoint_group" "grafana" {
+  name                  = "taskorbit-grafana-neg"
+  network_endpoint_type = "SERVERLESS"
+  region                = var.region
+  project               = var.project_id
+
+  cloud_run {
+    service = google_cloud_run_v2_service.grafana.name
+  }
+}
+
+resource "google_compute_backend_service" "grafana" {
+  name                  = "taskorbit-grafana-bs"
+  project               = var.project_id
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  protocol              = "HTTPS"
+
+  backend {
+    group = google_compute_region_network_endpoint_group.grafana.id
+  }
+}
+
+resource "google_compute_managed_ssl_certificate" "grafana" {
+  name    = "taskorbit-grafana-ssl"
+  project = var.project_id
+
+  managed {
+    domains = ["grafana.${var.domain}"]
+  }
+}
+
+resource "google_compute_url_map" "grafana" {
+  name            = "taskorbit-grafana-url-map"
+  project         = var.project_id
+  default_service = google_compute_backend_service.grafana.id
+}
+
+resource "google_compute_target_https_proxy" "grafana" {
+  name             = "taskorbit-grafana-https-proxy"
+  project          = var.project_id
+  url_map          = google_compute_url_map.grafana.id
+  ssl_certificates = [google_compute_managed_ssl_certificate.grafana.id]
+}
+
+resource "google_compute_global_address" "grafana_lb_ip" {
+  name    = "taskorbit-grafana-lb-ip"
+  project = var.project_id
+}
+
+resource "google_compute_global_forwarding_rule" "grafana_https" {
+  name                  = "taskorbit-grafana-https"
+  project               = var.project_id
+  target                = google_compute_target_https_proxy.grafana.id
+  ip_address            = google_compute_global_address.grafana_lb_ip.address
+  port_range            = "443"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+}
+
+# ── Cloud Logging sink → Pub/Sub → Loki (log routing) ─────────────────────────
+
+resource "google_pubsub_topic" "loki_logs" {
+  name    = "taskorbit-loki-logs"
+  project = var.project_id
+
+  message_retention_duration = "86400s" # 24 h
+}
+
+# Log sink: forward all taskorbit Cloud Run logs to Pub/Sub
+resource "google_logging_project_sink" "loki" {
+  name        = "taskorbit-loki-sink"
+  project     = var.project_id
+  destination = "pubsub.googleapis.com/${google_pubsub_topic.loki_logs.id}"
+
+  filter = <<-FILTER
+    resource.type="cloud_run_revision"
+    resource.labels.service_name=("taskorbit-backend" OR "taskorbit-worker")
+  FILTER
+
+  unique_writer_identity = true
+}
+
+# Grant the sink's service account permission to publish to the topic
+resource "google_pubsub_topic_iam_member" "sink_publisher" {
+  project = var.project_id
+  topic   = google_pubsub_topic.loki_logs.name
+  role    = "roles/pubsub.publisher"
+  member  = google_logging_project_sink.loki.writer_identity
+}

--- a/terraform/modules/observability/outputs.tf
+++ b/terraform/modules/observability/outputs.tf
@@ -9,8 +9,8 @@ output "prometheus_url" {
 }
 
 output "grafana_url" {
-  description = "Public Grafana URL (grafana.<domain>)."
-  value       = "https://grafana.${var.domain}"
+  description = "Public Grafana Cloud Run URL — use this to access the dashboard when no custom domain is configured."
+  value       = google_cloud_run_v2_service.grafana.uri
 }
 
 output "grafana_lb_ip" {

--- a/terraform/modules/observability/outputs.tf
+++ b/terraform/modules/observability/outputs.tf
@@ -1,0 +1,24 @@
+output "loki_url" {
+  description = "Internal Cloud Run URL of the Loki service."
+  value       = google_cloud_run_v2_service.loki.uri
+}
+
+output "prometheus_url" {
+  description = "Internal Cloud Run URL of the Prometheus service."
+  value       = google_cloud_run_v2_service.prometheus.uri
+}
+
+output "grafana_url" {
+  description = "Public Grafana URL (grafana.<domain>)."
+  value       = "https://grafana.${var.domain}"
+}
+
+output "grafana_lb_ip" {
+  description = "Grafana load balancer IP — point grafana.<domain> DNS A record here."
+  value       = google_compute_global_address.grafana_lb_ip.address
+}
+
+output "loki_logs_topic" {
+  description = "Pub/Sub topic that receives Cloud Logging export for Loki ingestion."
+  value       = google_pubsub_topic.loki_logs.id
+}

--- a/terraform/modules/observability/variables.tf
+++ b/terraform/modules/observability/variables.tf
@@ -20,3 +20,8 @@ variable "worker_url" {
   description = "Cloud Run service URL for the LiveKit worker — used in Prometheus scrape config."
   type        = string
 }
+
+variable "grafana_image" {
+  description = "Custom Grafana image with provisioning files baked in (e.g. europe-west3-docker.pkg.dev/PROJECT/taskorbit/grafana:latest)."
+  type        = string
+}

--- a/terraform/modules/observability/variables.tf
+++ b/terraform/modules/observability/variables.tf
@@ -1,0 +1,22 @@
+variable "project_id" { type = string }
+variable "region" { type = string }
+variable "domain" { type = string }
+
+variable "backend_sa_email" { type = string }
+variable "worker_sa_email" { type = string }
+variable "observability_sa_email" { type = string }
+
+variable "secret_ids" {
+  description = "Map of key → Secret Manager secret_id from the secrets module."
+  type        = map(string)
+}
+
+variable "backend_url" {
+  description = "Cloud Run service URL for the backend — used in Prometheus scrape config."
+  type        = string
+}
+
+variable "worker_url" {
+  description = "Cloud Run service URL for the LiveKit worker — used in Prometheus scrape config."
+  type        = string
+}

--- a/terraform/modules/registry/main.tf
+++ b/terraform/modules/registry/main.tf
@@ -1,0 +1,26 @@
+resource "google_artifact_registry_repository" "docker" {
+  repository_id = "taskorbit"
+  format        = "DOCKER"
+  location      = var.region
+  project       = var.project_id
+  description   = "TaskOrbit container images (backend, worker, frontend)"
+
+  cleanup_policy_dry_run = false
+
+  cleanup_policies {
+    id     = "keep-tagged-releases"
+    action = "KEEP"
+    most_recent_versions {
+      keep_count = 10
+    }
+  }
+
+  cleanup_policies {
+    id     = "delete-old-untagged"
+    action = "DELETE"
+    condition {
+      tag_state  = "UNTAGGED"
+      older_than = "604800s" # 7 days
+    }
+  }
+}

--- a/terraform/modules/registry/outputs.tf
+++ b/terraform/modules/registry/outputs.tf
@@ -1,0 +1,4 @@
+output "repository_url" {
+  description = "Docker repository root URL — prefix image names with this."
+  value       = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.docker.repository_id}"
+}

--- a/terraform/modules/registry/variables.tf
+++ b/terraform/modules/registry/variables.tf
@@ -1,0 +1,2 @@
+variable "project_id" { type = string }
+variable "region" { type = string }

--- a/terraform/modules/scheduler/main.tf
+++ b/terraform/modules/scheduler/main.tf
@@ -1,0 +1,171 @@
+# Auto-shutdown scheduler — reduces idle costs by stopping Cloud SQL and
+# scaling down non-critical Cloud Run services outside business hours.
+#
+# Cloud Run frontend and backend already scale to 0 when idle (Cloud Run
+# default behaviour). The worker stays at min_instances=1 to hold the
+# LiveKit WebSocket open; it can be scaled to 0 here during off-hours.
+#
+# Cloud SQL does NOT scale automatically — it runs (and bills) 24/7 unless
+# explicitly stopped. These jobs stop the instance at night and restart it
+# each morning. Cron times are in Europe/Berlin (CET/CEST).
+
+locals {
+  sql_api_base = "https://sqladmin.googleapis.com/v1/projects/${var.project_id}/instances/${var.db_instance_name}"
+  run_api_base = "https://run.googleapis.com/v2/projects/${var.project_id}/locations/${var.region}/services"
+}
+
+# ── Service account for the scheduler ────────────────────────────────────────
+
+resource "google_service_account" "scheduler" {
+  account_id   = "taskorbit-scheduler"
+  display_name = "TaskOrbit Cloud Scheduler"
+  project      = var.project_id
+}
+
+resource "google_project_iam_member" "scheduler_sql_admin" {
+  project = var.project_id
+  role    = "roles/cloudsql.admin"
+  member  = "serviceAccount:${google_service_account.scheduler.email}"
+}
+
+resource "google_project_iam_member" "scheduler_run_admin" {
+  project = var.project_id
+  role    = "roles/run.admin"
+  member  = "serviceAccount:${google_service_account.scheduler.email}"
+}
+
+# ── Cloud SQL stop / start ────────────────────────────────────────────────────
+
+resource "google_cloud_scheduler_job" "sql_stop" {
+  count = var.enable_auto_shutdown ? 1 : 0
+
+  name      = "taskorbit-sql-stop"
+  region    = var.region
+  project   = var.project_id
+  schedule  = var.sql_stop_cron   # default: 22:00 Mon–Fri
+  time_zone = var.time_zone
+
+  http_target {
+    uri         = local.sql_api_base
+    http_method = "PATCH"
+
+    # activationPolicy=NEVER stops the instance; billing for vCPU/RAM stops.
+    body = base64encode(jsonencode({
+      settings = { activationPolicy = "NEVER" }
+    }))
+
+    headers = {
+      "Content-Type" = "application/json"
+    }
+
+    oauth_token {
+      service_account_email = google_service_account.scheduler.email
+      scope                 = "https://www.googleapis.com/auth/cloud-platform"
+    }
+  }
+
+  retry_config {
+    retry_count = 3
+  }
+}
+
+resource "google_cloud_scheduler_job" "sql_start" {
+  count = var.enable_auto_shutdown ? 1 : 0
+
+  name      = "taskorbit-sql-start"
+  region    = var.region
+  project   = var.project_id
+  schedule  = var.sql_start_cron  # default: 07:00 Mon–Fri
+  time_zone = var.time_zone
+
+  http_target {
+    uri         = local.sql_api_base
+    http_method = "PATCH"
+
+    body = base64encode(jsonencode({
+      settings = { activationPolicy = "ALWAYS" }
+    }))
+
+    headers = {
+      "Content-Type" = "application/json"
+    }
+
+    oauth_token {
+      service_account_email = google_service_account.scheduler.email
+      scope                 = "https://www.googleapis.com/auth/cloud-platform"
+    }
+  }
+
+  retry_config {
+    retry_count = 3
+  }
+}
+
+# ── Worker min-instance scale-down / scale-up ─────────────────────────────────
+# The worker's min_instances=1 keeps the LiveKit agent alive during business
+# hours. Scaling to 0 overnight saves Cloud Run idle costs but drops any
+# active rooms — only enable if 24/7 availability is not required.
+
+resource "google_cloud_scheduler_job" "worker_scale_down" {
+  count = var.enable_auto_shutdown && var.scale_worker_overnight ? 1 : 0
+
+  name      = "taskorbit-worker-scale-down"
+  region    = var.region
+  project   = var.project_id
+  schedule  = var.sql_stop_cron
+  time_zone = var.time_zone
+
+  http_target {
+    uri         = "${local.run_api_base}/taskorbit-worker"
+    http_method = "PATCH"
+
+    body = base64encode(jsonencode({
+      template = { scaling = { minInstanceCount = 0 } }
+    }))
+
+    headers = {
+      "Content-Type" = "application/json"
+    }
+
+    oauth_token {
+      service_account_email = google_service_account.scheduler.email
+      scope                 = "https://www.googleapis.com/auth/cloud-platform"
+    }
+  }
+
+  retry_config {
+    retry_count = 3
+  }
+}
+
+resource "google_cloud_scheduler_job" "worker_scale_up" {
+  count = var.enable_auto_shutdown && var.scale_worker_overnight ? 1 : 0
+
+  name      = "taskorbit-worker-scale-up"
+  region    = var.region
+  project   = var.project_id
+  schedule  = var.sql_start_cron
+  time_zone = var.time_zone
+
+  http_target {
+    uri         = "${local.run_api_base}/taskorbit-worker"
+    http_method = "PATCH"
+
+    body = base64encode(jsonencode({
+      template = { scaling = { minInstanceCount = 1 } }
+    }))
+
+    headers = {
+      "Content-Type" = "application/json"
+    }
+
+    oauth_token {
+      service_account_email = google_service_account.scheduler.email
+      scope                 = "https://www.googleapis.com/auth/cloud-platform"
+    }
+  }
+
+  retry_config {
+    retry_count = 3
+  }
+}

--- a/terraform/modules/scheduler/outputs.tf
+++ b/terraform/modules/scheduler/outputs.tf
@@ -1,0 +1,3 @@
+output "scheduler_sa_email" {
+  value = google_service_account.scheduler.email
+}

--- a/terraform/modules/scheduler/variables.tf
+++ b/terraform/modules/scheduler/variables.tf
@@ -1,0 +1,33 @@
+variable "project_id" { type = string }
+variable "region" { type = string }
+variable "db_instance_name" { type = string }
+
+variable "enable_auto_shutdown" {
+  description = "Enable Cloud Scheduler jobs that stop Cloud SQL and (optionally) scale down the worker overnight."
+  type        = bool
+  default     = true
+}
+
+variable "scale_worker_overnight" {
+  description = "Also scale the LiveKit worker to 0 overnight. Drops active voice rooms — only enable if 24/7 availability is not required."
+  type        = bool
+  default     = false
+}
+
+variable "sql_stop_cron" {
+  description = "Cron expression for stopping Cloud SQL (time_zone applies)."
+  type        = string
+  default     = "0 22 * * 1-5"  # 22:00 Mon–Fri
+}
+
+variable "sql_start_cron" {
+  description = "Cron expression for starting Cloud SQL."
+  type        = string
+  default     = "0 7 * * 1-5"   # 07:00 Mon–Fri
+}
+
+variable "time_zone" {
+  description = "IANA time zone for cron schedules."
+  type        = string
+  default     = "Europe/Berlin"
+}

--- a/terraform/modules/secrets/main.tf
+++ b/terraform/modules/secrets/main.tf
@@ -1,0 +1,51 @@
+locals {
+  # Maps secret key (used as suffix in the Secret Manager ID) to its value.
+  # Keys that are truly optional (empty string) are still provisioned so Cloud
+  # Run env var references never break — the empty string is a valid secret value.
+  app_secrets = {
+    "livekit-url"           = var.livekit_url
+    "livekit-api-key"       = var.livekit_api_key
+    "livekit-api-secret"    = var.livekit_api_secret
+    "deepgram-api-key"      = var.deepgram_api_key
+    "deepgram-model"        = var.deepgram_model
+    "deepgram-language"     = var.deepgram_language
+    "elevenlabs-api-key"    = var.elevenlabs_api_key
+    "elevenlabs-voice-id"   = var.elevenlabs_voice_id
+    "elevenlabs-model"      = var.elevenlabs_model
+    "openai-api-key"        = var.openai_api_key
+    "openai-model"          = var.openai_model
+    "google-api-key"        = var.google_api_key
+    "google-model"          = var.google_model
+    "database-url"          = var.database_url
+    "grafana-admin-password" = var.grafana_admin_password
+  }
+}
+
+resource "google_secret_manager_secret" "secrets" {
+  for_each = local.app_secrets
+
+  secret_id = "taskorbit-${each.key}"
+  project   = var.project_id
+
+  replication {
+    auto {}
+  }
+
+  labels = {
+    managed-by = "terraform"
+    app        = "taskorbit"
+  }
+}
+
+resource "google_secret_manager_secret_version" "versions" {
+  for_each = local.app_secrets
+
+  secret      = google_secret_manager_secret.secrets[each.key].id
+  secret_data = each.value
+
+  # Allow manual key rotation (e.g. rolling API keys) without Terraform drift.
+  # To force an update, use `terraform taint` on the specific version resource.
+  lifecycle {
+    ignore_changes = [secret_data]
+  }
+}

--- a/terraform/modules/secrets/main.tf
+++ b/terraform/modules/secrets/main.tf
@@ -18,6 +18,7 @@ locals {
     "google-model"          = var.google_model
     "database-url"          = var.database_url
     "grafana-admin-password" = var.grafana_admin_password
+    "grafana-admin-user"     = var.grafana_admin_user
   }
 }
 

--- a/terraform/modules/secrets/outputs.tf
+++ b/terraform/modules/secrets/outputs.tf
@@ -1,0 +1,4 @@
+output "secret_ids" {
+  description = "Map of key → Secret Manager secret_id (short form, e.g. 'taskorbit-database-url')."
+  value       = { for k, v in google_secret_manager_secret.secrets : k => v.secret_id }
+}

--- a/terraform/modules/secrets/variables.tf
+++ b/terraform/modules/secrets/variables.tf
@@ -1,0 +1,17 @@
+variable "project_id" { type = string }
+
+variable "livekit_url" { type = string; sensitive = true }
+variable "livekit_api_key" { type = string; sensitive = true }
+variable "livekit_api_secret" { type = string; sensitive = true }
+variable "deepgram_api_key" { type = string; sensitive = true }
+variable "deepgram_model" { type = string }
+variable "deepgram_language" { type = string }
+variable "elevenlabs_api_key" { type = string; sensitive = true }
+variable "elevenlabs_voice_id" { type = string }
+variable "elevenlabs_model" { type = string }
+variable "openai_api_key" { type = string; sensitive = true; default = "" }
+variable "openai_model" { type = string; default = "gpt-4o-mini" }
+variable "google_api_key" { type = string; sensitive = true; default = "" }
+variable "google_model" { type = string; default = "gemini-2.5-flash" }
+variable "database_url" { type = string; sensitive = true }
+variable "grafana_admin_password" { type = string; sensitive = true }

--- a/terraform/modules/secrets/variables.tf
+++ b/terraform/modules/secrets/variables.tf
@@ -1,17 +1,76 @@
-variable "project_id" { type = string }
+variable "project_id" {
+  type = string
+}
 
-variable "livekit_url" { type = string; sensitive = true }
-variable "livekit_api_key" { type = string; sensitive = true }
-variable "livekit_api_secret" { type = string; sensitive = true }
-variable "deepgram_api_key" { type = string; sensitive = true }
-variable "deepgram_model" { type = string }
-variable "deepgram_language" { type = string }
-variable "elevenlabs_api_key" { type = string; sensitive = true }
-variable "elevenlabs_voice_id" { type = string }
-variable "elevenlabs_model" { type = string }
-variable "openai_api_key" { type = string; sensitive = true; default = "" }
-variable "openai_model" { type = string; default = "gpt-4o-mini" }
-variable "google_api_key" { type = string; sensitive = true; default = "" }
-variable "google_model" { type = string; default = "gemini-2.5-flash" }
-variable "database_url" { type = string; sensitive = true }
-variable "grafana_admin_password" { type = string; sensitive = true }
+variable "livekit_url" {
+  type      = string
+  sensitive = true
+}
+
+variable "livekit_api_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "livekit_api_secret" {
+  type      = string
+  sensitive = true
+}
+
+variable "deepgram_api_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "deepgram_model" {
+  type = string
+}
+
+variable "deepgram_language" {
+  type = string
+}
+
+variable "elevenlabs_api_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "elevenlabs_voice_id" {
+  type = string
+}
+
+variable "elevenlabs_model" {
+  type = string
+}
+
+variable "openai_api_key" {
+  type      = string
+  sensitive = true
+  default   = ""
+}
+
+variable "openai_model" {
+  type    = string
+  default = "gpt-4o-mini"
+}
+
+variable "google_api_key" {
+  type      = string
+  sensitive = true
+  default   = ""
+}
+
+variable "google_model" {
+  type    = string
+  default = "gemini-2.5-flash"
+}
+
+variable "database_url" {
+  type      = string
+  sensitive = true
+}
+
+variable "grafana_admin_password" {
+  type      = string
+  sensitive = true
+}

--- a/terraform/modules/secrets/variables.tf
+++ b/terraform/modules/secrets/variables.tf
@@ -74,3 +74,8 @@ variable "grafana_admin_password" {
   type      = string
   sensitive = true
 }
+
+variable "grafana_admin_user" {
+  type      = string
+  sensitive = true
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -47,11 +47,11 @@ output "load_balancer_ip" {
 
 # ── STEP 9 (ACTIVE): Observability ───────────────────────────────────────────
 output "grafana_url" {
-  description = "Grafana dashboard URL (grafana.<domain>)."
+  description = "Grafana dashboard Cloud Run URL — open this in your browser to access Grafana."
   value       = module.observability.grafana_url
 }
 
 output "grafana_lb_ip" {
-  description = "Grafana load balancer IP — point grafana.<domain> DNS A record here."
+  description = "Grafana load balancer IP — only needed when a custom domain is configured."
   value       = module.observability.grafana_lb_ip
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -13,16 +13,16 @@
 #   value       = module.database.instance_name
 # }
 
-# ── STEP 3 (COMMENTED): IAM ──────────────────────────────────────────────────
-# output "cicd_service_account_email" {
-#   description = "CI/CD service account email — configure as GitHub Actions secret GCP_SA_EMAIL."
-#   value       = module.iam.cicd_sa_email
-# }
-#
-# output "workload_identity_provider" {
-#   description = "Workload Identity provider resource name — configure as GitHub Actions secret GCP_WORKLOAD_IDENTITY_PROVIDER."
-#   value       = module.iam.workload_identity_provider
-# }
+# ── STEP 3 (ACTIVE): IAM ─────────────────────────────────────────────────────
+output "cicd_service_account_email" {
+  description = "CI/CD service account email — configure as GitHub Actions secret GCP_SA_EMAIL."
+  value       = module.iam.cicd_sa_email
+}
+
+output "workload_identity_provider" {
+  description = "Workload Identity provider resource name — configure as GitHub Actions secret GCP_WORKLOAD_IDENTITY_PROVIDER."
+  value       = module.iam.workload_identity_provider
+}
 
 # ── STEP 7 (COMMENTED): Cloud Run + Load Balancer ────────────────────────────
 # output "frontend_url" {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -24,26 +24,26 @@ output "workload_identity_provider" {
   value       = module.iam.workload_identity_provider
 }
 
-# ── STEP 7 (COMMENTED): Cloud Run + Load Balancer ────────────────────────────
-# output "frontend_url" {
-#   description = "Public URL of the React frontend."
-#   value       = module.cloud_run.frontend_url
-# }
-#
-# output "backend_url" {
-#   description = "Public URL of the FastAPI backend (api.<domain>)."
-#   value       = module.cloud_run.backend_url
-# }
-#
-# output "worker_url" {
-#   description = "Internal Cloud Run URL of the LiveKit worker (metrics at /metrics)."
-#   value       = module.cloud_run.worker_url
-# }
-#
-# output "load_balancer_ip" {
-#   description = "Global external IP — point your DNS A records here."
-#   value       = module.cloud_run.load_balancer_ip
-# }
+# ── STEP 7 (ACTIVE): Cloud Run + Load Balancer ───────────────────────────────
+output "frontend_url" {
+  description = "Public URL of the React frontend."
+  value       = module.cloud_run.frontend_url
+}
+
+output "backend_url" {
+  description = "Public URL of the FastAPI backend (api.<domain>)."
+  value       = module.cloud_run.backend_url
+}
+
+output "worker_url" {
+  description = "Internal Cloud Run URL of the LiveKit worker (metrics at /metrics)."
+  value       = module.cloud_run.worker_url
+}
+
+output "load_balancer_ip" {
+  description = "Global external IP — point your DNS A records here."
+  value       = module.cloud_run.load_balancer_ip
+}
 
 # ── STEP 9 (COMMENTED): Observability ────────────────────────────────────────
 # output "grafana_url" {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -7,11 +7,11 @@ output "artifact_registry_url" {
   value       = module.registry.repository_url
 }
 
-# ── STEP 5 (COMMENTED): Database ─────────────────────────────────────────────
-# output "database_instance_name" {
-#   description = "Cloud SQL instance name (for connecting via Cloud SQL proxy)."
-#   value       = module.database.instance_name
-# }
+# ── STEP 5 (ACTIVE): Database ────────────────────────────────────────────────
+output "database_instance_name" {
+  description = "Cloud SQL instance name (for connecting via Cloud SQL proxy)."
+  value       = module.database.instance_name
+}
 
 # ── STEP 3 (ACTIVE): IAM ─────────────────────────────────────────────────────
 output "cicd_service_account_email" {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,11 +1,11 @@
 # Outputs are commented out to match the incremental apply strategy in main.tf.
 # Uncomment each output when the corresponding module is enabled.
 
-# ── STEP 4 (COMMENTED): Artifact Registry ────────────────────────────────────
-# output "artifact_registry_url" {
-#   description = "Artifact Registry Docker repository URL."
-#   value       = module.registry.repository_url
-# }
+# ── STEP 4 (ACTIVE): Artifact Registry ───────────────────────────────────────
+output "artifact_registry_url" {
+  description = "Artifact Registry Docker repository URL."
+  value       = module.registry.repository_url
+}
 
 # ── STEP 5 (COMMENTED): Database ─────────────────────────────────────────────
 # output "database_instance_name" {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,44 @@
+output "frontend_url" {
+  description = "Public URL of the React frontend."
+  value       = module.cloud_run.frontend_url
+}
+
+output "backend_url" {
+  description = "Public URL of the FastAPI backend (api.<domain>)."
+  value       = module.cloud_run.backend_url
+}
+
+output "worker_url" {
+  description = "Internal Cloud Run URL of the LiveKit worker (metrics at /metrics)."
+  value       = module.cloud_run.worker_url
+}
+
+output "load_balancer_ip" {
+  description = "Global external IP — point your DNS A records here."
+  value       = module.cloud_run.load_balancer_ip
+}
+
+output "grafana_url" {
+  description = "Grafana dashboard URL (grafana.<domain>)."
+  value       = module.observability.grafana_url
+}
+
+output "artifact_registry_url" {
+  description = "Artifact Registry Docker repository URL."
+  value       = module.registry.repository_url
+}
+
+output "database_instance_name" {
+  description = "Cloud SQL instance name (for connecting via Cloud SQL proxy)."
+  value       = module.database.instance_name
+}
+
+output "cicd_service_account_email" {
+  description = "CI/CD service account email — configure as GitHub Actions secret GCP_SA_EMAIL."
+  value       = module.iam.cicd_sa_email
+}
+
+output "workload_identity_provider" {
+  description = "Workload Identity provider resource name — configure as GitHub Actions secret GCP_WORKLOAD_IDENTITY_PROVIDER."
+  value       = module.iam.workload_identity_provider
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,44 +1,52 @@
-output "frontend_url" {
-  description = "Public URL of the React frontend."
-  value       = module.cloud_run.frontend_url
-}
+# Outputs are commented out to match the incremental apply strategy in main.tf.
+# Uncomment each output when the corresponding module is enabled.
 
-output "backend_url" {
-  description = "Public URL of the FastAPI backend (api.<domain>)."
-  value       = module.cloud_run.backend_url
-}
+# ── STEP 4 (COMMENTED): Artifact Registry ────────────────────────────────────
+# output "artifact_registry_url" {
+#   description = "Artifact Registry Docker repository URL."
+#   value       = module.registry.repository_url
+# }
 
-output "worker_url" {
-  description = "Internal Cloud Run URL of the LiveKit worker (metrics at /metrics)."
-  value       = module.cloud_run.worker_url
-}
+# ── STEP 5 (COMMENTED): Database ─────────────────────────────────────────────
+# output "database_instance_name" {
+#   description = "Cloud SQL instance name (for connecting via Cloud SQL proxy)."
+#   value       = module.database.instance_name
+# }
 
-output "load_balancer_ip" {
-  description = "Global external IP — point your DNS A records here."
-  value       = module.cloud_run.load_balancer_ip
-}
+# ── STEP 3 (COMMENTED): IAM ──────────────────────────────────────────────────
+# output "cicd_service_account_email" {
+#   description = "CI/CD service account email — configure as GitHub Actions secret GCP_SA_EMAIL."
+#   value       = module.iam.cicd_sa_email
+# }
+#
+# output "workload_identity_provider" {
+#   description = "Workload Identity provider resource name — configure as GitHub Actions secret GCP_WORKLOAD_IDENTITY_PROVIDER."
+#   value       = module.iam.workload_identity_provider
+# }
 
-output "grafana_url" {
-  description = "Grafana dashboard URL (grafana.<domain>)."
-  value       = module.observability.grafana_url
-}
+# ── STEP 7 (COMMENTED): Cloud Run + Load Balancer ────────────────────────────
+# output "frontend_url" {
+#   description = "Public URL of the React frontend."
+#   value       = module.cloud_run.frontend_url
+# }
+#
+# output "backend_url" {
+#   description = "Public URL of the FastAPI backend (api.<domain>)."
+#   value       = module.cloud_run.backend_url
+# }
+#
+# output "worker_url" {
+#   description = "Internal Cloud Run URL of the LiveKit worker (metrics at /metrics)."
+#   value       = module.cloud_run.worker_url
+# }
+#
+# output "load_balancer_ip" {
+#   description = "Global external IP — point your DNS A records here."
+#   value       = module.cloud_run.load_balancer_ip
+# }
 
-output "artifact_registry_url" {
-  description = "Artifact Registry Docker repository URL."
-  value       = module.registry.repository_url
-}
-
-output "database_instance_name" {
-  description = "Cloud SQL instance name (for connecting via Cloud SQL proxy)."
-  value       = module.database.instance_name
-}
-
-output "cicd_service_account_email" {
-  description = "CI/CD service account email — configure as GitHub Actions secret GCP_SA_EMAIL."
-  value       = module.iam.cicd_sa_email
-}
-
-output "workload_identity_provider" {
-  description = "Workload Identity provider resource name — configure as GitHub Actions secret GCP_WORKLOAD_IDENTITY_PROVIDER."
-  value       = module.iam.workload_identity_provider
-}
+# ── STEP 9 (COMMENTED): Observability ────────────────────────────────────────
+# output "grafana_url" {
+#   description = "Grafana dashboard URL (grafana.<domain>)."
+#   value       = module.observability.grafana_url
+# }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -45,8 +45,13 @@ output "load_balancer_ip" {
   value       = module.cloud_run.load_balancer_ip
 }
 
-# ── STEP 9 (COMMENTED): Observability ────────────────────────────────────────
-# output "grafana_url" {
-#   description = "Grafana dashboard URL (grafana.<domain>)."
-#   value       = module.observability.grafana_url
-# }
+# ── STEP 9 (ACTIVE): Observability ───────────────────────────────────────────
+output "grafana_url" {
+  description = "Grafana dashboard URL (grafana.<domain>)."
+  value       = module.observability.grafana_url
+}
+
+output "grafana_lb_ip" {
+  description = "Grafana load balancer IP — point grafana.<domain> DNS A record here."
+  value       = module.observability.grafana_lb_ip
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -45,6 +45,12 @@ cors_allow_origins = "https://taskorbit.example.com"
 # ── GitHub (Workload Identity) ────────────────────────────────────────────────
 github_repository = "amosproj/amos2026ss04-taskorbit-conversational-agent"
 
+# ── Auto-shutdown (idle cost savings) ────────────────────────────────────────
+# Stops Cloud SQL at 22:00 Mon–Fri (CET) and restarts it at 07:00.
+# Cloud Run services scale to 0 automatically when idle (no config needed).
+enable_auto_shutdown   = true
+scale_worker_overnight = false  # set true to also scale the worker to 0 overnight
+
 # ── Cloud Run scaling ─────────────────────────────────────────────────────────
 backend_min_instances  = 1
 backend_max_instances  = 10

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -38,6 +38,7 @@ google_model   = "gemini-2.5-flash"
 
 # ── Grafana ───────────────────────────────────────────────────────────────────
 grafana_admin_password = "change-me-strong-password"
+grafana_admin_user = "change-the-admin-user"
 
 # ── CORS ──────────────────────────────────────────────────────────────────────
 cors_allow_origins = "https://taskorbit.example.com"

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -12,8 +12,9 @@ domain = "taskorbit.example.com"
 
 # ── Container images ──────────────────────────────────────────────────────────
 # Build and push images to Artifact Registry first, then reference the digest.
-backend_image  = "europe-west1-docker.pkg.dev/your-gcp-project-id/taskorbit/backend:latest"
-frontend_image = "europe-west1-docker.pkg.dev/your-gcp-project-id/taskorbit/frontend:latest"
+backend_image  = "europe-west3-docker.pkg.dev/your-gcp-project-id/taskorbit/backend:latest"
+frontend_image = "europe-west3-docker.pkg.dev/your-gcp-project-id/taskorbit/frontend:latest"
+grafana_image  = "europe-west3-docker.pkg.dev/your-gcp-project-id/taskorbit/grafana:latest"
 
 # ── LiveKit ───────────────────────────────────────────────────────────────────
 livekit_url        = "wss://your-project.livekit.cloud"

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -42,6 +42,11 @@ grafana_admin_password = "change-me-strong-password"
 # ── CORS ──────────────────────────────────────────────────────────────────────
 cors_allow_origins = "https://taskorbit.example.com"
 
+# ── API URL override (no-domain testing) ──────────────────────────────────────
+# Set to the backend Cloud Run URL when testing without a domain/load balancer.
+# Leave empty when using a real domain (uses https://api.<domain> instead).
+# api_url_override = "https://taskorbit-backend-<hash>-ew.a.run.app"
+
 # ── GitHub (Workload Identity) ────────────────────────────────────────────────
 github_repository = "amosproj/amos2026ss04-taskorbit-conversational-agent"
 

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,54 @@
+# Copy this file to terraform.tfvars and fill in real values.
+# terraform.tfvars is git-ignored — NEVER commit it.
+
+# ── GCP project ───────────────────────────────────────────────────────────────
+project_id = "your-gcp-project-id"
+region     = "europe-west1"
+
+# ── Domain ────────────────────────────────────────────────────────────────────
+# Point DNS A records for this domain AND api.<domain> AND grafana.<domain>
+# to the load_balancer_ip output after the first apply.
+domain = "taskorbit.example.com"
+
+# ── Container images ──────────────────────────────────────────────────────────
+# Build and push images to Artifact Registry first, then reference the digest.
+backend_image  = "europe-west1-docker.pkg.dev/your-gcp-project-id/taskorbit/backend:latest"
+frontend_image = "europe-west1-docker.pkg.dev/your-gcp-project-id/taskorbit/frontend:latest"
+
+# ── LiveKit ───────────────────────────────────────────────────────────────────
+livekit_url        = "wss://your-project.livekit.cloud"
+livekit_api_key    = ""
+livekit_api_secret = ""
+
+# ── Deepgram ──────────────────────────────────────────────────────────────────
+deepgram_api_key  = ""
+deepgram_model    = "nova-3"
+deepgram_language = "multi"
+
+# ── ElevenLabs ────────────────────────────────────────────────────────────────
+elevenlabs_api_key  = ""
+elevenlabs_voice_id = "21m00Tcm4TlvDq8ikWAM"
+elevenlabs_model    = "eleven_multilingual_v2"
+
+# ── LLM ───────────────────────────────────────────────────────────────────────
+openai_api_key = ""
+openai_model   = "gpt-4o-mini"
+google_api_key = ""
+google_model   = "gemini-2.5-flash"
+
+# ── Grafana ───────────────────────────────────────────────────────────────────
+grafana_admin_password = "change-me-strong-password"
+
+# ── CORS ──────────────────────────────────────────────────────────────────────
+cors_allow_origins = "https://taskorbit.example.com"
+
+# ── GitHub (Workload Identity) ────────────────────────────────────────────────
+github_repository = "amosproj/amos2026ss04-taskorbit-conversational-agent"
+
+# ── Cloud Run scaling ─────────────────────────────────────────────────────────
+backend_min_instances  = 1
+backend_max_instances  = 10
+worker_min_instances   = 1
+worker_max_instances   = 5
+frontend_min_instances = 1
+frontend_max_instances = 5

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -3,7 +3,7 @@
 
 # ── GCP project ───────────────────────────────────────────────────────────────
 project_id = "your-gcp-project-id"
-region     = "europe-west1"
+region     = "europe-west3"
 
 # ── Domain ────────────────────────────────────────────────────────────────────
 # Point DNS A records for this domain AND api.<domain> AND grafana.<domain>

--- a/terraform/tests/cloud_run.tftest.hcl
+++ b/terraform/tests/cloud_run.tftest.hcl
@@ -1,0 +1,152 @@
+# Tests for modules/cloud_run
+#
+# Verifies ingress settings, CORS origin wiring, SSL certificate domains,
+# and that the frontend BACKEND_URL env var is set.
+# Uses mock_provider so no real GCP credentials are required.
+
+mock_provider "google" {}
+
+variables {
+  project_id    = "test-project"
+  region        = "europe-west1"
+  domain        = "taskorbit.example.com"
+  backend_image  = "europe-west1-docker.pkg.dev/test-project/taskorbit/backend:latest"
+  frontend_image = "europe-west1-docker.pkg.dev/test-project/taskorbit/frontend:latest"
+
+  backend_sa_email  = "taskorbit-backend@test-project.iam.gserviceaccount.com"
+  worker_sa_email   = "taskorbit-worker@test-project.iam.gserviceaccount.com"
+  frontend_sa_email = "taskorbit-frontend@test-project.iam.gserviceaccount.com"
+
+  vpc_connector_id          = "projects/test-project/locations/europe-west1/connectors/taskorbit-connector"
+  cloud_sql_connection_name = "test-project:europe-west1:taskorbit-postgres"
+
+  secret_ids = {
+    "database-url"        = "taskorbit-database-url"
+    "livekit-url"         = "taskorbit-livekit-url"
+    "livekit-api-key"     = "taskorbit-livekit-api-key"
+    "livekit-api-secret"  = "taskorbit-livekit-api-secret"
+    "deepgram-api-key"    = "taskorbit-deepgram-api-key"
+    "deepgram-model"      = "taskorbit-deepgram-model"
+    "deepgram-language"   = "taskorbit-deepgram-language"
+    "elevenlabs-api-key"  = "taskorbit-elevenlabs-api-key"
+    "elevenlabs-voice-id" = "taskorbit-elevenlabs-voice-id"
+    "elevenlabs-model"    = "taskorbit-elevenlabs-model"
+    "openai-api-key"      = "taskorbit-openai-api-key"
+    "openai-model"        = "taskorbit-openai-model"
+    "google-api-key"      = "taskorbit-google-api-key"
+    "google-model"        = "taskorbit-google-model"
+  }
+}
+
+# ── Ingress settings ──────────────────────────────────────────────────────────
+
+run "worker_is_internal_only" {
+  command = plan
+
+  module {
+    source = "./modules/cloud_run"
+  }
+
+  assert {
+    condition     = google_cloud_run_v2_service.worker.ingress == "INGRESS_TRAFFIC_INTERNAL_ONLY"
+    error_message = "Worker must only accept internal traffic — it connects out to LiveKit, not inbound."
+  }
+}
+
+run "backend_and_frontend_accept_all_traffic" {
+  command = plan
+
+  module {
+    source = "./modules/cloud_run"
+  }
+
+  assert {
+    condition     = google_cloud_run_v2_service.backend.ingress == "INGRESS_TRAFFIC_ALL"
+    error_message = "Backend ingress must be INGRESS_TRAFFIC_ALL until LB + domain are confirmed."
+  }
+
+  assert {
+    condition     = google_cloud_run_v2_service.frontend.ingress == "INGRESS_TRAFFIC_ALL"
+    error_message = "Frontend ingress must be INGRESS_TRAFFIC_ALL until LB + domain are confirmed."
+  }
+}
+
+# ── CORS origin wiring ────────────────────────────────────────────────────────
+
+run "cors_defaults_to_domain_when_not_set" {
+  command = plan
+
+  module {
+    source = "./modules/cloud_run"
+  }
+
+  variables {
+    cors_allow_origins = ""
+  }
+
+  assert {
+    condition = anytrue([
+      for e in google_cloud_run_v2_service.backend.template[0].containers[0].env :
+      e.name == "CORS_ALLOW_ORIGINS" && e.value == "https://taskorbit.example.com"
+    ])
+    error_message = "CORS_ALLOW_ORIGINS must default to https://<domain> when cors_allow_origins is empty."
+  }
+}
+
+run "cors_uses_explicit_override" {
+  command = plan
+
+  module {
+    source = "./modules/cloud_run"
+  }
+
+  variables {
+    cors_allow_origins = "https://taskorbit-frontend-abc123.a.run.app"
+  }
+
+  assert {
+    condition = anytrue([
+      for e in google_cloud_run_v2_service.backend.template[0].containers[0].env :
+      e.name == "CORS_ALLOW_ORIGINS" && e.value == "https://taskorbit-frontend-abc123.a.run.app"
+    ])
+    error_message = "CORS_ALLOW_ORIGINS must use the explicit cors_allow_origins value when set."
+  }
+}
+
+# ── SSL certificate domains ───────────────────────────────────────────────────
+
+run "ssl_cert_covers_domain_and_api_subdomain" {
+  command = plan
+
+  module {
+    source = "./modules/cloud_run"
+  }
+
+  assert {
+    condition     = contains(google_compute_managed_ssl_certificate.main.managed[0].domains, "taskorbit.example.com")
+    error_message = "SSL certificate must cover the root domain."
+  }
+
+  assert {
+    condition     = contains(google_compute_managed_ssl_certificate.main.managed[0].domains, "api.taskorbit.example.com")
+    error_message = "SSL certificate must cover the api. subdomain."
+  }
+}
+
+# ── Frontend BACKEND_URL env var ──────────────────────────────────────────────
+
+run "frontend_has_backend_url_env" {
+  command = plan
+
+  module {
+    source = "./modules/cloud_run"
+  }
+
+  assert {
+    condition = anytrue([
+      for e in google_cloud_run_v2_service.frontend.template[0].containers[0].env :
+      e.name == "BACKEND_URL"
+    ])
+    error_message = "Frontend container must have BACKEND_URL set so nginx can proxy /api/* to the backend."
+  }
+}

--- a/terraform/tests/observability.tftest.hcl
+++ b/terraform/tests/observability.tftest.hcl
@@ -19,6 +19,7 @@ variables {
 
   secret_ids = {
     "grafana-admin-password" = "taskorbit-grafana-admin-password"
+    "grafana-admin-user"     = "taskorbit-grafana-admin-user"
   }
 }
 
@@ -112,6 +113,32 @@ run "pubsub_subscription_exists_for_loki" {
   assert {
     condition     = google_pubsub_subscription.loki_push.topic == google_pubsub_topic.loki_logs.id
     error_message = "Push subscription must be attached to the taskorbit-loki-logs topic."
+  }
+}
+
+# ── Grafana admin credentials ─────────────────────────────────────────────────
+
+run "grafana_admin_credentials_wired_from_secrets" {
+  command = plan
+
+  module {
+    source = "./modules/observability"
+  }
+
+  assert {
+    condition = anytrue([
+      for e in google_cloud_run_v2_service.grafana.template[0].containers[0].env :
+      e.name == "GF_SECURITY_ADMIN_USER"
+    ])
+    error_message = "Grafana container must have GF_SECURITY_ADMIN_USER set from Secret Manager."
+  }
+
+  assert {
+    condition = anytrue([
+      for e in google_cloud_run_v2_service.grafana.template[0].containers[0].env :
+      e.name == "GF_SECURITY_ADMIN_PASSWORD"
+    ])
+    error_message = "Grafana container must have GF_SECURITY_ADMIN_PASSWORD set from Secret Manager."
   }
 }
 

--- a/terraform/tests/observability.tftest.hcl
+++ b/terraform/tests/observability.tftest.hcl
@@ -1,0 +1,131 @@
+# Tests for modules/observability
+#
+# Verifies that Loki, Prometheus and Grafana Cloud Run services are created
+# with the correct ingress settings, that GCS buckets use the expected naming
+# convention, and that the Pub/Sub push subscription is wired to Loki.
+# Uses mock_provider so no real GCP credentials are required.
+
+mock_provider "google" {}
+
+variables {
+  project_id             = "test-project"
+  region                 = "europe-west1"
+  domain                 = "taskorbit.example.com"
+  backend_sa_email       = "taskorbit-backend@test-project.iam.gserviceaccount.com"
+  worker_sa_email        = "taskorbit-worker@test-project.iam.gserviceaccount.com"
+  observability_sa_email = "taskorbit-observability@test-project.iam.gserviceaccount.com"
+  backend_url            = "https://taskorbit-backend-abc123.a.run.app"
+  worker_url             = "https://taskorbit-worker-abc123.a.run.app"
+
+  secret_ids = {
+    "grafana-admin-password" = "taskorbit-grafana-admin-password"
+  }
+}
+
+# ── Ingress settings ──────────────────────────────────────────────────────────
+
+run "loki_and_prometheus_are_internal_only" {
+  command = plan
+
+  module {
+    source = "./modules/observability"
+  }
+
+  assert {
+    condition     = google_cloud_run_v2_service.loki.ingress == "INGRESS_TRAFFIC_INTERNAL_ONLY"
+    error_message = "Loki must not be exposed publicly — only Grafana and the Pub/Sub subscription reach it."
+  }
+
+  assert {
+    condition     = google_cloud_run_v2_service.prometheus.ingress == "INGRESS_TRAFFIC_INTERNAL_ONLY"
+    error_message = "Prometheus must not be exposed publicly — only Grafana scrapes it."
+  }
+}
+
+run "grafana_uses_internal_load_balancer" {
+  command = plan
+
+  module {
+    source = "./modules/observability"
+  }
+
+  assert {
+    condition     = google_cloud_run_v2_service.grafana.ingress == "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
+    error_message = "Grafana must be reachable only via the internal load balancer, not directly."
+  }
+}
+
+# ── GCS bucket naming ─────────────────────────────────────────────────────────
+
+run "gcs_buckets_use_project_prefix" {
+  command = plan
+
+  module {
+    source = "./modules/observability"
+  }
+
+  assert {
+    condition     = google_storage_bucket.loki.name == "test-project-taskorbit-loki"
+    error_message = "Loki GCS bucket must be named <project_id>-taskorbit-loki."
+  }
+
+  assert {
+    condition     = google_storage_bucket.prometheus.name == "test-project-taskorbit-prometheus"
+    error_message = "Prometheus GCS bucket must be named <project_id>-taskorbit-prometheus."
+  }
+}
+
+# ── GCS bucket retention ──────────────────────────────────────────────────────
+
+run "gcs_buckets_have_correct_retention" {
+  command = plan
+
+  module {
+    source = "./modules/observability"
+  }
+
+  assert {
+    condition     = google_storage_bucket.loki.lifecycle_rule[0].condition[0].age == 90
+    error_message = "Loki bucket must retain logs for 90 days."
+  }
+
+  assert {
+    condition     = google_storage_bucket.prometheus.lifecycle_rule[0].condition[0].age == 30
+    error_message = "Prometheus bucket must retain metrics for 30 days."
+  }
+}
+
+# ── Pub/Sub log pipeline ──────────────────────────────────────────────────────
+
+run "pubsub_subscription_exists_for_loki" {
+  command = plan
+
+  module {
+    source = "./modules/observability"
+  }
+
+  assert {
+    condition     = google_pubsub_subscription.loki_push.name == "taskorbit-loki-push"
+    error_message = "Pub/Sub push subscription must be named taskorbit-loki-push."
+  }
+
+  assert {
+    condition     = google_pubsub_subscription.loki_push.topic == google_pubsub_topic.loki_logs.id
+    error_message = "Push subscription must be attached to the taskorbit-loki-logs topic."
+  }
+}
+
+# ── Grafana SSL certificate ───────────────────────────────────────────────────
+
+run "grafana_ssl_cert_covers_grafana_subdomain" {
+  command = plan
+
+  module {
+    source = "./modules/observability"
+  }
+
+  assert {
+    condition     = contains(google_compute_managed_ssl_certificate.grafana.managed[0].domains, "grafana.taskorbit.example.com")
+    error_message = "Grafana SSL certificate must cover grafana.<domain>."
+  }
+}

--- a/terraform/tests/scheduler.tftest.hcl
+++ b/terraform/tests/scheduler.tftest.hcl
@@ -1,0 +1,150 @@
+# Tests for modules/scheduler
+#
+# Verifies the count logic that controls whether Cloud Scheduler jobs are
+# created based on enable_auto_shutdown and scale_worker_overnight flags.
+# Uses mock_provider so no real GCP credentials or project are required.
+
+mock_provider "google" {}
+
+# ── Shared variables ──────────────────────────────────────────────────────────
+
+variables {
+  project_id       = "test-project"
+  region           = "europe-west1"
+  db_instance_name = "taskorbit-postgres"
+}
+
+# ── auto_shutdown disabled ────────────────────────────────────────────────────
+
+run "no_jobs_when_auto_shutdown_disabled" {
+  command = plan
+
+  module {
+    source = "./modules/scheduler"
+  }
+
+  variables {
+    enable_auto_shutdown   = false
+    scale_worker_overnight = false
+  }
+
+  assert {
+    condition     = length(google_cloud_scheduler_job.sql_stop) == 0
+    error_message = "Expected no sql_stop job when auto_shutdown is disabled."
+  }
+
+  assert {
+    condition     = length(google_cloud_scheduler_job.sql_start) == 0
+    error_message = "Expected no sql_start job when auto_shutdown is disabled."
+  }
+
+  assert {
+    condition     = length(google_cloud_scheduler_job.worker_scale_down) == 0
+    error_message = "Expected no worker_scale_down job when auto_shutdown is disabled."
+  }
+
+  assert {
+    condition     = length(google_cloud_scheduler_job.worker_scale_up) == 0
+    error_message = "Expected no worker_scale_up job when auto_shutdown is disabled."
+  }
+}
+
+# ── auto_shutdown enabled, worker scale-down disabled ─────────────────────────
+
+run "sql_jobs_only_when_worker_overnight_disabled" {
+  command = plan
+
+  module {
+    source = "./modules/scheduler"
+  }
+
+  variables {
+    enable_auto_shutdown   = true
+    scale_worker_overnight = false
+  }
+
+  assert {
+    condition     = length(google_cloud_scheduler_job.sql_stop) == 1
+    error_message = "Expected exactly one sql_stop job."
+  }
+
+  assert {
+    condition     = length(google_cloud_scheduler_job.sql_start) == 1
+    error_message = "Expected exactly one sql_start job."
+  }
+
+  assert {
+    condition     = length(google_cloud_scheduler_job.worker_scale_down) == 0
+    error_message = "Expected no worker_scale_down job when scale_worker_overnight is false."
+  }
+
+  assert {
+    condition     = length(google_cloud_scheduler_job.worker_scale_up) == 0
+    error_message = "Expected no worker_scale_up job when scale_worker_overnight is false."
+  }
+}
+
+# ── auto_shutdown enabled, worker scale-down enabled ─────────────────────────
+
+run "all_four_jobs_when_both_flags_enabled" {
+  command = plan
+
+  module {
+    source = "./modules/scheduler"
+  }
+
+  variables {
+    enable_auto_shutdown   = true
+    scale_worker_overnight = true
+  }
+
+  assert {
+    condition     = length(google_cloud_scheduler_job.sql_stop) == 1
+    error_message = "Expected exactly one sql_stop job."
+  }
+
+  assert {
+    condition     = length(google_cloud_scheduler_job.sql_start) == 1
+    error_message = "Expected exactly one sql_start job."
+  }
+
+  assert {
+    condition     = length(google_cloud_scheduler_job.worker_scale_down) == 1
+    error_message = "Expected exactly one worker_scale_down job."
+  }
+
+  assert {
+    condition     = length(google_cloud_scheduler_job.worker_scale_up) == 1
+    error_message = "Expected exactly one worker_scale_up job."
+  }
+}
+
+# ── Cron schedule values ──────────────────────────────────────────────────────
+
+run "default_cron_schedules_are_correct" {
+  command = plan
+
+  module {
+    source = "./modules/scheduler"
+  }
+
+  variables {
+    enable_auto_shutdown   = true
+    scale_worker_overnight = false
+  }
+
+  assert {
+    condition     = google_cloud_scheduler_job.sql_stop[0].schedule == "0 22 * * 1-5"
+    error_message = "sql_stop schedule should be 22:00 Mon-Fri."
+  }
+
+  assert {
+    condition     = google_cloud_scheduler_job.sql_start[0].schedule == "0 7 * * 1-5"
+    error_message = "sql_start schedule should be 07:00 Mon-Fri."
+  }
+
+  assert {
+    condition     = google_cloud_scheduler_job.sql_stop[0].time_zone == "Europe/Berlin"
+    error_message = "time_zone should default to Europe/Berlin."
+  }
+}

--- a/terraform/tests/secrets.tftest.hcl
+++ b/terraform/tests/secrets.tftest.hcl
@@ -22,11 +22,12 @@ variables {
   google_model           = "gemini-2.5-flash"
   database_url           = "postgresql://taskorbit:pass@/taskorbit"
   grafana_admin_password = "test-grafana-password"
+  grafana_admin_user     = "test-admin"
 }
 
-# ── All 15 secrets are created ────────────────────────────────────────────────
+# ── All 16 secrets are created ────────────────────────────────────────────────
 
-run "creates_all_15_secrets" {
+run "creates_all_16_secrets" {
   command = plan
 
   module {
@@ -34,8 +35,8 @@ run "creates_all_15_secrets" {
   }
 
   assert {
-    condition     = length(google_secret_manager_secret.secrets) == 15
-    error_message = "Expected exactly 15 Secret Manager secrets."
+    condition     = length(google_secret_manager_secret.secrets) == 16
+    error_message = "Expected exactly 16 Secret Manager secrets."
   }
 }
 
@@ -83,6 +84,11 @@ run "secret_ids_output_contains_expected_keys" {
   assert {
     condition     = contains(keys(module.secret_ids), "grafana-admin-password")
     error_message = "secret_ids output must contain 'grafana-admin-password'."
+  }
+
+  assert {
+    condition     = contains(keys(module.secret_ids), "grafana-admin-user")
+    error_message = "secret_ids output must contain 'grafana-admin-user'."
   }
 }
 

--- a/terraform/tests/secrets.tftest.hcl
+++ b/terraform/tests/secrets.tftest.hcl
@@ -1,0 +1,111 @@
+# Tests for modules/secrets
+#
+# Verifies that all secrets are created with the correct taskorbit- prefix
+# and that the secret_ids output map contains the expected keys.
+
+mock_provider "google" {}
+
+variables {
+  project_id             = "test-project"
+  livekit_url            = "wss://test.livekit.cloud"
+  livekit_api_key        = "test-api-key"
+  livekit_api_secret     = "test-api-secret"
+  deepgram_api_key       = "test-deepgram-key"
+  deepgram_model         = "nova-3"
+  deepgram_language      = "multi"
+  elevenlabs_api_key     = "test-elevenlabs-key"
+  elevenlabs_voice_id    = "21m00Tcm4TlvDq8ikWAM"
+  elevenlabs_model       = "eleven_multilingual_v2"
+  openai_api_key         = "test-openai-key"
+  openai_model           = "gpt-4o-mini"
+  google_api_key         = "test-google-key"
+  google_model           = "gemini-2.5-flash"
+  database_url           = "postgresql://taskorbit:pass@/taskorbit"
+  grafana_admin_password = "test-grafana-password"
+}
+
+# ── All 15 secrets are created ────────────────────────────────────────────────
+
+run "creates_all_15_secrets" {
+  command = plan
+
+  module {
+    source = "./modules/secrets"
+  }
+
+  assert {
+    condition     = length(google_secret_manager_secret.secrets) == 15
+    error_message = "Expected exactly 15 Secret Manager secrets."
+  }
+}
+
+# ── Secret IDs use the taskorbit- prefix ──────────────────────────────────────
+
+run "all_secret_ids_have_taskorbit_prefix" {
+  command = plan
+
+  module {
+    source = "./modules/secrets"
+  }
+
+  assert {
+    condition = alltrue([
+      for k, v in google_secret_manager_secret.secrets : startswith(v.secret_id, "taskorbit-")
+    ])
+    error_message = "All secrets must be prefixed with 'taskorbit-'."
+  }
+}
+
+# ── Output map keys match the expected secret names ───────────────────────────
+
+run "secret_ids_output_contains_expected_keys" {
+  command = plan
+
+  module {
+    source = "./modules/secrets"
+  }
+
+  assert {
+    condition     = contains(keys(module.secret_ids), "livekit-url")
+    error_message = "secret_ids output must contain 'livekit-url'."
+  }
+
+  assert {
+    condition     = contains(keys(module.secret_ids), "database-url")
+    error_message = "secret_ids output must contain 'database-url'."
+  }
+
+  assert {
+    condition     = contains(keys(module.secret_ids), "openai-api-key")
+    error_message = "secret_ids output must contain 'openai-api-key'."
+  }
+
+  assert {
+    condition     = contains(keys(module.secret_ids), "grafana-admin-password")
+    error_message = "secret_ids output must contain 'grafana-admin-password'."
+  }
+}
+
+# ── Secrets are labelled with managed-by = terraform ─────────────────────────
+
+run "secrets_have_correct_labels" {
+  command = plan
+
+  module {
+    source = "./modules/secrets"
+  }
+
+  assert {
+    condition = alltrue([
+      for k, v in google_secret_manager_secret.secrets : v.labels["managed-by"] == "terraform"
+    ])
+    error_message = "All secrets must have the 'managed-by = terraform' label."
+  }
+
+  assert {
+    condition = alltrue([
+      for k, v in google_secret_manager_secret.secrets : v.labels["app"] == "taskorbit"
+    ])
+    error_message = "All secrets must have the 'app = taskorbit' label."
+  }
+}

--- a/terraform/tests/variables.tftest.hcl
+++ b/terraform/tests/variables.tftest.hcl
@@ -1,0 +1,157 @@
+# Tests for root module variable validations
+#
+# Verifies that invalid inputs are rejected at plan time with the correct
+# error messages. Uses expect_failures to assert that a validation fires.
+# Valid baseline values are declared in the shared variables block and
+# overridden per run.
+
+mock_provider "google" {}
+mock_provider "google-beta" {}
+mock_provider "random" {}
+
+# Baseline: a valid set of values that all validations accept.
+variables {
+  project_id             = "my-gcp-project"
+  region                 = "europe-west1"
+  domain                 = "taskorbit.example.com"
+  github_repository      = "amosproj/amos2026ss04-taskorbit-conversational-agent"
+  backend_image          = "europe-west1-docker.pkg.dev/my-project/taskorbit/backend:latest"
+  frontend_image         = "europe-west1-docker.pkg.dev/my-project/taskorbit/frontend:latest"
+  livekit_url            = "wss://test.livekit.cloud"
+  livekit_api_key        = "test-api-key"
+  livekit_api_secret     = "test-api-secret"
+  deepgram_api_key       = "test-deepgram-key"
+  elevenlabs_api_key     = "test-elevenlabs-key"
+  openai_api_key         = ""
+  google_api_key         = ""
+  grafana_admin_password = "strongpassword123"
+}
+
+# ── project_id ────────────────────────────────────────────────────────────────
+
+run "rejects_empty_project_id" {
+  command = plan
+
+  variables {
+    project_id = ""
+  }
+
+  expect_failures = [var.project_id]
+}
+
+# ── region ────────────────────────────────────────────────────────────────────
+
+run "rejects_invalid_region_format" {
+  command = plan
+
+  variables {
+    region = "europe_west1"  # underscore instead of hyphen
+  }
+
+  expect_failures = [var.region]
+}
+
+# ── domain ────────────────────────────────────────────────────────────────────
+
+run "rejects_bare_domain_without_tld" {
+  command = plan
+
+  variables {
+    domain = "notadomain"
+  }
+
+  expect_failures = [var.domain]
+}
+
+# ── github_repository ─────────────────────────────────────────────────────────
+
+run "rejects_github_repository_without_slash" {
+  command = plan
+
+  variables {
+    github_repository = "justaname"
+  }
+
+  expect_failures = [var.github_repository]
+}
+
+# ── backend_image ─────────────────────────────────────────────────────────────
+
+run "rejects_backend_image_without_tag" {
+  command = plan
+
+  variables {
+    backend_image = "europe-west1-docker.pkg.dev/my-project/taskorbit/backend"
+  }
+
+  expect_failures = [var.backend_image]
+}
+
+# ── livekit_url ───────────────────────────────────────────────────────────────
+
+run "rejects_livekit_url_with_https_scheme" {
+  command = plan
+
+  variables {
+    livekit_url = "https://test.livekit.cloud"
+  }
+
+  expect_failures = [var.livekit_url]
+}
+
+run "rejects_livekit_url_without_scheme" {
+  command = plan
+
+  variables {
+    livekit_url = "test.livekit.cloud"
+  }
+
+  expect_failures = [var.livekit_url]
+}
+
+# ── livekit_api_key / livekit_api_secret ──────────────────────────────────────
+
+run "rejects_empty_livekit_api_key" {
+  command = plan
+
+  variables {
+    livekit_api_key = ""
+  }
+
+  expect_failures = [var.livekit_api_key]
+}
+
+run "rejects_empty_livekit_api_secret" {
+  command = plan
+
+  variables {
+    livekit_api_secret = ""
+  }
+
+  expect_failures = [var.livekit_api_secret]
+}
+
+# ── grafana_admin_password ────────────────────────────────────────────────────
+
+run "rejects_short_grafana_password" {
+  command = plan
+
+  variables {
+    grafana_admin_password = "tooshort"  # 8 chars, minimum is 12
+  }
+
+  expect_failures = [var.grafana_admin_password]
+}
+
+# ── scaling: min > max ────────────────────────────────────────────────────────
+
+run "rejects_backend_min_greater_than_max" {
+  command = plan
+
+  variables {
+    backend_min_instances = 5
+    backend_max_instances = 2
+  }
+
+  expect_failures = [var.backend_min_instances]
+}

--- a/terraform/tests/variables.tftest.hcl
+++ b/terraform/tests/variables.tftest.hcl
@@ -109,6 +109,30 @@ run "rejects_livekit_url_without_scheme" {
   expect_failures = [var.livekit_url]
 }
 
+# ── deepgram_api_key ──────────────────────────────────────────────────────────
+
+run "rejects_empty_deepgram_api_key" {
+  command = plan
+
+  variables {
+    deepgram_api_key = ""
+  }
+
+  expect_failures = [var.deepgram_api_key]
+}
+
+# ── elevenlabs_api_key ────────────────────────────────────────────────────────
+
+run "rejects_empty_elevenlabs_api_key" {
+  command = plan
+
+  variables {
+    elevenlabs_api_key = ""
+  }
+
+  expect_failures = [var.elevenlabs_api_key]
+}
+
 # ── livekit_api_key / livekit_api_secret ──────────────────────────────────────
 
 run "rejects_empty_livekit_api_key" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -150,6 +150,18 @@ variable "grafana_admin_password" {
 
 # ── Observability ─────────────────────────────────────────────────────────────
 
+variable "enable_auto_shutdown" {
+  description = "Enable Cloud Scheduler jobs to stop Cloud SQL and (optionally) scale down the worker outside business hours."
+  type        = bool
+  default     = true
+}
+
+variable "scale_worker_overnight" {
+  description = "Scale the LiveKit worker to 0 overnight. Saves cost but drops active voice rooms. Only enable when 24/7 availability is not required."
+  type        = bool
+  default     = false
+}
+
 variable "cors_allow_origins" {
   description = "Comma-separated list of origins allowed by the FastAPI CORS middleware."
   type        = string

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -287,3 +287,9 @@ variable "cors_allow_origins" {
   type        = string
   default     = ""
 }
+
+variable "api_url_override" {
+  description = "Override VITE_API_URL for the frontend — set to the backend Cloud Run URL when no domain/LB is configured. Leave empty to use https://api.<domain>."
+  type        = string
+  default     = ""
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,157 @@
+# ── GCP project ──────────────────────────────────────────────────────────────
+
+variable "project_id" {
+  description = "GCP project ID where all resources are created."
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region for all regional resources."
+  type        = string
+  default     = "europe-west1"
+}
+
+# ── Domain ───────────────────────────────────────────────────────────────────
+
+variable "domain" {
+  description = "Root domain (e.g. taskorbit.example.com). Subdomains api. and grafana. are derived automatically."
+  type        = string
+}
+
+# ── GitHub repository (for Workload Identity) ─────────────────────────────────
+
+variable "github_repository" {
+  description = "GitHub repo in owner/name format used to scope Workload Identity (e.g. amosproj/amos2026ss04-taskorbit-conversational-agent)."
+  type        = string
+  default     = "amosproj/amos2026ss04-taskorbit-conversational-agent"
+}
+
+# ── Container images ─────────────────────────────────────────────────────────
+
+variable "backend_image" {
+  description = "Full Artifact Registry image URL for the backend / worker (e.g. europe-west1-docker.pkg.dev/PROJECT/taskorbit/backend:sha-abc1234)."
+  type        = string
+}
+
+variable "frontend_image" {
+  description = "Full Artifact Registry image URL for the frontend (e.g. europe-west1-docker.pkg.dev/PROJECT/taskorbit/frontend:sha-abc1234)."
+  type        = string
+}
+
+# ── Cloud Run scaling ─────────────────────────────────────────────────────────
+
+variable "backend_min_instances" {
+  description = "Minimum backend Cloud Run instances (≥1 to avoid cold starts)."
+  type        = number
+  default     = 1
+}
+
+variable "backend_max_instances" {
+  type    = number
+  default = 10
+}
+
+variable "worker_min_instances" {
+  description = "Minimum worker instances — keep at 1 so the LiveKit agent is always listening."
+  type        = number
+  default     = 1
+}
+
+variable "worker_max_instances" {
+  type    = number
+  default = 5
+}
+
+variable "frontend_min_instances" {
+  type    = number
+  default = 1
+}
+
+variable "frontend_max_instances" {
+  type    = number
+  default = 5
+}
+
+# ── Application secrets (loaded from terraform.tfvars — never commit) ─────────
+
+variable "livekit_url" {
+  description = "LiveKit Cloud WSS URL (wss://…livekit.cloud)."
+  type        = string
+  sensitive   = true
+}
+
+variable "livekit_api_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "livekit_api_secret" {
+  type      = string
+  sensitive = true
+}
+
+variable "deepgram_api_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "deepgram_model" {
+  type    = string
+  default = "nova-3"
+}
+
+variable "deepgram_language" {
+  type    = string
+  default = "multi"
+}
+
+variable "elevenlabs_api_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "elevenlabs_voice_id" {
+  type    = string
+  default = "21m00Tcm4TlvDq8ikWAM"
+}
+
+variable "elevenlabs_model" {
+  type    = string
+  default = "eleven_multilingual_v2"
+}
+
+variable "openai_api_key" {
+  type      = string
+  sensitive = true
+  default   = ""
+}
+
+variable "openai_model" {
+  type    = string
+  default = "gpt-4o-mini"
+}
+
+variable "google_api_key" {
+  type      = string
+  sensitive = true
+  default   = ""
+}
+
+variable "google_model" {
+  type    = string
+  default = "gemini-2.5-flash"
+}
+
+variable "grafana_admin_password" {
+  description = "Grafana admin password stored in Secret Manager."
+  type        = string
+  sensitive   = true
+}
+
+# ── Observability ─────────────────────────────────────────────────────────────
+
+variable "cors_allow_origins" {
+  description = "Comma-separated list of origins allowed by the FastAPI CORS middleware."
+  type        = string
+  default     = ""
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -68,6 +68,16 @@ variable "frontend_image" {
   }
 }
 
+variable "grafana_image" {
+  description = "Custom Grafana image with provisioning files baked in (built from infra/grafana/Dockerfile)."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9.-]+/.+:.+$", var.grafana_image))
+    error_message = "grafana_image must be a fully qualified image URL with a tag."
+  }
+}
+
 # ── Cloud Run scaling ─────────────────────────────────────────────────────────
 
 variable "backend_min_instances" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -3,12 +3,22 @@
 variable "project_id" {
   description = "GCP project ID where all resources are created."
   type        = string
+
+  validation {
+    condition     = length(var.project_id) > 0
+    error_message = "project_id must not be empty."
+  }
 }
 
 variable "region" {
   description = "GCP region for all regional resources."
   type        = string
   default     = "europe-west1"
+
+  validation {
+    condition     = can(regex("^[a-z]+-[a-z]+[0-9]+$", var.region))
+    error_message = "region must be a valid GCP region (e.g. europe-west1)."
+  }
 }
 
 # ── Domain ───────────────────────────────────────────────────────────────────
@@ -16,6 +26,11 @@ variable "region" {
 variable "domain" {
   description = "Root domain (e.g. taskorbit.example.com). Subdomains api. and grafana. are derived automatically."
   type        = string
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9][a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", var.domain))
+    error_message = "domain must be a valid hostname (e.g. taskorbit.example.com)."
+  }
 }
 
 # ── GitHub repository (for Workload Identity) ─────────────────────────────────
@@ -24,6 +39,11 @@ variable "github_repository" {
   description = "GitHub repo in owner/name format used to scope Workload Identity (e.g. amosproj/amos2026ss04-taskorbit-conversational-agent)."
   type        = string
   default     = "amosproj/amos2026ss04-taskorbit-conversational-agent"
+
+  validation {
+    condition     = can(regex("^[^/]+/[^/]+$", var.github_repository))
+    error_message = "github_repository must be in owner/name format (e.g. amosproj/amos2026ss04-taskorbit-conversational-agent)."
+  }
 }
 
 # ── Container images ─────────────────────────────────────────────────────────
@@ -31,11 +51,21 @@ variable "github_repository" {
 variable "backend_image" {
   description = "Full Artifact Registry image URL for the backend / worker (e.g. europe-west1-docker.pkg.dev/PROJECT/taskorbit/backend:sha-abc1234)."
   type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9.-]+/.+:.+$", var.backend_image))
+    error_message = "backend_image must be a fully qualified image URL with a tag (e.g. europe-west1-docker.pkg.dev/PROJECT/taskorbit/backend:latest)."
+  }
 }
 
 variable "frontend_image" {
   description = "Full Artifact Registry image URL for the frontend (e.g. europe-west1-docker.pkg.dev/PROJECT/taskorbit/frontend:sha-abc1234)."
   type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9.-]+/.+:.+$", var.frontend_image))
+    error_message = "frontend_image must be a fully qualified image URL with a tag (e.g. europe-west1-docker.pkg.dev/PROJECT/taskorbit/frontend:latest)."
+  }
 }
 
 # ── Cloud Run scaling ─────────────────────────────────────────────────────────
@@ -44,32 +74,62 @@ variable "backend_min_instances" {
   description = "Minimum backend Cloud Run instances (≥1 to avoid cold starts)."
   type        = number
   default     = 1
+
+  validation {
+    condition     = var.backend_min_instances >= 1 && var.backend_min_instances <= var.backend_max_instances
+    error_message = "backend_min_instances must be ≥1 and ≤ backend_max_instances."
+  }
 }
 
 variable "backend_max_instances" {
   type    = number
   default = 10
+
+  validation {
+    condition     = var.backend_max_instances >= 1
+    error_message = "backend_max_instances must be ≥1."
+  }
 }
 
 variable "worker_min_instances" {
   description = "Minimum worker instances — keep at 1 so the LiveKit agent is always listening."
   type        = number
   default     = 1
+
+  validation {
+    condition     = var.worker_min_instances >= 0 && var.worker_min_instances <= var.worker_max_instances
+    error_message = "worker_min_instances must be ≥0 and ≤ worker_max_instances."
+  }
 }
 
 variable "worker_max_instances" {
   type    = number
   default = 5
+
+  validation {
+    condition     = var.worker_max_instances >= 1
+    error_message = "worker_max_instances must be ≥1."
+  }
 }
 
 variable "frontend_min_instances" {
   type    = number
   default = 1
+
+  validation {
+    condition     = var.frontend_min_instances >= 0 && var.frontend_min_instances <= var.frontend_max_instances
+    error_message = "frontend_min_instances must be ≥0 and ≤ frontend_max_instances."
+  }
 }
 
 variable "frontend_max_instances" {
   type    = number
   default = 5
+
+  validation {
+    condition     = var.frontend_max_instances >= 1
+    error_message = "frontend_max_instances must be ≥1."
+  }
 }
 
 # ── Application secrets (loaded from terraform.tfvars — never commit) ─────────
@@ -78,46 +138,91 @@ variable "livekit_url" {
   description = "LiveKit Cloud WSS URL (wss://…livekit.cloud)."
   type        = string
   sensitive   = true
+
+  validation {
+    condition     = startswith(var.livekit_url, "wss://")
+    error_message = "livekit_url must start with wss:// (e.g. wss://your-project.livekit.cloud)."
+  }
 }
 
 variable "livekit_api_key" {
   type      = string
   sensitive = true
+
+  validation {
+    condition     = length(var.livekit_api_key) > 0
+    error_message = "livekit_api_key must not be empty."
+  }
 }
 
 variable "livekit_api_secret" {
   type      = string
   sensitive = true
+
+  validation {
+    condition     = length(var.livekit_api_secret) > 0
+    error_message = "livekit_api_secret must not be empty."
+  }
 }
 
 variable "deepgram_api_key" {
   type      = string
   sensitive = true
+
+  validation {
+    condition     = length(var.deepgram_api_key) > 0
+    error_message = "deepgram_api_key must not be empty."
+  }
 }
 
 variable "deepgram_model" {
   type    = string
   default = "nova-3"
+
+  validation {
+    condition     = length(var.deepgram_model) > 0
+    error_message = "deepgram_model must not be empty."
+  }
 }
 
 variable "deepgram_language" {
   type    = string
   default = "multi"
+
+  validation {
+    condition     = length(var.deepgram_language) > 0
+    error_message = "deepgram_language must not be empty."
+  }
 }
 
 variable "elevenlabs_api_key" {
   type      = string
   sensitive = true
+
+  validation {
+    condition     = length(var.elevenlabs_api_key) > 0
+    error_message = "elevenlabs_api_key must not be empty."
+  }
 }
 
 variable "elevenlabs_voice_id" {
   type    = string
   default = "21m00Tcm4TlvDq8ikWAM"
+
+  validation {
+    condition     = length(var.elevenlabs_voice_id) > 0
+    error_message = "elevenlabs_voice_id must not be empty."
+  }
 }
 
 variable "elevenlabs_model" {
   type    = string
   default = "eleven_multilingual_v2"
+
+  validation {
+    condition     = length(var.elevenlabs_model) > 0
+    error_message = "elevenlabs_model must not be empty."
+  }
 }
 
 variable "openai_api_key" {
@@ -129,6 +234,11 @@ variable "openai_api_key" {
 variable "openai_model" {
   type    = string
   default = "gpt-4o-mini"
+
+  validation {
+    condition     = length(var.openai_model) > 0
+    error_message = "openai_model must not be empty."
+  }
 }
 
 variable "google_api_key" {
@@ -140,12 +250,22 @@ variable "google_api_key" {
 variable "google_model" {
   type    = string
   default = "gemini-2.5-flash"
+
+  validation {
+    condition     = length(var.google_model) > 0
+    error_message = "google_model must not be empty."
+  }
 }
 
 variable "grafana_admin_password" {
   description = "Grafana admin password stored in Secret Manager."
   type        = string
   sensitive   = true
+
+  validation {
+    condition     = length(var.grafana_admin_password) >= 12
+    error_message = "grafana_admin_password must be at least 12 characters."
+  }
 }
 
 # ── Observability ─────────────────────────────────────────────────────────────

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -13,7 +13,7 @@ variable "project_id" {
 variable "region" {
   description = "GCP region for all regional resources."
   type        = string
-  default     = "europe-west1"
+  default     = "europe-west3"
 
   validation {
     condition     = can(regex("^[a-z]+-[a-z]+[0-9]+$", var.region))

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -268,6 +268,18 @@ variable "grafana_admin_password" {
   }
 }
 
+variable "grafana_admin_user" {
+  description = "Grafana admin username stored in Secret Manager."
+  type        = string
+  sensitive   = true
+  default     = "admin"
+
+  validation {
+    condition     = length(var.grafana_admin_user) > 0
+    error_message = "grafana_admin_user must not be empty."
+  }
+}
+
 # ── Observability ─────────────────────────────────────────────────────────────
 
 variable "enable_auto_shutdown" {

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 6.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+}


### PR DESCRIPTION
```md
# GCP Production Infrastructure & CI/CD Setup for TaskOrbit

This PR provisions the full GCP production environment for TaskOrbit using Terraform and wires it into the CI/CD pipeline.

---

## Infrastructure as Code (`terraform/`)

All GCP resources are defined in Terraform `>= 1.7` across 7 reusable modules. No resources are created manually.

| Module | What it provisions |
|---|---|
| `network` | Custom VPC, private subnet, Cloud NAT, Serverless VPC connector, private service access for Cloud SQL |
| `iam` | Service accounts for backend / worker / frontend / observability / CI-CD; Workload Identity Pool for GitHub Actions OIDC (no long-lived SA keys) |
| `registry` | Artifact Registry Docker repository with automatic image cleanup |
| `database` | Cloud SQL PostgreSQL 16, regional high-availability, private IP only, automated backups with point-in-time recovery |
| `secrets` | Secret Manager secrets for all API keys, DB connection string, and Grafana admin password |
| `cloud_run` | Backend, worker, and frontend Cloud Run services; HTTPS global load balancer with managed SSL certificates and HTTP → HTTPS redirect |
| `observability` | Prometheus, Loki, Grafana on Cloud Run; GCS buckets for log and metrics storage; configs stored in Secret Manager; Cloud Logging sink → Pub/Sub for log routing to Loki |
| `scheduler` | Cloud Scheduler jobs that stop Cloud SQL at `22:00` and restart it at `07:00` Mon–Fri (`Europe/Berlin`) to eliminate idle compute costs |

---

## CI/CD Pipeline (`.github/workflows/deploy.yml`)

- Triggers on every push to `main`
- Authenticates to GCP using Workload Identity Federation (OIDC) — no service-account JSON key is stored in GitHub secrets
- Builds production Docker targets for backend and frontend
- Pushes images to Artifact Registry tagged with the commit SHA
- Deploys all three Cloud Run services in a single pipeline run

---

## Automatic Idle-Cost Reduction

- Cloud Run frontend and backend scale to zero automatically when idle
- Cloud SQL is stopped overnight via Cloud Scheduler (saves ~65% of daily compute cost)
- Worker `min_instances=1` is preserved by default to keep the LiveKit agent live
- Optional variable `scale_worker_overnight` can reduce worker instances to `0` outside business hours

---

## Documentation (`docs/Cloud-Deployment.md`)

New wiki page covering:

- How Workload Identity OIDC authentication works end-to-end
- Which GitHub Actions secrets to configure and where to get the values
- How secrets are stored in Secret Manager and accessed by Cloud Run at runtime
- How to rotate secrets without redeployment
- How the auto-shutdown scheduler works and how to disable it
- How developers authenticate locally using Application Default Credentials and the Cloud SQL Auth Proxy

---

## Test Plan

- `terraform init && terraform plan` runs without errors against a real GCP project
- `terraform apply` creates all resources; `terraform output` returns all expected values
- DNS `A` records pointed at `load_balancer_ip` → frontend loads at `https://<domain>`
- DNS `A` records pointed at `load_balancer_ip` → backend health check available at `https://api.<domain>/health`
- Push to `main` triggers `deploy.yml`; all three Cloud Run services update without downtime
- At `22:00 CET`, Cloud SQL instance stops (`activationPolicy=NEVER`) and restarts at `07:00`
- Grafana accessible at `https://grafana.<domain>` with admin login (anonymous access disabled)
- Secret rotation validated by:
  - Updating a Secret Manager version
  - Forcing a new Cloud Run revision
  - Confirming the new value is active
```
