### PR TITLE
feat(worker): load agent config from LiveKit JWT metadata (part of #100)

### DIFF
--- a/backend/src/taskorbit/livekit_agent/session.py
+++ b/backend/src/taskorbit/livekit_agent/session.py
@@ -26,6 +26,7 @@ from livekit.plugins.elevenlabs import VoiceSettings
 from taskorbit.config import Settings, get_settings
 from taskorbit.livekit_agent.llm import OrchestratorAgent
 from taskorbit.orchestration import ConversationOrchestrator
+from taskorbit.types import AgentConfig
 
 
 def build_agent_session(
@@ -96,12 +97,18 @@ def build_default_agent(
     *,
     orchestrator: ConversationOrchestrator | None = None,
     settings: Settings | None = None,
+    agent_config: AgentConfig | None = None,
 ) -> OrchestratorAgent:
     """Build the ``OrchestratorAgent`` paired with this session.
 
     Kept separate from ``build_agent_session`` because ``session.start``
     expects the agent as a parameter, not as a constructor argument.
+
+    Pass ``agent_config`` when the caller has parsed it from participant
+    metadata (#100) so the voice path uses the user's saved configuration
+    instead of the hardcoded ``_default_agent_config`` fallback.
     """
     return OrchestratorAgent(
         orchestrator=orchestrator or ConversationOrchestrator(settings=settings),
+        agent_config=agent_config,
     )

--- a/backend/src/taskorbit/worker.py
+++ b/backend/src/taskorbit/worker.py
@@ -22,7 +22,6 @@ from livekit import rtc
 from livekit.agents import AutoSubscribe, JobContext, WorkerOptions, cli
 from livekit.agents.metrics import STTMetrics, TTSMetrics
 from livekit.agents.voice.events import AgentEvent
-
 from pydantic import ValidationError
 
 from taskorbit.config import get_settings

--- a/backend/src/taskorbit/worker.py
+++ b/backend/src/taskorbit/worker.py
@@ -23,10 +23,13 @@ from livekit.agents import AutoSubscribe, JobContext, WorkerOptions, cli
 from livekit.agents.metrics import STTMetrics, TTSMetrics
 from livekit.agents.voice.events import AgentEvent
 
+from pydantic import ValidationError
+
 from taskorbit.config import get_settings
 from taskorbit.livekit_agent import build_agent_session, build_default_agent
 from taskorbit.logging.setup import get_logger
 from taskorbit.observability.metrics import configure_default_metrics, get_metrics
+from taskorbit.types import AgentConfig
 
 logger = get_logger(__name__)
 
@@ -43,21 +46,40 @@ async def entrypoint(ctx: JobContext) -> None:
 
     cfg = get_settings()
 
-    # Read the greeting from participant metadata so we can speak it through
-    # the session — same TTS/WebRTC pipeline as every other agent turn, so
-    # the voice is identical. The frontend used to call ElevenLabs directly
-    # for the greeting which produced a different audio path (plain MP3
-    # playback vs WebRTC Opus), making the voices sound different.
+    # Read participant metadata and parse it into an AgentConfig so the
+    # voice path uses the user's saved configuration instead of the
+    # hardcoded fallback in ``_default_agent_config`` (#100). The frontend
+    # serialises this via ``buildLiveKitWorkerMetadata`` and the backend
+    # embeds it in ``RoomAgentDispatch.metadata`` on the JWT.
+    #
+    # ``greeting`` is still extracted separately because ``session.say()``
+    # below speaks it through the same TTS/WebRTC pipeline as every other
+    # agent turn — the frontend used to call ElevenLabs directly which
+    # produced a different audio path (plain MP3 vs WebRTC Opus).
     greeting: str = ""
+    agent_config: AgentConfig | None = None
     try:
         participant = await ctx.wait_for_participant()
         meta = json.loads(participant.metadata or "{}")
         greeting = str(meta.get("greeting") or "")
+        try:
+            agent_config = AgentConfig.model_validate(meta)
+            logger.info(
+                "worker_agent_config_loaded_from_metadata",
+                agent_id=agent_config.id,
+                agent_name=agent_config.name,
+            )
+        except ValidationError as exc:
+            logger.warning(
+                "worker_agent_config_parse_failed",
+                error=str(exc),
+                fallback="_default_agent_config",
+            )
     except Exception:  # noqa: BLE001
         pass
 
     session = build_agent_session(settings=cfg)
-    agent = build_default_agent(settings=cfg)
+    agent = build_default_agent(settings=cfg, agent_config=agent_config)
 
     @session.on("metrics_collected")
     def _on_metrics(ev: AgentEvent) -> None:

--- a/backend/tests/test_worker.py
+++ b/backend/tests/test_worker.py
@@ -505,3 +505,95 @@ async def test_interrupt_after_completed_task_does_not_raise(configured_settings
         handler(_data_packet(json.dumps({"type": "interrupt_playback"}).encode()))
 
     mock_session.interrupt.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Issue #100 — agent config parsing from participant metadata
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_entrypoint_parses_agent_config_from_metadata(configured_settings: None) -> None:
+    """entrypoint() should parse participant metadata into an AgentConfig and
+    forward it to build_default_agent, so the voice path uses the user's saved
+    configuration instead of the hardcoded _default_agent_config fallback (#100).
+    """
+    ctx, _ = _make_ctx()
+    mock_session = _make_session_mock()
+    mock_agent = MagicMock()
+
+    participant = MagicMock()
+    participant.metadata = json.dumps(
+        {
+            "id": "pizza-bot",
+            "name": "PizzaBot",
+            "persona": "You are a pizza expert. Only pizza.",
+            "greeting": "Welcome to the pizza party!",
+            "stt": {"provider": "deepgram", "language": "multi", "model": "nova-3"},
+            "llm": {"provider": "openai", "model": "gpt-4o-mini"},
+            "tts": {
+                "provider": "elevenlabs",
+                "voice_id": "21m00Tcm4TlvDq8ikWAM",
+                "model": "eleven_multilingual_v2",
+            },
+            "tools": [],
+        }
+    )
+    ctx.wait_for_participant = AsyncMock(return_value=participant)
+
+    with (
+        patch("taskorbit.worker.build_agent_session", return_value=mock_session),
+        patch("taskorbit.worker.build_default_agent", return_value=mock_agent) as mock_build,
+    ):
+        await entrypoint(ctx)
+
+    build_kwargs = mock_build.call_args.kwargs
+    assert "agent_config" in build_kwargs
+    parsed = build_kwargs["agent_config"]
+    assert parsed is not None
+    assert parsed.id == "pizza-bot"
+    assert parsed.name == "PizzaBot"
+    assert parsed.persona == "You are a pizza expert. Only pizza."
+
+
+@pytest.mark.asyncio
+async def test_entrypoint_falls_back_when_metadata_missing(configured_settings: None) -> None:
+    """If participant metadata is empty or absent, agent_config is None so the
+    default fallback in _default_agent_config kicks in unchanged."""
+    ctx, _ = _make_ctx()
+    mock_session = _make_session_mock()
+    mock_agent = MagicMock()
+
+    participant = MagicMock()
+    participant.metadata = ""
+    ctx.wait_for_participant = AsyncMock(return_value=participant)
+
+    with (
+        patch("taskorbit.worker.build_agent_session", return_value=mock_session),
+        patch("taskorbit.worker.build_default_agent", return_value=mock_agent) as mock_build,
+    ):
+        await entrypoint(ctx)
+
+    assert mock_build.call_args.kwargs.get("agent_config") is None
+
+
+@pytest.mark.asyncio
+async def test_entrypoint_falls_back_when_metadata_malformed(configured_settings: None) -> None:
+    """If metadata JSON does not validate against AgentConfig, log a warning and
+    pass None to build_default_agent so the fallback applies — never crash."""
+    ctx, _ = _make_ctx()
+    mock_session = _make_session_mock()
+    mock_agent = MagicMock()
+
+    participant = MagicMock()
+    # Missing required fields (id, name, persona, greeting)
+    participant.metadata = json.dumps({"unrelated": "shape"})
+    ctx.wait_for_participant = AsyncMock(return_value=participant)
+
+    with (
+        patch("taskorbit.worker.build_agent_session", return_value=mock_session),
+        patch("taskorbit.worker.build_default_agent", return_value=mock_agent) as mock_build,
+    ):
+        await entrypoint(ctx)
+
+    assert mock_build.call_args.kwargs.get("agent_config") is None

--- a/frontend/src/lib/livekitAgentMetadata.ts
+++ b/frontend/src/lib/livekitAgentMetadata.ts
@@ -6,6 +6,10 @@
  * Tool definitions are omitted for now — the echo orchestrator ignores them
  * and serialising Meisterwerk tools into backend ToolDefinition rows is a
  * separate ticket.
+ *
+ * `persona_constraints` is included so #69 guardrails apply to the voice
+ * path too; before #100 the worker discarded the whole metadata and used
+ * a hardcoded default agent, so guardrails never reached voice sessions.
  */
 
 import type { AgentConfig } from "@/types/agentConfig";
@@ -32,5 +36,6 @@ export function buildLiveKitWorkerMetadata(agent: AgentConfig): Record<string, u
       model: agent.tts.model,
     },
     tools: [],
+    persona_constraints: agent.persona_constraints ?? null,
   };
 }


### PR DESCRIPTION
Part of #100. Does not close it on its own - see the "What this does not fix" section below.

## What this does

Wires the voice worker to actually read the user's agent config from the LiveKit JWT metadata instead of throwing it away and using the hardcoded default. Three files on the backend, one on the FE.

Full change rationale is in the commit message. Short version: text path goes through the API (config in request body, worked already), voice path goes through the worker container (config never made it past the greeting extract until this PR). Abdul named this split in the 27 May sprint meeting.

## What this does NOT fix

The IntentRouter from Abdul's #8 / PR #108 still overrides the loaded `agent_config` by picking one of its hardcoded agent classes (SalesAgent etc.) based on intent detection. So the user-visible bug still reproduces on screen even with this PR merged. The routing-layer fix is owned by @abdulmoeez1225 on the routing branch. 

## Testing

- 3 new tests in `test_worker.py` (happy path, empty metadata, malformed metadata)
- Smoke-tested locally - `worker_agent_config_loaded_from_metadata` log fires every voice session with the right agent_name
- Checked the DB directly - save/load roundtrip clean

cc @abdulmoeez1225 
