### PR TITLE
fix(frontend): share active agent state between config page and chat …

### DIFF
--- a/frontend/src/components/ConversationalChat.tsx
+++ b/frontend/src/components/ConversationalChat.tsx
@@ -14,9 +14,9 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useVoiceCall } from "@/hooks/useVoiceCall";
 import type { TranscriptionSegment } from "@/hooks/useAgentTranscription";
+import { useActiveAgent } from "@/components/active-agent-provider";
 import { buildLiveKitWorkerMetadata } from "@/lib/livekitAgentMetadata";
 import { sendMessage, getConversations } from "@/lib/conversationApi";
-import { JOHN_DOE_AGENT } from "@/lib/mockAgents";
 import { playSynthesizedSpeech } from "@/lib/ttsApi";
 import type { ConfirmationPromptState } from "@/types/callState";
 
@@ -41,7 +41,10 @@ const mockConfirmationPrompt: ConfirmationPromptState = {
  * answer is still heard when the user uses the text disclosure.
  */
 export function ConversationalChat() {
-  const agent = JOHN_DOE_AGENT;
+  // Active agent comes from shared context, set on the config page. Before
+  // this hook existed, the chat was hardcoded to JOHN_DOE_AGENT — Christoph
+  // + Carl reported the bug on Discord 2026-05-24.
+  const { agent } = useActiveAgent();
   const appName = import.meta.env.VITE_APP_NAME ?? "TaskOrbit";
 
   const call = useVoiceCall();

--- a/frontend/src/components/active-agent-provider.tsx
+++ b/frontend/src/components/active-agent-provider.tsx
@@ -1,0 +1,97 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+
+import { JOHN_DOE_AGENT } from "@/lib/mockAgents";
+import type { AgentConfig } from "@/types/agentConfig";
+
+/**
+ * Shared "currently active agent" for the whole app.
+ *
+ * Before this provider existed, `AgentConfigPage` held the form-edited
+ * agent in a local `useState` and `ConversationalChat` hardcoded
+ * `JOHN_DOE_AGENT`, so loading a custom agent on the config page never
+ * reached the chat surface — Christoph + Carl reported this on Discord
+ * 2026-05-24 as a midterm blocker.
+ *
+ * Mirrors the existing `ThemeProvider` pattern (lazy-init from
+ * localStorage, persist on change) so saved choices survive route
+ * navigation AND hard reloads.
+ */
+
+type ActiveAgentState = {
+  agent: AgentConfig;
+  loadedConfigId: string | null;
+  setActiveAgent: (agent: AgentConfig, loadedConfigId: string | null) => void;
+  resetActiveAgent: () => void;
+};
+
+const STORAGE_KEY = "taskorbit-active-agent";
+
+const initialState: ActiveAgentState = {
+  agent: JOHN_DOE_AGENT,
+  loadedConfigId: null,
+  setActiveAgent: () => null,
+  resetActiveAgent: () => null,
+};
+
+const ActiveAgentContext = createContext<ActiveAgentState>(initialState);
+
+type Persisted = {
+  agent: AgentConfig;
+  loadedConfigId: string | null;
+};
+
+function readFromStorage(): Persisted | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<Persisted>;
+    if (!parsed.agent) return null;
+    return {
+      agent: parsed.agent,
+      loadedConfigId: parsed.loadedConfigId ?? null,
+    };
+  } catch {
+    // Storage unavailable (incognito) or corrupt JSON — fall through to defaults.
+    return null;
+  }
+}
+
+export function ActiveAgentProvider({ children }: { children: ReactNode }) {
+  const [agent, setAgent] = useState<AgentConfig>(() => {
+    return readFromStorage()?.agent ?? JOHN_DOE_AGENT;
+  });
+  const [loadedConfigId, setLoadedConfigId] = useState<string | null>(() => {
+    return readFromStorage()?.loadedConfigId ?? null;
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ agent, loadedConfigId }));
+    } catch {
+      // Storage unavailable — preference won't persist this session.
+    }
+  }, [agent, loadedConfigId]);
+
+  const value: ActiveAgentState = {
+    agent,
+    loadedConfigId,
+    setActiveAgent: (nextAgent, nextLoadedConfigId) => {
+      setAgent(nextAgent);
+      setLoadedConfigId(nextLoadedConfigId);
+    },
+    resetActiveAgent: () => {
+      setAgent(JOHN_DOE_AGENT);
+      setLoadedConfigId(null);
+    },
+  };
+
+  return <ActiveAgentContext.Provider value={value}>{children}</ActiveAgentContext.Provider>;
+}
+
+export const useActiveAgent = () => {
+  const context = useContext(ActiveAgentContext);
+  if (context === undefined) {
+    throw new Error("useActiveAgent must be used within an ActiveAgentProvider");
+  }
+  return context;
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,6 +6,7 @@ import "@livekit/components-styles";
 import "./index.css";
 
 import { App } from "@/App";
+import { ActiveAgentProvider } from "@/components/active-agent-provider";
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
 
@@ -19,8 +20,10 @@ createRoot(rootEl).render(
         itself. Keeping both avoids forking the existing provider. */}
     <ThemeProvider defaultTheme="system" storageKey="taskorbit-ui-theme">
       <NextThemesProvider attribute="class" defaultTheme="system" enableSystem>
-        <App />
-        <Toaster richColors position="bottom-right" />
+        <ActiveAgentProvider>
+          <App />
+          <Toaster richColors position="bottom-right" />
+        </ActiveAgentProvider>
       </NextThemesProvider>
     </ThemeProvider>
   </StrictMode>,

--- a/frontend/src/pages/AgentConfigPage.tsx
+++ b/frontend/src/pages/AgentConfigPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { Copy, FileDown, Loader2, RefreshCw, RotateCcw, Save, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
+import { useActiveAgent } from "@/components/active-agent-provider";
 import { AdvancedSection } from "@/components/agent-config/AdvancedSection";
 import { ConfirmationsSection } from "@/components/agent-config/ConfirmationsSection";
 import { IdentitySection } from "@/components/agent-config/IdentitySection";
@@ -40,11 +41,16 @@ function isComplete(agent: AgentConfig) {
 }
 
 export function AgentConfigPage() {
-  const [agent, setAgent] = useState<AgentConfig>(JOHN_DOE_AGENT);
+  // Active agent + loadedConfigId live in shared context so the chat surface
+  // sees whatever was last loaded/saved here, and the form survives route
+  // navigation + page reloads (see active-agent-provider.tsx).
+  const { agent, loadedConfigId, setActiveAgent } = useActiveAgent();
+  // Shim so the inline JSX `setAgent({ ...agent, fieldX })` callsites below
+  // don't need rewriting; loadedConfigId is preserved on every form edit.
+  const setAgent = (next: AgentConfig) => setActiveAgent(next, loadedConfigId);
   const [showErrors, setShowErrors] = useState(false);
   const [savedConfigs, setSavedConfigs] = useState<SavedAgentConfigSummary[]>([]);
   const [isListLoading, setIsListLoading] = useState(false);
-  const [loadedConfigId, setLoadedConfigId] = useState<string | null>(null);
 
   // Fetch the saved-config list once on mount + expose a refresh helper.
   // Used by the "Load preset" dropdown and re-called after a successful save
@@ -70,24 +76,21 @@ export function AgentConfigPage() {
   }, [refreshList]);
 
   const reset = () => {
-    setAgent(EMPTY_AGENT);
+    setActiveAgent(EMPTY_AGENT, null);
     setShowErrors(false);
-    setLoadedConfigId(null);
     toast("Reset to empty.");
   };
 
   const loadPreset = () => {
-    setAgent(JOHN_DOE_AGENT);
+    setActiveAgent(JOHN_DOE_AGENT, null);
     setShowErrors(false);
-    setLoadedConfigId(null);
     toast.success("Preset loaded.");
   };
 
   const loadById = async (id: string) => {
     try {
       const saved = await loadAgentConfig(id);
-      setAgent(saved.config as unknown as AgentConfig);
-      setLoadedConfigId(saved.id);
+      setActiveAgent(saved.config as unknown as AgentConfig, saved.id);
       setShowErrors(false);
       toast.success("Configuration loaded.", {
         description: `Loaded "${saved.name}".`,
@@ -106,7 +109,8 @@ export function AgentConfigPage() {
       await deleteAgentConfig(id);
       toast.success("Configuration deleted.");
       if (loadedConfigId === id) {
-        setLoadedConfigId(null);
+        // Keep current form contents but unlink from the deleted DB row.
+        setActiveAgent(agent, null);
       }
       void refreshList();
     } catch (err) {


### PR DESCRIPTION
The chat surface hardcoded JOHN_DOE_AGENT, so loading a custom agent on the config page never reached chat. The config form also lived in local useState, so navigating away and back reset it to the John Doe default.

Adds ActiveAgentProvider context backed by localStorage (mirrors the existing ThemeProvider pattern) so the active agent + loadedConfigId are shared across routes and persist across reloads.

<Signed-off-by: Asad Raza asadraza1702@gmail.com>