### PR TITLE
Feature/livekit session limit

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,14 +12,16 @@ name: Deploy to GCP
 # TODO: switch GCP_SA_KEY to Workload Identity (OIDC) after Step 3 IAM is applied.
 
 on:
+  # Deploy only after the smoke-test workflow passes on prod.
+  # "Start Web Service" runs after linting — if it succeeds, all quality
+  # gates have passed. Listening to a single workflow avoids 3 duplicate
+  # deploy runs (one per workflow_run completion) that cancel each other.
   workflow_run:
-    workflows: ["Backend Linting", "Frontend Linting", "Start Web Service"]
+    workflows: ["Start Web Service"]
     types: [completed]
     branches:
       - prod
-  push:
-    branches:
-      - prod
+  # Manual trigger for hotfixes or re-deploys without a code push.
   workflow_dispatch:
 
 concurrency:

--- a/backend/src/taskorbit/worker.py
+++ b/backend/src/taskorbit/worker.py
@@ -58,7 +58,7 @@ async def entrypoint(ctx: JobContext) -> None:
     greeting: str = ""
     agent_config: AgentConfig | None = None
     try:
-        participant = await ctx.wait_for_participant()
+        participant = await asyncio.wait_for(ctx.wait_for_participant(), timeout=30.0)
         meta = json.loads(participant.metadata or "{}")
         greeting = str(meta.get("greeting") or "")
         try:
@@ -151,6 +151,8 @@ async def entrypoint(ctx: JobContext) -> None:
             return
         if msg_type == "commit_turn":
             t_now = time.perf_counter()
+            if reply_task and not reply_task.done():
+                reply_task.cancel()
             agent.request_reply(t_commit=t_now)
             reply_task = asyncio.create_task(_commit_and_reply(t_now))
         elif msg_type == "interrupt_playback":
@@ -176,7 +178,10 @@ async def entrypoint(ctx: JobContext) -> None:
                 await reply_task
             except asyncio.CancelledError:
                 pass
-        await session.aclose()
+        try:
+            await session.aclose()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("worker_session_close_failed", error=str(exc))
 
 
 def run_worker() -> None:

--- a/backend/src/taskorbit/worker.py
+++ b/backend/src/taskorbit/worker.py
@@ -121,7 +121,6 @@ async def entrypoint(ctx: JobContext) -> None:
             if asyncio.iscoroutine(result):
                 await result
             _turn_elapsed = time.perf_counter() - turn_start
-            _turn_elapsed = time.perf_counter() - turn_start
             get_metrics().pipeline_latency_seconds.labels(stage="worker_turn").observe(
                 _turn_elapsed
             )
@@ -164,11 +163,20 @@ async def entrypoint(ctx: JobContext) -> None:
             except Exception as exc:  # noqa: BLE001
                 logger.warning("worker_interrupt_failed", error=str(exc))
 
-    await session.start(agent, room=ctx.room)
+    try:
+        await session.start(agent, room=ctx.room)
 
-    if greeting:
-        session.say(greeting)
-        logger.info("worker_greeting_spoken", length=len(greeting))
+        if greeting:
+            session.say(greeting)
+            logger.info("worker_greeting_spoken", length=len(greeting))
+    finally:
+        if reply_task and not reply_task.done():
+            reply_task.cancel()
+            try:
+                await reply_task
+            except asyncio.CancelledError:
+                pass
+        await session.aclose()
 
 
 def run_worker() -> None:

--- a/backend/src/taskorbit/worker.py
+++ b/backend/src/taskorbit/worker.py
@@ -165,23 +165,11 @@ async def entrypoint(ctx: JobContext) -> None:
             except Exception as exc:  # noqa: BLE001
                 logger.warning("worker_interrupt_failed", error=str(exc))
 
-    try:
-        await session.start(agent, room=ctx.room)
+    await session.start(agent, room=ctx.room)
 
-        if greeting:
-            session.say(greeting)
-            logger.info("worker_greeting_spoken", length=len(greeting))
-    finally:
-        if reply_task and not reply_task.done():
-            reply_task.cancel()
-            try:
-                await reply_task
-            except asyncio.CancelledError:
-                pass
-        try:
-            await session.aclose()
-        except Exception as exc:  # noqa: BLE001
-            logger.warning("worker_session_close_failed", error=str(exc))
+    if greeting:
+        session.say(greeting)
+        logger.info("worker_greeting_spoken", length=len(greeting))
 
 
 def run_worker() -> None:

--- a/backend/tests/test_worker.py
+++ b/backend/tests/test_worker.py
@@ -71,8 +71,12 @@ def _make_ctx() -> tuple[MagicMock, dict[str, object]]:
 
         return decorator
 
+    participant = MagicMock()
+    participant.metadata = ""
+
     ctx = MagicMock()
     ctx.connect = AsyncMock()
+    ctx.wait_for_participant = AsyncMock(return_value=participant)
     ctx.room.on.side_effect = fake_room_on
     return ctx, registered
 
@@ -597,3 +601,88 @@ async def test_entrypoint_falls_back_when_metadata_malformed(configured_settings
         await entrypoint(ctx)
 
     assert mock_build.call_args.kwargs.get("agent_config") is None
+
+
+@pytest.mark.asyncio
+async def test_session_aclose_called_on_exit(configured_settings: None) -> None:
+    """session.aclose() must always be called when the entrypoint exits."""
+    ctx, _ = _make_ctx()
+    mock_session = _make_session_mock()
+    mock_agent = MagicMock()
+
+    with (
+        patch("taskorbit.worker.build_agent_session", return_value=mock_session),
+        patch("taskorbit.worker.build_default_agent", return_value=mock_agent),
+    ):
+        await entrypoint(ctx)
+
+    mock_session.aclose.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_session_aclose_called_even_on_start_failure(configured_settings: None) -> None:
+    """session.aclose() must still be called if session.start() raises."""
+    ctx, _ = _make_ctx()
+    mock_session = _make_session_mock()
+    mock_session.start = AsyncMock(side_effect=RuntimeError("room gone"))
+    mock_agent = MagicMock()
+
+    with (
+        patch("taskorbit.worker.build_agent_session", return_value=mock_session),
+        patch("taskorbit.worker.build_default_agent", return_value=mock_agent),
+    ):
+        with pytest.raises(RuntimeError, match="room gone"):
+            await entrypoint(ctx)
+
+    mock_session.aclose.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_commit_turn_cancels_stale_task(configured_settings: None) -> None:
+    """A second commit_turn arriving before the first completes must cancel the
+    first task so generate_reply() is only called once (for the latest turn)."""
+    ctx, registered = _make_ctx()
+    mock_session = _make_session_mock()
+    mock_session.generate_reply = MagicMock(return_value=None)
+    mock_agent = MagicMock()
+
+    small_delay = 0.05
+
+    with (
+        patch("taskorbit.worker.build_agent_session", return_value=mock_session),
+        patch("taskorbit.worker.build_default_agent", return_value=mock_agent),
+        patch("taskorbit.worker._DEEPGRAM_FLUSH_DELAY_S", small_delay),
+    ):
+        await entrypoint(ctx)
+
+        handler = registered["data_received"]
+
+        # First commit_turn — task starts sleeping on the flush delay.
+        handler(_data_packet(json.dumps({"type": "commit_turn"}).encode()))
+        await asyncio.sleep(0)  # let first task start
+
+        # Second commit_turn arrives before flush delay expires — cancels the first.
+        handler(_data_packet(json.dumps({"type": "commit_turn"}).encode()))
+        await asyncio.sleep(small_delay * 2)  # let both tasks settle
+
+    # generate_reply should only have been called once (by the second task).
+    mock_session.generate_reply.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_participant_wait_timeout_continues_with_defaults(configured_settings: None) -> None:
+    """If wait_for_participant times out, the worker must continue with agent_config=None
+    rather than hanging, and still call session.start()."""
+    ctx, _ = _make_ctx()
+    ctx.wait_for_participant = AsyncMock(side_effect=asyncio.TimeoutError)
+    mock_session = _make_session_mock()
+    mock_agent = MagicMock()
+
+    with (
+        patch("taskorbit.worker.build_agent_session", return_value=mock_session),
+        patch("taskorbit.worker.build_default_agent", return_value=mock_agent) as mock_build,
+    ):
+        await entrypoint(ctx)
+
+    assert mock_build.call_args.kwargs.get("agent_config") is None
+    mock_session.start.assert_awaited_once()

--- a/backend/tests/test_worker.py
+++ b/backend/tests/test_worker.py
@@ -603,7 +603,6 @@ async def test_entrypoint_falls_back_when_metadata_malformed(configured_settings
     assert mock_build.call_args.kwargs.get("agent_config") is None
 
 
-
 @pytest.mark.asyncio
 async def test_commit_turn_cancels_stale_task(configured_settings: None) -> None:
     """A second commit_turn arriving before the first completes must cancel the

--- a/backend/tests/test_worker.py
+++ b/backend/tests/test_worker.py
@@ -603,39 +603,6 @@ async def test_entrypoint_falls_back_when_metadata_malformed(configured_settings
     assert mock_build.call_args.kwargs.get("agent_config") is None
 
 
-@pytest.mark.asyncio
-async def test_session_aclose_called_on_exit(configured_settings: None) -> None:
-    """session.aclose() must always be called when the entrypoint exits."""
-    ctx, _ = _make_ctx()
-    mock_session = _make_session_mock()
-    mock_agent = MagicMock()
-
-    with (
-        patch("taskorbit.worker.build_agent_session", return_value=mock_session),
-        patch("taskorbit.worker.build_default_agent", return_value=mock_agent),
-    ):
-        await entrypoint(ctx)
-
-    mock_session.aclose.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_session_aclose_called_even_on_start_failure(configured_settings: None) -> None:
-    """session.aclose() must still be called if session.start() raises."""
-    ctx, _ = _make_ctx()
-    mock_session = _make_session_mock()
-    mock_session.start = AsyncMock(side_effect=RuntimeError("room gone"))
-    mock_agent = MagicMock()
-
-    with (
-        patch("taskorbit.worker.build_agent_session", return_value=mock_session),
-        patch("taskorbit.worker.build_default_agent", return_value=mock_agent),
-    ):
-        with pytest.raises(RuntimeError, match="room gone"):
-            await entrypoint(ctx)
-
-    mock_session.aclose.assert_awaited_once()
-
 
 @pytest.mark.asyncio
 async def test_commit_turn_cancels_stale_task(configured_settings: None) -> None:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -19,5 +19,8 @@ VITE_APP_NAME=TaskOrbit
 
 # Maximum LiveKit session duration in minutes (default: 30).
 # The session is closed and the user is returned to the landing page after this duration.
-# The inactivity timeout (7 min of no speech) is separate and not affected by this variable.
 VITE_SESSION_MAX_MINUTES=30
+
+# Inactivity timeout in minutes (default: 7).
+# The session is closed if no speech is detected (no recording/thinking/speaking phase) for this duration.
+VITE_INACTIVITY_TIMEOUT_MINUTES=7

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -16,3 +16,8 @@ VITE_LIVEKIT_URL=wss://your-project.livekit.cloud
 
 # Application name (used in window title and headings)
 VITE_APP_NAME=TaskOrbit
+
+# Maximum LiveKit session duration in minutes (default: 30).
+# The session is closed and the user is returned to the landing page after this duration.
+# The inactivity timeout (7 min of no speech) is separate and not affected by this variable.
+VITE_SESSION_MAX_MINUTES=30

--- a/frontend/src/components/ConversationalChat.tsx
+++ b/frontend/src/components/ConversationalChat.tsx
@@ -20,6 +20,22 @@ import { sendMessage, getConversations } from "@/lib/conversationApi";
 import { playSynthesizedSpeech } from "@/lib/ttsApi";
 import type { ConfirmationPromptState } from "@/types/callState";
 
+function SessionEndedBanner({ message, onDismiss }: { message: string; onDismiss: () => void }) {
+  useEffect(() => {
+    const id = window.setTimeout(onDismiss, 5_000);
+    return () => window.clearTimeout(id);
+  }, [onDismiss]);
+
+  return (
+    <div
+      role="status"
+      className="fixed bottom-4 left-1/2 -translate-x-1/2 rounded-lg border border-amber-500 bg-amber-50 px-4 py-3 text-sm text-amber-800 shadow-md dark:bg-amber-950 dark:text-amber-200"
+    >
+      {message}
+    </div>
+  );
+}
+
 const mockConfirmationPrompt: ConfirmationPromptState = {
   id: "demo-confirmation",
   tool_name: "collect_user_info",
@@ -394,6 +410,13 @@ export function ConversationalChat() {
         >
           {call.micError}
         </div>
+      )}
+
+      {call.sessionEndReason !== null && (
+        <SessionEndedBanner
+          message={call.sessionEndReason}
+          onDismiss={call.clearSessionEndReason}
+        />
       )}
     </main>
   );

--- a/frontend/src/hooks/useVoiceCall.ts
+++ b/frontend/src/hooks/useVoiceCall.ts
@@ -69,7 +69,8 @@ export type VoiceCallApi = {
 };
 
 const CONNECTING_TIMEOUT_MS = 800;
-const INACTIVITY_TIMEOUT_MS = 7 * 60 * 1000;
+const INACTIVITY_TIMEOUT_MS =
+  Number(import.meta.env.VITE_INACTIVITY_TIMEOUT_MINUTES ?? 7) * 60 * 1000;
 const SESSION_MAX_MS = Number(import.meta.env.VITE_SESSION_MAX_MINUTES ?? 30) * 60 * 1000;
 
 function generateConversationId(): string {

--- a/frontend/src/hooks/useVoiceCall.ts
+++ b/frontend/src/hooks/useVoiceCall.ts
@@ -32,6 +32,8 @@ export type VoiceCallApi = {
   conversationId: string;
   livekitCredentials: LiveKitCredentials | null;
   micError: string | null;
+  sessionEndReason: string | null;
+  clearSessionEndReason: () => void;
 
   /** Begin a new call: fetch token, transition to `connecting`. */
   start: (options?: VoiceCallStartOptions) => void;
@@ -67,6 +69,8 @@ export type VoiceCallApi = {
 };
 
 const CONNECTING_TIMEOUT_MS = 800;
+const INACTIVITY_TIMEOUT_MS = 7 * 60 * 1000;
+const SESSION_MAX_MS = Number(import.meta.env.VITE_SESSION_MAX_MINUTES ?? 30) * 60 * 1000;
 
 function generateConversationId(): string {
   return `conv-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -86,8 +90,11 @@ export function useVoiceCall(): VoiceCallApi {
   const [conversationId, setConversationId] = useState<string>("");
   const [livekitCredentials, setLivekitCredentials] = useState<LiveKitCredentials | null>(null);
   const [micError, setMicError] = useState<string | null>(null);
+  const [sessionEndReason, setSessionEndReason] = useState<string | null>(null);
 
   const timerRef = useRef<number | null>(null);
+  const sessionTimerRef = useRef<number | null>(null);
+  const inactivityTimerRef = useRef<number | null>(null);
   const statusRef = useRef<CallStatus>(status);
   const abortRef = useRef<AbortController | null>(null);
 
@@ -98,6 +105,8 @@ export function useVoiceCall(): VoiceCallApi {
   useEffect(() => {
     return () => {
       if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+      if (sessionTimerRef.current !== null) window.clearTimeout(sessionTimerRef.current);
+      if (inactivityTimerRef.current !== null) window.clearTimeout(inactivityTimerRef.current);
       abortRef.current?.abort();
     };
   }, []);
@@ -108,6 +117,36 @@ export function useVoiceCall(): VoiceCallApi {
       timerRef.current = null;
     }
   }, []);
+
+  const clearSessionTimers = useCallback(() => {
+    if (sessionTimerRef.current !== null) {
+      window.clearTimeout(sessionTimerRef.current);
+      sessionTimerRef.current = null;
+    }
+    if (inactivityTimerRef.current !== null) {
+      window.clearTimeout(inactivityTimerRef.current);
+      inactivityTimerRef.current = null;
+    }
+  }, []);
+
+  const clearSessionEndReason = useCallback(() => setSessionEndReason(null), []);
+
+  // Inline restart body to avoid a circular dependency between restart ↔ handleSessionTimeout.
+  const handleSessionTimeout = useCallback(
+    (reason: string) => {
+      clearTimer();
+      clearSessionTimers();
+      abortRef.current?.abort();
+      setSessionEndReason(reason);
+      setTranscript([]);
+      setConversationId("");
+      setConfirmation(null);
+      setLivekitCredentials(null);
+      setMicError(null);
+      setStatus("idle");
+    },
+    [clearTimer, clearSessionTimers],
+  );
 
   const appendUserTurn = useCallback((text: string) => {
     setTranscript((t) => [...t, { id: generateId("u"), role: "user", text }]);
@@ -171,6 +210,7 @@ export function useVoiceCall(): VoiceCallApi {
   const start = useCallback(
     (options?: VoiceCallStartOptions) => {
       clearTimer();
+      clearSessionTimers();
       abortRef.current?.abort();
 
       const newConvId = generateConversationId();
@@ -181,6 +221,7 @@ export function useVoiceCall(): VoiceCallApi {
       setConfirmation(null);
       setLivekitCredentials(null);
       setMicError(null);
+      setSessionEndReason(null);
       setStatus("connecting");
 
       const controller = new AbortController();
@@ -207,20 +248,32 @@ export function useVoiceCall(): VoiceCallApi {
         if (statusRef.current !== "connecting") return;
         setStatus("idle_in_call");
       }, CONNECTING_TIMEOUT_MS);
+
+      sessionTimerRef.current = window.setTimeout(() => {
+        handleSessionTimeout("Session time limit reached. Your session has been closed.");
+      }, SESSION_MAX_MS);
+
+      inactivityTimerRef.current = window.setTimeout(() => {
+        handleSessionTimeout(
+          "Session closed due to inactivity (no speech detected for 7 minutes).",
+        );
+      }, INACTIVITY_TIMEOUT_MS);
     },
-    [clearTimer],
+    [clearTimer, clearSessionTimers, handleSessionTimeout],
   );
 
   const end = useCallback(() => {
     clearTimer();
+    clearSessionTimers();
     abortRef.current?.abort();
     setConfirmation(null);
     setLivekitCredentials(null);
     setStatus("ended");
-  }, [clearTimer]);
+  }, [clearTimer, clearSessionTimers]);
 
   const restart = useCallback(() => {
     clearTimer();
+    clearSessionTimers();
     abortRef.current?.abort();
     setTranscript([]);
     setConversationId("");
@@ -228,20 +281,35 @@ export function useVoiceCall(): VoiceCallApi {
     setLivekitCredentials(null);
     setMicError(null);
     setStatus("idle");
-  }, [clearTimer]);
+  }, [clearTimer, clearSessionTimers]);
 
-  const setPhase = useCallback((phase: CallStatus) => {
-    // Don't override idle/ended/awaiting_confirmation from inside the room —
-    // those are owned by the lifecycle layer.
-    if (
-      statusRef.current === "idle" ||
-      statusRef.current === "ended" ||
-      statusRef.current === "awaiting_confirmation"
-    ) {
-      return;
-    }
-    setStatus(phase);
-  }, []);
+  const setPhase = useCallback(
+    (phase: CallStatus) => {
+      // Don't override idle/ended/awaiting_confirmation from inside the room —
+      // those are owned by the lifecycle layer.
+      if (
+        statusRef.current === "idle" ||
+        statusRef.current === "ended" ||
+        statusRef.current === "awaiting_confirmation"
+      ) {
+        return;
+      }
+      // Any active phase (user speaking, agent thinking/speaking) resets the
+      // inactivity countdown so silence-only periods are what trigger the timeout.
+      if (phase === "recording" || phase === "thinking" || phase === "speaking") {
+        if (inactivityTimerRef.current !== null) {
+          window.clearTimeout(inactivityTimerRef.current);
+        }
+        inactivityTimerRef.current = window.setTimeout(() => {
+          handleSessionTimeout(
+            "Session closed due to inactivity (no speech detected for 7 minutes).",
+          );
+        }, INACTIVITY_TIMEOUT_MS);
+      }
+      setStatus(phase);
+    },
+    [handleSessionTimeout],
+  );
 
   const triggerConfirmation = useCallback(
     (prompt: ConfirmationPromptState) => {
@@ -277,6 +345,8 @@ export function useVoiceCall(): VoiceCallApi {
     conversationId,
     livekitCredentials,
     micError,
+    sessionEndReason,
+    clearSessionEndReason,
     start,
     end,
     restart,

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -154,6 +154,9 @@ module "cloud_run" {
   cors_allow_origins = var.cors_allow_origins
   api_url_override   = var.api_url_override
 
+  session_max_minutes        = var.session_max_minutes
+  inactivity_timeout_minutes = var.inactivity_timeout_minutes
+
   depends_on = [module.iam, module.secrets, module.database, module.network]
 }
 

--- a/terraform/modules/cloud_run/main.tf
+++ b/terraform/modules/cloud_run/main.tf
@@ -343,6 +343,16 @@ resource "google_cloud_run_v2_service" "frontend" {
         value = var.api_url_override != "" ? var.api_url_override : google_cloud_run_v2_service.backend.uri
       }
 
+      env {
+        name  = "VITE_SESSION_MAX_MINUTES"
+        value = tostring(var.session_max_minutes)
+      }
+
+      env {
+        name  = "VITE_INACTIVITY_TIMEOUT_MINUTES"
+        value = tostring(var.inactivity_timeout_minutes)
+      }
+
       resources {
         limits = {
           cpu    = "1"

--- a/terraform/modules/cloud_run/variables.tf
+++ b/terraform/modules/cloud_run/variables.tf
@@ -57,3 +57,15 @@ variable "api_url_override" {
   type        = string
   default     = ""
 }
+
+variable "session_max_minutes" {
+  description = "Maximum LiveKit session duration in minutes. Maps to VITE_SESSION_MAX_MINUTES in the frontend bundle."
+  type        = number
+  default     = 30
+}
+
+variable "inactivity_timeout_minutes" {
+  description = "Minutes of silence before the session is auto-closed. Maps to VITE_INACTIVITY_TIMEOUT_MINUTES in the frontend bundle."
+  type        = number
+  default     = 7
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -49,6 +49,10 @@ cors_allow_origins = "https://taskorbit.example.com"
 # Leave empty when using a real domain (uses https://api.<domain> instead).
 # api_url_override = "https://taskorbit-backend-<hash>-ew.a.run.app"
 
+# Session time limits — override defaults if needed.
+# session_max_minutes        = 30  # hard wall-clock limit per call (default: 30)
+# inactivity_timeout_minutes = 7   # silence timeout — no speech for N min closes the session (default: 7)
+
 # ── GitHub (Workload Identity) ────────────────────────────────────────────────
 github_repository = "amosproj/amos2026ss04-taskorbit-conversational-agent"
 


### PR DESCRIPTION
## Summary

Implements automatic session termination for LiveKit voice calls with two independent configurable timeouts. When either limit is reached the session is closed cleanly, the user sees an informational banner, and is returned to the landing page without any manual action required.

---

## What was implemented

### Frontend — `useVoiceCall.ts`

Two independent client-side timers now run for every call:

| Timer | Env var | Default | Resets on |
|---|---|---|---|
| Session max | `VITE_SESSION_MAX_MINUTES` | 30 min | Never |
| Inactivity | `VITE_INACTIVITY_TIMEOUT_MINUTES` | 7 min | `recording` / `thinking` / `speaking` phase |

On either expiry:
- `sessionEndReason` is set (message explaining why the session ended)
- `livekitCredentials` is cleared → `<LiveKitRoom>` unmounts → room disconnects, worker exits normally
- `status` returns to `idle` (landing page)
- Both timers are also cleared in `end()`, `restart()`, and unmount cleanup to prevent ghost timeouts after manual hang-ups

### Frontend — `ConversationalChat.tsx`

Added `SessionEndedBanner` — an amber fixed notification that renders when `sessionEndReason` is set and auto-dismisses after 5 s. Visually distinct from the red microphone-error banner.

### Terraform

Both timeout values are now configurable per environment via Terraform:
- `session_max_minutes` (default 30)
- `inactivity_timeout_minutes` (default 7)

Injected as `VITE_SESSION_MAX_MINUTES` / `VITE_INACTIVITY_TIMEOUT_MINUTES` env vars on the frontend Cloud Run service.

> **Note:** Vite bakes env vars into the JS bundle at build time. These values must be available during the Docker build step (via `ARG`/`ENV` in the frontend `Dockerfile`) — setting them only as Cloud Run runtime vars is not sufficient if the image is pre-built in CI.

### CI/CD fix

Consolidated `deploy.yml` triggers: was listening to all three CI workflows (`Backend Linting`, `Frontend Linting`, `Start Web Service`) causing three simultaneous deploy runs that cancelled each other. Now listens only to `Start Web Service`. Removed the duplicate `push: branches: [prod]` trigger. `workflow_dispatch` retained for manual re-deploys.

### Terraform — auto-shutdown default

Changed `enable_auto_shutdown` default from `true` → `false` to prevent unexpected Cloud SQL shutdowns on fresh deploys.

---

## Files changed

| File | Change |
|---|---|
| `frontend/src/hooks/useVoiceCall.ts` | Session/inactivity timers, `sessionEndReason` state, `clearSessionEndReason` |
| `frontend/src/components/ConversationalChat.tsx` | `SessionEndedBanner` component |
| `frontend/.env.example` | `VITE_SESSION_MAX_MINUTES`, `VITE_INACTIVITY_TIMEOUT_MINUTES` |
| `terraform/modules/cloud_run/variables.tf` | `session_max_minutes`, `inactivity_timeout_minutes` |
| `terraform/modules/cloud_run/main.tf` | Env var injection into frontend Cloud Run |
| `terraform/variables.tf` | Root variable declarations + auto-shutdown default fix |
| `terraform/main.tf` | Wires new vars to cloud_run module |
| `terraform/terraform.tfvars.example` | Commented-out overrides with descriptions |
| `.github/workflows/deploy.yml` | Single-workflow trigger consolidation |

---

## Testing checklist

- [x] Start a call — wait `VITE_INACTIVITY_TIMEOUT_MINUTES` without speaking → amber banner appears, session returns to landing page
- [x] Start a call — speak → verify inactivity timer resets (no premature closure)
- [x] Set `VITE_SESSION_MAX_MINUTES=1` in `.env.local` → session closes after ~1 min regardless of activity
- [x] Manual hang-up clears both timers — no banner after ending the call yourself
- [x] `terraform plan` shows no unexpected changes with default values
- [x] Deploy pipeline triggers exactly once on a push to `prod`