### PR TITLE
fix(#99): align LLM provider/model handling across text and voice

### DIFF
--- a/backend/src/taskorbit/integrations/llm/factory.py
+++ b/backend/src/taskorbit/integrations/llm/factory.py
@@ -13,6 +13,27 @@ from taskorbit.types import LLMConfig, LLMProvider
 from .base import LLMClient
 from .errors import LLMConfigError
 
+# A mismatched provider/model pair (ticket #99) used to reach the concrete
+# client untouched — a Gemini client handed an OpenAI model returns 404 mid
+# voice turn. Fail fast here with a clear error instead. Prefix-based on
+# purpose: it only rejects names that unambiguously belong elsewhere and
+# leaves anything it doesn't recognise to the provider to validate.
+_PROVIDER_MODEL_PREFIXES = {
+    LLMProvider.OPENAI: "gpt-",
+    LLMProvider.GOOGLE: "gemini-",
+}
+
+
+def _guard_provider_model_match(llm_config: LLMConfig) -> None:
+    model = llm_config.model.lower()
+    for provider, prefix in _PROVIDER_MODEL_PREFIXES.items():
+        if model.startswith(prefix) and llm_config.provider != provider:
+            raise LLMConfigError(
+                f"Model {llm_config.model!r} belongs to provider "
+                f"{provider.value!r}, not the selected provider "
+                f"{llm_config.provider.value!r}"
+            )
+
 
 def get_llm_client(
     llm_config: LLMConfig,
@@ -42,6 +63,8 @@ def get_llm_client(
     """
     if settings is None:
         settings = get_settings()
+
+    _guard_provider_model_match(llm_config)
 
     if llm_config.provider == LLMProvider.OPENAI:
         if not settings.openai_api_key:

--- a/backend/tests/test_llm_factory.py
+++ b/backend/tests/test_llm_factory.py
@@ -2,7 +2,7 @@ import pytest
 
 from taskorbit.config import Settings
 from taskorbit.integrations.llm.errors import LLMConfigError
-from taskorbit.integrations.llm.factory import get_llm_client
+from taskorbit.integrations.llm.factory import _guard_provider_model_match, get_llm_client
 from taskorbit.integrations.llm.gemini_client import GeminiClient
 from taskorbit.integrations.llm.openai_client import OpenAIClient
 from taskorbit.types import LLMConfig, LLMProvider
@@ -20,7 +20,9 @@ def test_missing_openai_key_raises_config_error():
 
 
 def test_missing_google_key_raises_config_error():
-    llm_config = LLMConfig(provider=LLMProvider.GOOGLE)
+    # Explicit Gemini model so the provider/model guard passes and the missing
+    # key is what triggers the error (LLMConfig defaults model to gpt-4o-mini).
+    llm_config = LLMConfig(provider=LLMProvider.GOOGLE, model="gemini-2.5-flash")
     settings = Settings(openai_api_key="anything", google_api_key="")
     with pytest.raises(LLMConfigError, match="GOOGLE_API_KEY"):
         get_llm_client(llm_config, settings=settings)
@@ -39,7 +41,34 @@ def test_openai_provider_returns_openai_client():
 
 
 def test_google_provider_returns_gemini_client():
-    llm_config = LLMConfig(provider=LLMProvider.GOOGLE, model="gemini-2.0-flash")
+    llm_config = LLMConfig(provider=LLMProvider.GOOGLE, model="gemini-2.5-flash")
     settings = Settings(openai_api_key="", google_api_key="AIza-test-key")
     client = get_llm_client(llm_config, settings=settings)
     assert isinstance(client, GeminiClient)
+
+
+# ---------------------------------------------------------------------------
+# Provider/model mismatch guard (ticket #99)
+# ---------------------------------------------------------------------------
+
+
+def test_google_provider_with_openai_model_raises_config_error():
+    llm_config = LLMConfig(provider=LLMProvider.GOOGLE, model="gpt-4o-mini")
+    with pytest.raises(LLMConfigError, match="gpt-4o-mini"):
+        _guard_provider_model_match(llm_config)
+
+
+def test_openai_provider_with_gemini_model_raises_config_error():
+    llm_config = LLMConfig(provider=LLMProvider.OPENAI, model="gemini-2.5-flash")
+    with pytest.raises(LLMConfigError, match="gemini-2.5-flash"):
+        _guard_provider_model_match(llm_config)
+
+
+def test_openai_provider_with_openai_model_passes():
+    llm_config = LLMConfig(provider=LLMProvider.OPENAI, model="gpt-4o-mini")
+    _guard_provider_model_match(llm_config)
+
+
+def test_google_provider_with_gemini_model_passes():
+    llm_config = LLMConfig(provider=LLMProvider.GOOGLE, model="gemini-2.5-flash")
+    _guard_provider_model_match(llm_config)

--- a/frontend/src/components/agent-config/PipelineSection.tsx
+++ b/frontend/src/components/agent-config/PipelineSection.tsx
@@ -14,13 +14,22 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-import type { AgentConfig } from "@/types/agentConfig";
+import type { AgentConfig, LlmProvider } from "@/types/agentConfig";
 
 type Value = Pick<AgentConfig, "stt" | "tts" | "llm">;
 
 type Props = {
   value: Value;
   onChange: (next: Value) => void;
+};
+
+// Each LLM provider speaks only its own model names; pairing e.g. gemini with
+// gpt-4o-mini reaches the voice path and 404s mid-call (ticket #99). Switching
+// provider resets the model to that provider's default so a mismatch can't be
+// authored in the first place.
+const LLM_MODEL_DEFAULTS: Record<LlmProvider, string> = {
+  openai: "gpt-4o-mini",
+  gemini: "gemini-2.5-flash",
 };
 
 function StageHeader({ icon: Icon, label }: { icon: LucideIcon; label: string }) {
@@ -96,12 +105,13 @@ export function PipelineSection({ value, onChange }: Props) {
               <FieldLabel>Provider</FieldLabel>
               <Select
                 value={value.llm.provider}
-                onValueChange={(v) =>
+                onValueChange={(v) => {
+                  const provider = v as LlmProvider;
                   onChange({
                     ...value,
-                    llm: { ...value.llm, provider: v as "openai" | "gemini" },
-                  })
-                }
+                    llm: { provider, model: LLM_MODEL_DEFAULTS[provider] },
+                  });
+                }}
               >
                 <SelectTrigger>
                   <SelectValue />

--- a/frontend/src/lib/conversationApi.ts
+++ b/frontend/src/lib/conversationApi.ts
@@ -92,13 +92,16 @@ function adaptTool(tool: FrontendTool): BackendTool {
 }
 
 function adaptAgentConfig(agent: AgentConfig): BackendAgentConfig {
+  // Map FE provider id to backend LLMProvider enum, matching the voice
+  // path in livekitAgentMetadata.ts (backend accepts "openai"/"google").
+  const llmProvider = agent.llm.provider === "gemini" ? "google" : "openai";
   const out: BackendAgentConfig = {
     id: agent.agent_id,
     name: agent.name,
     persona: agent.instructions,
     greeting: agent.first_message.message,
     stt: { provider: agent.stt.provider, language: "multi", model: agent.stt.model },
-    llm: { provider: agent.llm.provider, model: agent.llm.model },
+    llm: { provider: llmProvider, model: agent.llm.model },
     tts: { provider: agent.tts.provider, voice_id: agent.tts.voice_id, model: agent.tts.model },
     tools: agent.tools.map(adaptTool),
   };


### PR DESCRIPTION
Closes #99.

## Problem
Voice sessions defaulted to the wrong persona / blocked answers because the LLM call crashed. Tracing showed the agent config form let users pair an LLM provider with a model from a different provider (e.g. provider=gemini, model=gpt-4o-mini). On the voice path this sent an OpenAI model name to the Gemini API, returning 404 and crashing the turn mid-call.

While fixing this, two further issues surfaced during reproduction:
- Text conversations with Gemini configs returned 422, because the text path sent the frontend provider id "gemini" raw, but the backend LLMProvider enum only accepts "openai"/"google". The voice path already mapped this; the text path did not.
- The default Gemini model gemini-2.0-flash was retired by Google on 2026-06-01 and now returns 404. Moved the default to the current stable gemini-2.5-flash.

## Changes
- **Frontend (PipelineSection.tsx):** switching the LLM provider now resets the model to that provider's default, so a mismatched pair can't be authored.
- **Backend (factory.py):** the LLM factory rejects a model whose name belongs to a different provider, raising LLMConfigError. This fires before any network call and lands in the orchestrator's existing graceful handler, so the agent responds with a configuration message instead of crashing.
- **Frontend (conversationApi.ts):** the text path now maps "gemini" → "google", matching the voice path and fixing the 422.
- **Default model:** gemini-2.5-flash replaces the retired gemini-2.0-flash.

## Testing
- Added unit tests in test_llm_factory.py covering both mismatch directions and both matched pairs.
- Full backend suite: 226 passed.
- Manually verified all four paths work end-to-end: text+OpenAI, text+Gemini, voice+OpenAI, voice+Gemini.

## Note for reviewer
Existing saved configs that still carry gemini-2.0-flash will need re-saving through the UI to pick up the new default. The provider mapping (in both text and voice paths) collapses any non-gemini value to openai — fine for the current two-provider set, but both would need updating if a third provider is added.