### PR TITLE
feat(docker): auto-run database migrations on container startup

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -48,13 +48,16 @@
     COPY pyproject.toml poetry.lock* README.md ./
     COPY src ./src
     COPY tests ./tests
+    COPY alembic.ini ./
+    COPY migrations ./migrations
+    COPY start.sh ./start.sh
 
-    RUN poetry install --no-ansi
+    RUN poetry install --no-ansi && chmod +x start.sh
 
     ENV PATH="/app/.venv/bin:${PATH}"
 
     EXPOSE 8000
-    CMD ["poetry", "run", "taskorbit-api", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+    CMD ["bash", "start.sh"]
 
     # ---------- Prod image ----------
     FROM python:3.11-slim AS prod

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Running database migrations..."
+poetry run alembic upgrade head
+
+echo "Starting API server..."
+exec poetry run taskorbit-api --host 0.0.0.0 --port 8000 --reload

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,10 @@ services:
     volumes:
       - ./backend/src:/app/src
       - ./backend/tests:/app/tests
-    command: poetry run taskorbit-api --host 0.0.0.0 --port 8000 --reload
+      - ./backend/migrations:/app/migrations
+      - ./backend/alembic.ini:/app/alembic.ini
+      - ./backend/start.sh:/app/start.sh
+    command: bash start.sh
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
Add a start.sh entrypoint script that runs alembic upgrade head before starting the API server, so migrations are applied automatically on every docker compose up without manual intervention.

- backend/start.sh: new entrypoint — runs migrations then execs the API
- backend/Dockerfile: dev stage copies alembic.ini, migrations/, start.sh and uses start.sh as CMD
- docker-compose.yml: backend command updated to bash start.sh; added bind-mounts for migrations/, alembic.ini, and start.sh so new migration files are picked up without rebuilding the image