### PR TITLE
Fix container build under Windows due to CRLF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.sh text eol=lf


### PR DESCRIPTION
Small issue where Git selected CRLF instead of LF under Windows that caused the backend container to crash

Took it over because it was only a small issue, it's important for mid project review and I wanted to relieve the dev team