### PR TITLE
Feat/user conversation history

### DIFF
--- a/backend/migrations/versions/e5f6a7b8c9d0_add_slot_extractions_table.py
+++ b/backend/migrations/versions/e5f6a7b8c9d0_add_slot_extractions_table.py
@@ -1,0 +1,51 @@
+"""add slot_extractions table
+
+Revision ID: e5f6a7b8c9d0
+Revises: c3d4e5f6a7b8
+Create Date: 2026-06-05
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e5f6a7b8c9d0"
+down_revision: str | Sequence[str] | None = "c3d4e5f6a7b8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "slot_extractions",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("conversation_id", sa.String(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=True),
+        sa.Column("tool_id", sa.String(), nullable=False),
+        sa.Column("field_name", sa.String(), nullable=False),
+        sa.Column("field_value", sa.String(), nullable=True),
+        sa.Column(
+            "extracted_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["conversation_id"], ["conversations.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_slot_extractions_conversation_id",
+        "slot_extractions",
+        ["conversation_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_slot_extractions_conversation_id", table_name="slot_extractions")
+    op.drop_table("slot_extractions")

--- a/backend/src/taskorbit/api/routes/conversations.py
+++ b/backend/src/taskorbit/api/routes/conversations.py
@@ -9,13 +9,19 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from taskorbit.api.deps import get_current_user_id
 from taskorbit.config import Settings, get_settings
 from taskorbit.database import get_session
 from taskorbit.database.crud import (
+    create_conversation,
     create_conversation_message,
+    create_slot_extractions,
+    create_tool_execution,
+    get_conversation,
+    get_conversation_history,
     get_messages_by_conversation,
 )
-from taskorbit.database.models import Conversation
+from taskorbit.database.models import Conversation  # used in POST "" route
 from taskorbit.logging.setup import get_logger
 from taskorbit.orchestration import ConversationOrchestrator
 from taskorbit.types import ConversationRequest, ConversationResponse, MessageRole
@@ -36,53 +42,84 @@ async def process_conversation(
     request: ConversationRequest,
     orchestrator: ConversationOrchestrator = Depends(get_orchestrator),  # noqa: B008
     db: AsyncSession = Depends(get_session),  # noqa: B008
+    user_id: int = Depends(get_current_user_id),  # noqa: B008
 ) -> ConversationResponse:
     """Process one turn of a conversation through the TaskOrbit orchestration engine and persist messages."""
+    # Auto-create conversation when absent or unknown so the frontend never
+    # needs to call POST /v1/conversations explicitly before the first message.
+    conversation_id = request.conversation_id
+    if not conversation_id or not await get_conversation(db, conversation_id):
+        conv = await create_conversation(
+            db=db,
+            agent_id=request.agent_config.id,
+            agent_name=request.agent_config.name,
+        )
+        if conv is None:
+            raise HTTPException(status_code=500, detail="Failed to create conversation")
+        conversation_id = conv.id
+        request = request.model_copy(update={"conversation_id": conversation_id})
+        logger.info("conversation_auto_created", conversation_id=conversation_id)
+
     logger.info(
         "conversation_request_received",
-        conversation_id=request.conversation_id,
+        conversation_id=conversation_id,
         message_count=len(request.messages),
     )
     try:
         response = await orchestrator.process_message(request)
 
-        # Save user message (only the last message if it's from user)
+        # Save user message (last message in the list if sent by user)
         last_msg = request.messages[-1] if request.messages else None
         last_user = last_msg if last_msg and last_msg.role == MessageRole.USER else None
 
         if last_user:
-            result = await db.execute(
-                select(Conversation).where(Conversation.id == request.conversation_id)
-            )
-            conversation = result.scalar_one_or_none()
-            if not conversation:
-                logger.warning("conversation_not_found", conversation_id=request.conversation_id)
-
             saved = await create_conversation_message(
                 db=db,
-                conversation_id=request.conversation_id,
+                conversation_id=conversation_id,
                 role=last_user.role.value,
                 content=last_user.content,
+                user_id=user_id,
             )
             if saved is None:
-                logger.error("failed_to_save_user_message", conversation_id=request.conversation_id)
+                logger.error("failed_to_save_user_message", conversation_id=conversation_id)
 
         # Save assistant reply
         if response.reply:
             saved = await create_conversation_message(
                 db=db,
-                conversation_id=request.conversation_id,
+                conversation_id=conversation_id,
                 role=response.reply.role.value,
                 content=response.reply.content,
             )
             if saved is None:
-                logger.error(
-                    "failed_to_save_assistant_message", conversation_id=request.conversation_id
-                )
+                logger.error("failed_to_save_assistant_message", conversation_id=conversation_id)
+
+        # Persist slot extractions with tool attribution for history transparency
+        if response.extracted_slots:
+            tool_id = response.tool_invoked.id if response.tool_invoked else "orchestrator"
+            await create_slot_extractions(
+                db=db,
+                conversation_id=conversation_id,
+                tool_id=tool_id,
+                slots=response.extracted_slots,
+                user_id=user_id,
+            )
+
+        # Record tool invocation so the history endpoint can surface it
+        if response.tool_invoked:
+            await create_tool_execution(
+                db=db,
+                conversation_id=conversation_id,
+                tool_id=response.tool_invoked.id,
+                tool_type=response.tool_invoked.type.value,
+                result={"extracted_slots": response.extracted_slots}
+                if response.extracted_slots
+                else None,
+            )
 
         logger.info(
             "conversation_request_completed",
-            conversation_id=request.conversation_id,
+            conversation_id=conversation_id,
             intent=response.selected_intent,
             status=response.status,
         )
@@ -91,7 +128,7 @@ async def process_conversation(
     except NotImplementedError as exc:
         logger.warning(
             "orchestration_not_implemented",
-            conversation_id=request.conversation_id,
+            conversation_id=conversation_id,
         )
         raise HTTPException(
             status_code=501, detail="Orchestration engine not yet implemented."
@@ -99,7 +136,7 @@ async def process_conversation(
 
 
 @router.post("", status_code=201)
-async def create_conversation(
+async def create_bare_conversation(
     db: AsyncSession = Depends(get_session),  # noqa: B008
 ) -> dict:
     """Create a new conversation."""
@@ -143,6 +180,18 @@ async def get_conversations(
     except Exception as e:
         logger.error("get_conversations_failed", error=str(e))
         raise HTTPException(status_code=500, detail="Failed to retrieve conversations") from e
+
+
+@router.get("/{conversation_id}/history")
+async def get_history(
+    conversation_id: str,
+    db: AsyncSession = Depends(get_session),  # noqa: B008
+) -> dict:
+    """Return a conversation with all messages, tool executions, and slot extractions."""
+    history = await get_conversation_history(db=db, conversation_id=conversation_id)
+    if history is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    return history
 
 
 @router.get("/{conversation_id}/messages")

--- a/backend/src/taskorbit/database/crud.py
+++ b/backend/src/taskorbit/database/crud.py
@@ -142,11 +142,11 @@ async def get_conversation(db: AsyncSession, conversation_id: str) -> Conversati
 
 
 async def create_conversation(
-    db: AsyncSession, agent_id: str, agent_name: str
+    db: AsyncSession, agent_id: str, agent_name: str, id: str | None = None
 ) -> Conversation | None:
     try:
         conversation = Conversation(
-            id=str(uuid4()),
+            id=id or str(uuid4()),
             agent_id=agent_id,
             agent_name=agent_name,
             started_at=datetime.now(UTC),

--- a/backend/src/taskorbit/database/crud.py
+++ b/backend/src/taskorbit/database/crud.py
@@ -1,6 +1,6 @@
 """CRUD operations for database models."""
 
-from datetime import datetime
+from datetime import UTC, datetime
 from uuid import uuid4
 
 from sqlalchemy import select
@@ -10,7 +10,15 @@ from sqlalchemy.orm import Session
 
 from taskorbit.logging.setup import get_logger
 
-from .models import AgentConfiguration, ConversationMessage, DefaultAgentTemplate, User
+from .models import (
+    AgentConfiguration,
+    Conversation,
+    ConversationMessage,
+    DefaultAgentTemplate,
+    SlotExtraction,
+    ToolExecution,
+    User,
+)
 
 logger = get_logger(__name__)
 
@@ -119,6 +127,206 @@ async def delete_user(db: AsyncSession, user_id: int) -> bool:
         logger.error("delete_user_failed", error=str(e))
         await db.rollback()
         return False
+
+
+# ============ CONVERSATION CRUD ============
+
+
+async def get_conversation(db: AsyncSession, conversation_id: str) -> Conversation | None:
+    try:
+        result = await db.execute(select(Conversation).where(Conversation.id == conversation_id))
+        return result.scalar_one_or_none()
+    except SQLAlchemyError as e:
+        logger.error("get_conversation_failed", error=str(e))
+        return None
+
+
+async def create_conversation(
+    db: AsyncSession, agent_id: str, agent_name: str
+) -> Conversation | None:
+    try:
+        conversation = Conversation(
+            id=str(uuid4()),
+            agent_id=agent_id,
+            agent_name=agent_name,
+            started_at=datetime.now(UTC),
+        )
+        db.add(conversation)
+        await db.commit()
+        await db.refresh(conversation)
+        logger.info("conversation_created", conversation_id=conversation.id)
+        return conversation
+    except SQLAlchemyError as e:
+        logger.error("create_conversation_failed", error=str(e))
+        await db.rollback()
+        return None
+
+
+# ============ SLOT EXTRACTION CRUD ============
+
+
+async def create_slot_extractions(
+    db: AsyncSession,
+    conversation_id: str,
+    tool_id: str,
+    slots: dict,
+    user_id: int | None = None,
+) -> list[SlotExtraction]:
+    """Bulk-insert one row per extracted field, recording which tool extracted it."""
+    if not slots:
+        return []
+    try:
+        extractions = [
+            SlotExtraction(
+                conversation_id=conversation_id,
+                user_id=user_id,
+                tool_id=tool_id,
+                field_name=str(name),
+                field_value=str(value) if value is not None else None,
+            )
+            for name, value in slots.items()
+        ]
+        db.add_all(extractions)
+        await db.commit()
+        for extraction in extractions:
+            await db.refresh(extraction)
+        logger.info(
+            "slot_extractions_saved",
+            conversation_id=conversation_id,
+            tool_id=tool_id,
+            count=len(extractions),
+        )
+        return extractions
+    except SQLAlchemyError as e:
+        logger.error("create_slot_extractions_failed", error=str(e))
+        await db.rollback()
+        return []
+
+
+async def get_slot_extractions(db: AsyncSession, conversation_id: str) -> list[SlotExtraction]:
+    """Return all slot extractions for a conversation ordered by extraction time."""
+    try:
+        result = await db.execute(
+            select(SlotExtraction)
+            .where(SlotExtraction.conversation_id == conversation_id)
+            .order_by(SlotExtraction.extracted_at.asc())
+        )
+        return list(result.scalars().all())
+    except SQLAlchemyError as e:
+        logger.error("get_slot_extractions_failed", error=str(e))
+        return []
+
+
+# ============ CONVERSATION HISTORY ============
+
+
+async def get_conversation_history(db: AsyncSession, conversation_id: str) -> dict | None:
+    """Return a conversation with its messages, tool executions, and slot extractions.
+
+    Returns None when the conversation does not exist.
+    """
+    try:
+        conv = await get_conversation(db, conversation_id)
+        if conv is None:
+            return None
+
+        messages_result = await db.execute(
+            select(ConversationMessage)
+            .where(ConversationMessage.conversation_id == conversation_id)
+            .order_by(ConversationMessage.created_at.asc())
+        )
+        messages = list(messages_result.scalars().all())
+
+        tools_result = await db.execute(
+            select(ToolExecution)
+            .where(ToolExecution.conversation_id == conversation_id)
+            .order_by(ToolExecution.executed_at.asc())
+        )
+        tool_executions = list(tools_result.scalars().all())
+
+        slots_result = await db.execute(
+            select(SlotExtraction)
+            .where(SlotExtraction.conversation_id == conversation_id)
+            .order_by(SlotExtraction.extracted_at.asc())
+        )
+        slot_extractions = list(slots_result.scalars().all())
+
+        return {
+            "conversation_id": conv.id,
+            "agent_id": conv.agent_id,
+            "agent_name": conv.agent_name,
+            "started_at": conv.started_at.isoformat() if conv.started_at else None,
+            "ended_at": conv.ended_at.isoformat() if conv.ended_at else None,
+            "messages": [
+                {
+                    "id": m.id,
+                    "role": m.role,
+                    "content": m.content,
+                    "created_at": m.created_at.isoformat() if m.created_at else None,
+                }
+                for m in messages
+            ],
+            "tool_executions": [
+                {
+                    "id": t.id,
+                    "tool_id": t.tool_id,
+                    "tool_type": t.tool_type,
+                    "confirmed": t.confirmed,
+                    "executed_at": t.executed_at.isoformat() if t.executed_at else None,
+                    "result": t.result,
+                }
+                for t in tool_executions
+            ],
+            "slot_extractions": [
+                {
+                    "id": s.id,
+                    "tool_id": s.tool_id,
+                    "field_name": s.field_name,
+                    "field_value": s.field_value,
+                    "extracted_at": s.extracted_at.isoformat() if s.extracted_at else None,
+                }
+                for s in slot_extractions
+            ],
+        }
+    except SQLAlchemyError as e:
+        logger.error(
+            "get_conversation_history_failed", conversation_id=conversation_id, error=str(e)
+        )
+        return None
+
+
+# ============ TOOL EXECUTION CRUD ============
+
+
+async def create_tool_execution(
+    db: AsyncSession,
+    conversation_id: str,
+    tool_id: str,
+    tool_type: str,
+    result: dict | None = None,
+) -> ToolExecution | None:
+    """Record a tool invocation for the conversation history."""
+    try:
+        execution = ToolExecution(
+            conversation_id=conversation_id,
+            tool_id=tool_id,
+            tool_type=tool_type,
+            result=result,
+        )
+        db.add(execution)
+        await db.commit()
+        await db.refresh(execution)
+        logger.info(
+            "tool_execution_saved",
+            conversation_id=conversation_id,
+            tool_id=tool_id,
+            tool_type=tool_type,
+        )
+        return execution
+    except SQLAlchemyError as e:
+        logger.error("create_tool_execution_failed", error=str(e))
+        await db.rollback()
+        return None
 
 
 # ============ CONVERSATION MESSAGE CRUD ============

--- a/backend/src/taskorbit/database/models.py
+++ b/backend/src/taskorbit/database/models.py
@@ -28,6 +28,9 @@ class Conversation(Base):
     tool_executions: Mapped[list[ToolExecution]] = relationship(
         back_populates="conversation", cascade="all, delete-orphan"
     )
+    slot_extractions: Mapped[list[SlotExtraction]] = relationship(
+        back_populates="conversation", cascade="all, delete-orphan"
+    )
 
 
 class ConversationMessage(Base):
@@ -120,3 +123,29 @@ class DefaultAgentTemplate(Base):
     config: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
+class SlotExtraction(Base):
+    """One row per extracted field per conversation turn.
+
+    tool_id records which tool triggered the extraction (e.g. "data_extraction",
+    "agent_transfer") so the frontend can show provenance per field.
+    """
+
+    __tablename__ = "slot_extractions"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    conversation_id: Mapped[str] = mapped_column(
+        String, ForeignKey("conversations.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    user_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    tool_id: Mapped[str] = mapped_column(String, nullable=False)
+    field_name: Mapped[str] = mapped_column(String, nullable=False)
+    field_value: Mapped[str | None] = mapped_column(String, nullable=True)
+    extracted_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+    conversation: Mapped[Conversation] = relationship(back_populates="slot_extractions")

--- a/backend/src/taskorbit/livekit_agent/llm.py
+++ b/backend/src/taskorbit/livekit_agent/llm.py
@@ -21,6 +21,14 @@ from typing import Any
 
 from livekit.agents import Agent, FunctionTool, ModelSettings, llm
 
+from taskorbit.database import AsyncSessionLocal
+from taskorbit.database.crud import (
+    create_conversation,
+    create_conversation_message,
+    create_slot_extractions,
+    create_tool_execution,
+    get_conversation,
+)
 from taskorbit.logging.setup import get_logger
 from taskorbit.observability.metrics import get_metrics
 from taskorbit.orchestration import ConversationOrchestrator
@@ -234,6 +242,60 @@ class OrchestratorAgent(Agent):
         self._locked_intent_name = response.locked_intent_name
         if response.selected_agent:
             self._current_routed_agent = response.selected_agent
+
+        # Persist the voice turn to the database so conversation history is
+        # available regardless of whether the user interacted via text or voice.
+        try:
+            async with AsyncSessionLocal() as db:
+                conv_id = self._conversation_id
+                if not await get_conversation(db, conv_id):
+                    conv = await create_conversation(
+                        db,
+                        agent_id=self._agent_config.id,
+                        agent_name=self._agent_config.name,
+                    )
+                    if conv:
+                        conv_id = conv.id
+                        self._conversation_id = conv_id
+                if last_user:
+                    await create_conversation_message(
+                        db,
+                        conversation_id=conv_id,
+                        role=last_user.role.value,
+                        content=last_user.content,
+                    )
+                if response.reply:
+                    await create_conversation_message(
+                        db,
+                        conversation_id=conv_id,
+                        role=response.reply.role.value,
+                        content=response.reply.content,
+                    )
+                if response.extracted_slots:
+                    tool_id = response.tool_invoked.id if response.tool_invoked else "orchestrator"
+                    await create_slot_extractions(
+                        db,
+                        conversation_id=conv_id,
+                        tool_id=tool_id,
+                        slots=response.extracted_slots,
+                    )
+                if response.tool_invoked:
+                    await create_tool_execution(
+                        db,
+                        conversation_id=conv_id,
+                        tool_id=response.tool_invoked.id,
+                        tool_type=response.tool_invoked.type.value,
+                        result={"extracted_slots": response.extracted_slots}
+                        if response.extracted_slots
+                        else None,
+                    )
+        except Exception as exc:
+            log.error(
+                "voice_turn_db_persist_failed",
+                error=str(exc),
+                conversation_id=self._conversation_id,
+            )
+
         status = "success" if response.status == "success" else "error"
         get_metrics().voice_pipeline_requests_total.labels(
             handler="/v1/conversations/process", status=status

--- a/backend/src/taskorbit/livekit_agent/llm.py
+++ b/backend/src/taskorbit/livekit_agent/llm.py
@@ -248,15 +248,16 @@ class OrchestratorAgent(Agent):
         try:
             async with AsyncSessionLocal() as db:
                 conv_id = self._conversation_id
+                log.debug("voice_turn_db_persist_start", conversation_id=conv_id)
                 if not await get_conversation(db, conv_id):
                     conv = await create_conversation(
                         db,
                         agent_id=self._agent_config.id,
                         agent_name=self._agent_config.name,
+                        id=conv_id,
                     )
-                    if conv:
-                        conv_id = conv.id
-                        self._conversation_id = conv_id
+                    if conv is None:
+                        log.error("voice_turn_conversation_create_failed", conversation_id=conv_id)
                 if last_user:
                     await create_conversation_message(
                         db,
@@ -295,6 +296,8 @@ class OrchestratorAgent(Agent):
                 error=str(exc),
                 conversation_id=self._conversation_id,
             )
+        else:
+            log.info("voice_turn_db_persist_ok", conversation_id=conv_id)
 
         status = "success" if response.status == "success" else "error"
         get_metrics().voice_pipeline_requests_total.labels(

--- a/backend/src/taskorbit/livekit_agent/session.py
+++ b/backend/src/taskorbit/livekit_agent/session.py
@@ -101,6 +101,7 @@ def build_default_agent(
     orchestrator: ConversationOrchestrator | None = None,
     settings: Settings | None = None,
     agent_config: AgentConfig | None = None,
+    conversation_id: str | None = None,
 ) -> OrchestratorAgent:
     """Build the ``OrchestratorAgent`` paired with this session.
 
@@ -112,8 +113,14 @@ def build_default_agent(
     instead of the hardcoded ``_default_agent_config`` fallback. With the
     full agent (including tools) the orchestrator can also dispatch the
     agent_transfer tool on voice, enabling mid-call handoff (AC7 of #8).
+
+    Pass ``conversation_id`` (= LiveKit room name) so voice turns are
+    persisted under the same conversation ID the frontend tracks.
     """
-    return OrchestratorAgent(
+    kwargs: dict = dict(
         orchestrator=orchestrator or ConversationOrchestrator(settings=settings),
         agent_config=agent_config,
     )
+    if conversation_id is not None:
+        kwargs["conversation_id"] = conversation_id
+    return OrchestratorAgent(**kwargs)

--- a/backend/src/taskorbit/types.py
+++ b/backend/src/taskorbit/types.py
@@ -157,7 +157,7 @@ class AgentConfig(BaseModel):
 
 
 class ConversationRequest(BaseModel):
-    conversation_id: str
+    conversation_id: str | None = None  # omit on first message; backend assigns and returns one
     agent_config: AgentConfig
     messages: list[Message]
     current_intent_name: str | None = None

--- a/backend/src/taskorbit/worker.py
+++ b/backend/src/taskorbit/worker.py
@@ -85,7 +85,11 @@ async def entrypoint(ctx: JobContext) -> None:
         pass
 
     session = build_agent_session(settings=cfg)
-    agent = build_default_agent(settings=cfg, agent_config=agent_config)
+    agent = build_default_agent(
+        settings=cfg,
+        agent_config=agent_config,
+        conversation_id=ctx.room.name,
+    )
 
     @session.on("metrics_collected")
     def _on_metrics(ev: AgentEvent) -> None:

--- a/backend/tests/test_conversations_route.py
+++ b/backend/tests/test_conversations_route.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi.testclient import TestClient
 
+from taskorbit.api.deps import get_current_user_id
 from taskorbit.api.main import create_app
 from taskorbit.api.routes.conversations import get_orchestrator, get_session
 from taskorbit.types import (
@@ -49,10 +50,18 @@ def test_process_conversation_returns_200_with_mock() -> None:
     app = create_app()
     app.dependency_overrides[get_orchestrator] = lambda: mock_orchestrator
     app.dependency_overrides[get_session] = _mock_db
-    with patch(
-        "taskorbit.api.routes.conversations.create_conversation_message",
-        new_callable=AsyncMock,
-        return_value=None,
+    app.dependency_overrides[get_current_user_id] = lambda: 1
+    with (
+        patch(
+            "taskorbit.api.routes.conversations.get_conversation",
+            new_callable=AsyncMock,
+            return_value=MagicMock(),  # truthy — conversation exists, skip auto-create
+        ),
+        patch(
+            "taskorbit.api.routes.conversations.create_conversation_message",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
     ):
         with TestClient(app) as client:
             response = client.post("/v1/conversations/process", json=_VALID_PAYLOAD)
@@ -61,6 +70,61 @@ def test_process_conversation_returns_200_with_mock() -> None:
     assert body["conversation_id"] == "conv-1"
     assert "[Mocked] Hello" == body["reply"]["content"]
     assert body["reply"]["role"] == "assistant"
+    app.dependency_overrides = {}
+
+
+def test_process_conversation_auto_creates_when_no_id() -> None:
+    """When no conversation_id is sent the endpoint auto-creates one and returns the assigned ID."""
+    new_conv_id = "auto-conv-abc123"
+    mock_conv = MagicMock()
+    mock_conv.id = new_conv_id
+
+    mock_response = ConversationResponse(
+        conversation_id=new_conv_id,
+        reply=Message(role=MessageRole.ASSISTANT, content="Hello!"),
+        status="success",
+    )
+    mock_orchestrator = AsyncMock()
+    mock_orchestrator.process_message.return_value = mock_response
+
+    app = create_app()
+    app.dependency_overrides[get_orchestrator] = lambda: mock_orchestrator
+    app.dependency_overrides[get_session] = _mock_db
+    app.dependency_overrides[get_current_user_id] = lambda: 1
+
+    payload = {
+        "agent_config": {
+            "id": "agent-1",
+            "name": "Bot",
+            "persona": "Helpful",
+            "greeting": "Hi!",
+        },
+        "messages": [{"role": "user", "content": "Hello"}],
+    }
+
+    with (
+        patch(
+            "taskorbit.api.routes.conversations.get_conversation",
+            new_callable=AsyncMock,
+            return_value=None,  # simulates unknown / first-ever conversation
+        ),
+        patch(
+            "taskorbit.api.routes.conversations.create_conversation",
+            new_callable=AsyncMock,
+            return_value=mock_conv,
+        ),
+        patch(
+            "taskorbit.api.routes.conversations.create_conversation_message",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+    ):
+        with TestClient(app) as client:
+            response = client.post("/v1/conversations/process", json=payload)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["conversation_id"] == new_conv_id
     app.dependency_overrides = {}
 
 
@@ -109,4 +173,78 @@ def test_create_conversation_returns_201() -> None:
     with TestClient(app) as client:
         response = client.post("/v1/conversations")
     assert response.status_code == 201
+    app.dependency_overrides = {}
+
+
+def test_get_history_returns_200() -> None:
+    """GET /v1/conversations/{id}/history returns the full history payload."""
+    history_payload = {
+        "conversation_id": "conv-1",
+        "agent_id": "agent-1",
+        "agent_name": "Bot",
+        "started_at": "2026-06-05T20:00:00+00:00",
+        "ended_at": None,
+        "messages": [
+            {"id": 1, "role": "user", "content": "Hi", "created_at": "2026-06-05T20:00:01+00:00"},
+            {
+                "id": 2,
+                "role": "assistant",
+                "content": "Hello!",
+                "created_at": "2026-06-05T20:00:02+00:00",
+            },
+        ],
+        "tool_executions": [
+            {
+                "id": 1,
+                "tool_id": "data_extraction",
+                "tool_type": "extraction",
+                "confirmed": False,
+                "executed_at": "2026-06-05T20:00:02+00:00",
+                "result": {"extracted_slots": {"name": "Alice"}},
+            }
+        ],
+        "slot_extractions": [
+            {
+                "id": 1,
+                "tool_id": "data_extraction",
+                "field_name": "name",
+                "field_value": "Alice",
+                "extracted_at": "2026-06-05T20:00:02+00:00",
+            }
+        ],
+    }
+    app = create_app()
+    app.dependency_overrides[get_session] = _mock_db
+    with patch(
+        "taskorbit.api.routes.conversations.get_conversation_history",
+        new_callable=AsyncMock,
+        return_value=history_payload,
+    ):
+        with TestClient(app) as client:
+            response = client.get("/v1/conversations/conv-1/history")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["conversation_id"] == "conv-1"
+    assert body["agent_name"] == "Bot"
+    assert len(body["messages"]) == 2
+    assert len(body["tool_executions"]) == 1
+    assert body["tool_executions"][0]["tool_id"] == "data_extraction"
+    assert len(body["slot_extractions"]) == 1
+    assert body["slot_extractions"][0]["field_name"] == "name"
+    assert body["slot_extractions"][0]["tool_id"] == "data_extraction"
+    app.dependency_overrides = {}
+
+
+def test_get_history_returns_404_when_not_found() -> None:
+    """GET /v1/conversations/{id}/history returns 404 for unknown conversation."""
+    app = create_app()
+    app.dependency_overrides[get_session] = _mock_db
+    with patch(
+        "taskorbit.api.routes.conversations.get_conversation_history",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        with TestClient(app) as client:
+            response = client.get("/v1/conversations/nonexistent/history")
+    assert response.status_code == 404
     app.dependency_overrides = {}

--- a/backend/tests/test_conversations_route.py
+++ b/backend/tests/test_conversations_route.py
@@ -132,9 +132,11 @@ def test_process_conversation_auto_creates_when_no_id() -> None:
 
 def test_process_conversation_rejects_invalid_payload() -> None:
     app = create_app()
+    app.dependency_overrides[get_current_user_id] = lambda: 1
     with TestClient(app) as client:
         response = client.post("/v1/conversations/process", json={"bad": "payload"})
     assert response.status_code == 422
+    app.dependency_overrides = {}
 
 
 def test_get_conversations_returns_200() -> None:

--- a/backend/tests/test_conversations_route.py
+++ b/backend/tests/test_conversations_route.py
@@ -13,6 +13,8 @@ from taskorbit.types import (
     ConversationResponse,
     Message,
     MessageRole,
+    ToolDefinition,
+    ToolType,
 )
 
 _VALID_PAYLOAD = {
@@ -247,4 +249,110 @@ def test_get_history_returns_404_when_not_found() -> None:
         with TestClient(app) as client:
             response = client.get("/v1/conversations/nonexistent/history")
     assert response.status_code == 404
+    app.dependency_overrides = {}
+
+
+def test_process_conversation_persists_slot_extractions() -> None:
+    """When the orchestrator returns extracted_slots, create_slot_extractions is called once."""
+    tool = ToolDefinition(
+        id="data_extraction",
+        name="collect_info",
+        type=ToolType.DATA_EXTRACTION,
+        description="Collects user info",
+    )
+    mock_response = ConversationResponse(
+        conversation_id="conv-1",
+        reply=Message(role=MessageRole.ASSISTANT, content="Got it!"),
+        status="success",
+        tool_invoked=tool,
+        extracted_slots={"name": "Alice", "email": "alice@example.com"},
+    )
+    mock_orchestrator = AsyncMock()
+    mock_orchestrator.process_message.return_value = mock_response
+
+    app = create_app()
+    app.dependency_overrides[get_orchestrator] = lambda: mock_orchestrator
+    app.dependency_overrides[get_session] = _mock_db
+    app.dependency_overrides[get_current_user_id] = lambda: 1
+
+    with (
+        patch(
+            "taskorbit.api.routes.conversations.get_conversation",
+            new_callable=AsyncMock,
+            return_value=MagicMock(),
+        ),
+        patch(
+            "taskorbit.api.routes.conversations.create_conversation_message",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "taskorbit.api.routes.conversations.create_slot_extractions",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as mock_extractions,
+        patch(
+            "taskorbit.api.routes.conversations.create_tool_execution",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+    ):
+        with TestClient(app) as client:
+            response = client.post("/v1/conversations/process", json=_VALID_PAYLOAD)
+
+    assert response.status_code == 200
+    mock_extractions.assert_called_once()
+    call_kwargs = mock_extractions.call_args.kwargs
+    assert call_kwargs["tool_id"] == "data_extraction"
+    assert call_kwargs["slots"] == {"name": "Alice", "email": "alice@example.com"}
+    app.dependency_overrides = {}
+
+
+def test_process_conversation_records_tool_execution() -> None:
+    """When the orchestrator returns tool_invoked, create_tool_execution is called once."""
+    tool = ToolDefinition(
+        id="agent_transfer",
+        name="transfer",
+        type=ToolType.AGENT_TRANSFER,
+        description="Transfers the call",
+    )
+    mock_response = ConversationResponse(
+        conversation_id="conv-1",
+        reply=Message(role=MessageRole.ASSISTANT, content="Transferring now."),
+        status="success",
+        tool_invoked=tool,
+    )
+    mock_orchestrator = AsyncMock()
+    mock_orchestrator.process_message.return_value = mock_response
+
+    app = create_app()
+    app.dependency_overrides[get_orchestrator] = lambda: mock_orchestrator
+    app.dependency_overrides[get_session] = _mock_db
+    app.dependency_overrides[get_current_user_id] = lambda: 1
+
+    with (
+        patch(
+            "taskorbit.api.routes.conversations.get_conversation",
+            new_callable=AsyncMock,
+            return_value=MagicMock(),
+        ),
+        patch(
+            "taskorbit.api.routes.conversations.create_conversation_message",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "taskorbit.api.routes.conversations.create_tool_execution",
+            new_callable=AsyncMock,
+            return_value=None,
+        ) as mock_execution,
+    ):
+        with TestClient(app) as client:
+            response = client.post("/v1/conversations/process", json=_VALID_PAYLOAD)
+
+    assert response.status_code == 200
+    mock_execution.assert_called_once()
+    call_kwargs = mock_execution.call_args.kwargs
+    assert call_kwargs["tool_id"] == "agent_transfer"
+    assert call_kwargs["tool_type"] == ToolType.AGENT_TRANSFER.value
     app.dependency_overrides = {}

--- a/backend/tests/test_crud.py
+++ b/backend/tests/test_crud.py
@@ -7,10 +7,14 @@ import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from taskorbit.database.crud import (
+    create_conversation,
     create_conversation_message,
+    create_slot_extractions,
+    create_tool_execution,
     create_user,
     delete_conversation_message,
     delete_user,
+    get_conversation_history,
     get_messages_by_conversation,
     get_messages_by_user,
     get_user,
@@ -196,3 +200,96 @@ class TestConversationMessageCRUD:
         assert result is True
         deleted = await get_messages_by_conversation(db_session, "conv-del")
         assert len(deleted) == 0
+
+
+class TestConversationHistoryCRUD:
+    """Tests for conversation, slot extraction, tool execution, and history CRUD."""
+
+    @pytest.mark.asyncio
+    async def test_create_conversation(self, db_session):
+        conv = await create_conversation(db_session, agent_id="agent-1", agent_name="Bot")
+        assert conv is not None
+        assert conv.id is not None
+        assert conv.agent_id == "agent-1"
+        assert conv.agent_name == "Bot"
+        assert conv.started_at is not None
+
+    @pytest.mark.asyncio
+    async def test_create_slot_extractions_returns_one_row_per_field(self, db_session):
+        conv = await create_conversation(db_session, agent_id="agent-1", agent_name="Bot")
+        rows = await create_slot_extractions(
+            db_session,
+            conversation_id=conv.id,
+            tool_id="data_extraction",
+            slots={"name": "Alice", "email": "alice@example.com"},
+        )
+        assert len(rows) == 2
+        field_names = {r.field_name for r in rows}
+        assert field_names == {"name", "email"}
+        assert all(r.tool_id == "data_extraction" for r in rows)
+        assert all(r.conversation_id == conv.id for r in rows)
+
+    @pytest.mark.asyncio
+    async def test_create_slot_extractions_empty_slots_returns_empty(self, db_session):
+        conv = await create_conversation(db_session, agent_id="agent-1", agent_name="Bot")
+        rows = await create_slot_extractions(
+            db_session, conversation_id=conv.id, tool_id="data_extraction", slots={}
+        )
+        assert rows == []
+
+    @pytest.mark.asyncio
+    async def test_create_tool_execution(self, db_session):
+        conv = await create_conversation(db_session, agent_id="agent-1", agent_name="Bot")
+        execution = await create_tool_execution(
+            db_session,
+            conversation_id=conv.id,
+            tool_id="data_extraction",
+            tool_type="data_extraction",
+            result={"extracted_slots": {"name": "Alice"}},
+        )
+        assert execution is not None
+        assert execution.tool_id == "data_extraction"
+        assert execution.tool_type == "data_extraction"
+        assert execution.result == {"extracted_slots": {"name": "Alice"}}
+        assert execution.conversation_id == conv.id
+
+    @pytest.mark.asyncio
+    async def test_get_conversation_history_returns_none_for_unknown(self, db_session):
+        result = await get_conversation_history(db_session, "nonexistent-id")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_conversation_history_returns_full_data(self, db_session):
+        conv = await create_conversation(db_session, agent_id="agent-1", agent_name="Bot")
+        await create_conversation_message(
+            db_session, conversation_id=conv.id, role="user", content="Hello"
+        )
+        await create_conversation_message(
+            db_session, conversation_id=conv.id, role="assistant", content="Hi!"
+        )
+        await create_slot_extractions(
+            db_session,
+            conversation_id=conv.id,
+            tool_id="data_extraction",
+            slots={"name": "Alice"},
+        )
+        await create_tool_execution(
+            db_session,
+            conversation_id=conv.id,
+            tool_id="data_extraction",
+            tool_type="data_extraction",
+        )
+
+        history = await get_conversation_history(db_session, conv.id)
+
+        assert history is not None
+        assert history["conversation_id"] == conv.id
+        assert history["agent_name"] == "Bot"
+        assert len(history["messages"]) == 2
+        assert history["messages"][0]["role"] == "user"
+        assert history["messages"][1]["role"] == "assistant"
+        assert len(history["slot_extractions"]) == 1
+        assert history["slot_extractions"][0]["field_name"] == "name"
+        assert history["slot_extractions"][0]["tool_id"] == "data_extraction"
+        assert len(history["tool_executions"]) == 1
+        assert history["tool_executions"][0]["tool_id"] == "data_extraction"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,7 @@ services:
     env_file:
       - ./backend/.env
     environment:
+      DATABASE_URL: postgresql://taskorbit:taskorbit@postgres:5432/taskorbit
       PYTHONUNBUFFERED: "1"
       LOG_JSON: "true"
       PROMETHEUS_MULTIPROC_DIR: /tmp/prometheus_multiproc
@@ -88,6 +89,8 @@ services:
       - taskorbit-worker-prometheus:/tmp/prometheus_multiproc
     command: poetry run taskorbit-worker dev
     depends_on:
+      postgres:
+        condition: service_healthy
       backend:
         condition: service_started
 

--- a/frontend/src/components/ConversationalChat.tsx
+++ b/frontend/src/components/ConversationalChat.tsx
@@ -201,6 +201,7 @@ export function ConversationalChat() {
             controller.signal,
             lockedIntentRef.current,
           );
+          call.updateConversationId(response.conversation_id);
           lockedIntentRef.current = response.locked_intent_name ?? null;
           if (response.selected_agent) setRoutedAgent(response.selected_agent);
           const replyText = response.reply.content;

--- a/frontend/src/components/history/ConversationListItem.tsx
+++ b/frontend/src/components/history/ConversationListItem.tsx
@@ -1,9 +1,16 @@
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
-import type { Conversation } from "@/lib/mockConversations";
+
+export type ConversationRow = {
+  id: string;
+  agent_name: string;
+  started_at: string;
+  duration_seconds: number | null;
+  tool_count: number;
+};
 
 type Props = {
-  conversation: Conversation;
+  conversation: ConversationRow;
   selected: boolean;
   onSelect: () => void;
   formatRelativeStart: (iso: string) => string;
@@ -23,7 +30,7 @@ export function ConversationListItem({
   formatRelativeStart,
   formatDuration,
 }: Props) {
-  const toolCount = conversation.tool_firings.length;
+  const toolCount = conversation.tool_count;
   return (
     <button
       type="button"
@@ -43,9 +50,10 @@ export function ConversationListItem({
             {formatRelativeStart(conversation.started_at)}
           </span>
         </div>
-        <span className="truncate text-sm text-muted-foreground">{conversation.caller_label}</span>
         <div className="flex flex-wrap items-center gap-1.5 pt-1">
-          <Badge variant="secondary">{formatDuration(conversation.duration_seconds)}</Badge>
+          {conversation.duration_seconds !== null && (
+            <Badge variant="secondary">{formatDuration(conversation.duration_seconds)}</Badge>
+          )}
           {toolCount > 0 ? (
             <Badge variant="outline">
               {toolCount} {toolCount === 1 ? "tool" : "tools"}

--- a/frontend/src/components/history/SlotExtractionCard.tsx
+++ b/frontend/src/components/history/SlotExtractionCard.tsx
@@ -1,0 +1,40 @@
+import { Badge } from "@/components/ui/badge";
+import type { ConversationHistory } from "@/lib/conversationApi";
+
+type SlotExtraction = ConversationHistory["slot_extractions"][number];
+
+function groupByTool(extractions: SlotExtraction[]): Map<string, SlotExtraction[]> {
+  const map = new Map<string, SlotExtraction[]>();
+  for (const s of extractions) {
+    const list = map.get(s.tool_id) ?? [];
+    list.push(s);
+    map.set(s.tool_id, list);
+  }
+  return map;
+}
+
+type Props = { extractions: SlotExtraction[] };
+
+export function SlotExtractionCard({ extractions }: Props) {
+  const byTool = groupByTool(extractions);
+
+  return (
+    <dl className="flex flex-col gap-5">
+      {[...byTool.entries()].map(([toolId, fields]) => (
+        <div key={toolId} className="flex flex-col gap-2">
+          <Badge variant="secondary" className="w-fit text-xs font-normal">
+            Extracted by: {toolId}
+          </Badge>
+          <div className="flex flex-col gap-2 pl-1">
+            {fields.map((f) => (
+              <div key={f.id} className="flex flex-col gap-0.5">
+                <dt className="text-xs text-muted-foreground">{f.field_name}</dt>
+                <dd className="font-mono text-sm break-all">{f.field_value ?? "—"}</dd>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/frontend/src/hooks/useVoiceCall.ts
+++ b/frontend/src/hooks/useVoiceCall.ts
@@ -13,6 +13,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { getConversationHistory } from "@/lib/conversationApi";
 import { fetchLiveKitToken } from "@/lib/livekitToken";
 import type { CallStatus, ConfirmationPromptState, LiveTranscriptTurn } from "@/types/callState";
 
@@ -52,6 +53,9 @@ export type VoiceCallApi = {
   /** Called from inside LiveKitRoom on permission errors. */
   setMicError: (message: string | null) => void;
 
+  /** Sync the backend-assigned conversation ID and persist it to localStorage. */
+  updateConversationId: (id: string) => void;
+
   /** Append a final user transcript turn (called when STT segment is final). */
   appendUserTurn: (text: string) => void;
   /** Append an assistant transcript turn. */
@@ -68,6 +72,7 @@ export type VoiceCallApi = {
   removeTurnById: (id: string) => void;
 };
 
+const CONV_ID_STORAGE_KEY = "taskorbit_conversation_id";
 const CONNECTING_TIMEOUT_MS = 800;
 const INACTIVITY_TIMEOUT_MS =
   Number(import.meta.env.VITE_INACTIVITY_TIMEOUT_MINUTES ?? 7) * 60 * 1000;
@@ -88,7 +93,9 @@ export function useVoiceCall(): VoiceCallApi {
   const [status, setStatus] = useState<CallStatus>("idle");
   const [transcript, setTranscript] = useState<LiveTranscriptTurn[]>([]);
   const [confirmation, setConfirmation] = useState<ConfirmationPromptState | null>(null);
-  const [conversationId, setConversationId] = useState<string>("");
+  const [conversationId, setConversationId] = useState<string>(
+    () => localStorage.getItem(CONV_ID_STORAGE_KEY) ?? "",
+  );
   const [livekitCredentials, setLivekitCredentials] = useState<LiveKitCredentials | null>(null);
   const [micError, setMicError] = useState<string | null>(null);
   const [sessionEndReason, setSessionEndReason] = useState<string | null>(null);
@@ -111,6 +118,41 @@ export function useVoiceCall(): VoiceCallApi {
       abortRef.current?.abort();
     };
   }, []);
+
+  useEffect(() => {
+    if (conversationId) {
+      localStorage.setItem(CONV_ID_STORAGE_KEY, conversationId);
+    } else {
+      localStorage.removeItem(CONV_ID_STORAGE_KEY);
+    }
+  }, [conversationId]);
+
+  const updateConversationId = useCallback((id: string) => {
+    setConversationId(id);
+  }, []);
+
+  // On mount, if a previous conversation ID is stored, fetch its history and
+  // restore the transcript so the user sees prior turns on reload.
+  useEffect(() => {
+    const storedId = localStorage.getItem(CONV_ID_STORAGE_KEY);
+    if (!storedId) return;
+
+    void getConversationHistory(storedId)
+      .then((history) => {
+        const turns: LiveTranscriptTurn[] = history.messages.map((m) => ({
+          id: `restored-${m.id}`,
+          role: m.role === "user" ? "user" : "assistant",
+          text: m.content,
+          isFinal: true,
+        }));
+        setTranscript(turns);
+      })
+      .catch(() => {
+        // Backend unreachable or conversation deleted — start clean.
+        localStorage.removeItem(CONV_ID_STORAGE_KEY);
+        setConversationId("");
+      });
+  }, []); // intentionally empty — runs once on mount only
 
   const clearTimer = useCallback(() => {
     if (timerRef.current !== null) {
@@ -267,6 +309,7 @@ export function useVoiceCall(): VoiceCallApi {
     clearTimer();
     clearSessionTimers();
     abortRef.current?.abort();
+    setConversationId("");
     setConfirmation(null);
     setLivekitCredentials(null);
     setStatus("ended");
@@ -356,6 +399,7 @@ export function useVoiceCall(): VoiceCallApi {
     denyConfirmation,
     setPhase,
     setMicError,
+    updateConversationId,
     appendUserTurn,
     appendAssistantTurn,
     upsertTurnById,

--- a/frontend/src/lib/conversationApi.ts
+++ b/frontend/src/lib/conversationApi.ts
@@ -82,6 +82,30 @@ type ConversationsResponse = {
   total: number;
 };
 
+export type ConversationHistory = {
+  conversation_id: string;
+  agent_id: string;
+  agent_name: string;
+  started_at: string;
+  ended_at: string | null;
+  messages: Array<{ id: number; role: string; content: string; created_at: string }>;
+  tool_executions: Array<{
+    id: number;
+    tool_id: string;
+    tool_type: string;
+    confirmed: boolean;
+    executed_at: string;
+    result: Record<string, unknown> | null;
+  }>;
+  slot_extractions: Array<{
+    id: number;
+    tool_id: string;
+    field_name: string;
+    field_value: string | null;
+    extracted_at: string;
+  }>;
+};
+
 // ---------------------------------------------------------------------------
 // Adapters: frontend schema → backend wire schema
 // ---------------------------------------------------------------------------
@@ -185,6 +209,18 @@ export async function getConversations(): Promise<ConversationsResponse> {
   const response = await fetch("/api/v1/conversations");
   if (!response.ok) {
     throw new Error("Failed to fetch conversations");
+  }
+  return response.json();
+}
+
+/**
+ * Fetch full history for a single conversation — messages, tool executions,
+ * and slot extractions. Used on reload to restore a previous session.
+ */
+export async function getConversationHistory(conversationId: string): Promise<ConversationHistory> {
+  const response = await fetch(`/api/v1/conversations/${conversationId}/history`);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch history for conversation ${conversationId}`);
   }
   return response.json();
 }

--- a/frontend/src/pages/HistoryPage.tsx
+++ b/frontend/src/pages/HistoryPage.tsx
@@ -1,14 +1,20 @@
-import { Fragment, useEffect, useRef, useState } from "react";
-import { DatabaseZap, MessageSquareDashed } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { DatabaseZap, Loader2, MessageSquareDashed } from "lucide-react";
 
-import { ConversationListItem } from "@/components/history/ConversationListItem";
+import {
+  ConversationListItem,
+  type ConversationRow,
+} from "@/components/history/ConversationListItem";
+import { SlotExtractionCard } from "@/components/history/SlotExtractionCard";
 import { TranscriptBubble } from "@/components/history/TranscriptBubble";
-import { TranscriptToolMarker } from "@/components/history/TranscriptToolMarker";
 import { Empty } from "@/components/Empty";
-import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { MOCK_CONVERSATIONS, type Conversation, type ToolFiring } from "@/lib/mockConversations";
+import {
+  getConversationHistory,
+  getConversations,
+  type ConversationHistory,
+} from "@/lib/conversationApi";
 
 const dateTimeFormatter = new Intl.DateTimeFormat(undefined, {
   dateStyle: "medium",
@@ -31,10 +37,7 @@ function formatRelativeStart(iso: string): string {
   const now = new Date();
   const then = new Date(iso);
   const diffDays = Math.round((startOfDay(now).getTime() - startOfDay(then).getTime()) / dayMs);
-  const time = then.toLocaleTimeString([], {
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+  const time = then.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
   if (diffDays === 0) return `Today, ${time}`;
   if (diffDays === 1) return `Yesterday, ${time}`;
   if (diffDays > 1 && diffDays < 7) return `${diffDays}d ago, ${time}`;
@@ -47,53 +50,71 @@ function formatDuration(seconds: number): string {
   return m > 0 ? `${m}m ${s}s` : `${s}s`;
 }
 
-const languageDisplayNames =
-  typeof Intl !== "undefined" && "DisplayNames" in Intl
-    ? new Intl.DisplayNames(undefined, { type: "language" })
-    : null;
-
-function formatLanguage(tag: string): string {
-  return languageDisplayNames?.of(tag) ?? tag.toUpperCase();
+function durationSeconds(startedAt: string, endedAt: string | null): number | null {
+  if (!endedAt) return null;
+  return Math.round((new Date(endedAt).getTime() - new Date(startedAt).getTime()) / 1000);
 }
 
-function groupFiringsByTurn(firings: ToolFiring[]): Map<string, ToolFiring[]> {
-  const map = new Map<string, ToolFiring[]>();
-  for (const firing of firings) {
-    const list = map.get(firing.triggered_after_turn_id) ?? [];
-    list.push(firing);
-    map.set(firing.triggered_after_turn_id, list);
-  }
-  return map;
-}
-
-// `lg` in Tailwind v4 is the 1024px breakpoint — anything below collapses
-// the two-pane grid into a single column. On mobile/tablet the detail pane
-// renders below the list, so we scroll it into view when a call is picked.
 const lgBreakpointPx = 1024;
 
 export function HistoryPage() {
+  const [conversations, setConversations] = useState<ConversationRow[]>([]);
+  const [listLoading, setListLoading] = useState(true);
+  const [listError, setListError] = useState<string | null>(null);
+
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [selectedHistory, setSelectedHistory] = useState<ConversationHistory | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+
   const detailRef = useRef<HTMLDivElement>(null);
 
-  const selected: Conversation | null =
-    selectedId !== null ? (MOCK_CONVERSATIONS.find((c) => c.id === selectedId) ?? null) : null;
-
-  const extractionRows: Array<[string, string | number | boolean]> = selected
-    ? selected.tool_firings.flatMap((f) =>
-        f.type === "data_extraction" ? Object.entries(f.values) : [],
-      )
-    : [];
-
-  const firingsByTurn = selected
-    ? groupFiringsByTurn(selected.tool_firings)
-    : new Map<string, ToolFiring[]>();
-
   useEffect(() => {
-    if (selectedId === null) return;
-    if (typeof window === "undefined") return;
-    if (window.innerWidth >= lgBreakpointPx) return;
-    detailRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
-  }, [selectedId]);
+    getConversations()
+      .then((data) => {
+        setConversations(
+          data.conversations.map((c) => ({
+            id: c.id,
+            agent_name: c.agent_name,
+            started_at: c.started_at,
+            duration_seconds: durationSeconds(c.started_at, c.ended_at),
+            tool_count: 0,
+          })),
+        );
+      })
+      .catch(() => setListError("Failed to load conversations."))
+      .finally(() => setListLoading(false));
+  }, []);
+
+  const handleSelect = (id: string) => {
+    setSelectedId(id);
+    setDetailLoading(true);
+    setSelectedHistory(null);
+
+    if (typeof window !== "undefined" && window.innerWidth < lgBreakpointPx) {
+      detailRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+
+    getConversationHistory(id)
+      .then((h) => {
+        setSelectedHistory(h);
+        // Update tool_count in list once detail is loaded
+        setConversations((prev) =>
+          prev.map((c) => (c.id === id ? { ...c, tool_count: h.tool_executions.length } : c)),
+        );
+      })
+      .catch(() => setSelectedHistory(null))
+      .finally(() => setDetailLoading(false));
+  };
+
+  const selectedMeta = conversations.find((c) => c.id === selectedId) ?? null;
+
+  const transcriptTurns =
+    selectedHistory?.messages.map((m) => ({
+      id: String(m.id),
+      role: m.role as "user" | "assistant",
+      text: m.content,
+      isFinal: true as const,
+    })) ?? [];
 
   return (
     <section className="mx-auto max-w-6xl px-4 py-10 sm:px-6">
@@ -109,87 +130,104 @@ export function HistoryPage() {
       </header>
 
       <div className="mt-8 grid gap-6 lg:grid-cols-[18rem_minmax(0,1fr)_18rem]">
+        {/* Left: conversation list */}
         <aside aria-label="Past conversations">
           <ScrollArea className="h-[min(70vh,40rem)] pr-2">
-            <ul className="flex flex-col gap-3">
-              {MOCK_CONVERSATIONS.map((c) => (
-                <li key={c.id}>
-                  <ConversationListItem
-                    conversation={c}
-                    selected={c.id === selectedId}
-                    onSelect={() => setSelectedId(c.id)}
-                    formatRelativeStart={formatRelativeStart}
-                    formatDuration={formatDuration}
-                  />
-                </li>
-              ))}
-            </ul>
+            {listLoading ? (
+              <div className="flex items-center justify-center py-12 text-muted-foreground">
+                <Loader2 className="size-5 animate-spin" />
+              </div>
+            ) : listError ? (
+              <p className="py-8 text-center text-sm text-destructive">{listError}</p>
+            ) : conversations.length === 0 ? (
+              <p className="py-8 text-center text-sm text-muted-foreground">
+                No conversations yet.
+              </p>
+            ) : (
+              <ul className="flex flex-col gap-3">
+                {conversations.map((c) => (
+                  <li key={c.id}>
+                    <ConversationListItem
+                      conversation={c}
+                      selected={c.id === selectedId}
+                      onSelect={() => handleSelect(c.id)}
+                      formatRelativeStart={formatRelativeStart}
+                      formatDuration={formatDuration}
+                    />
+                  </li>
+                ))}
+              </ul>
+            )}
           </ScrollArea>
         </aside>
 
+        {/* Centre: transcript */}
         <div ref={detailRef} className="flex min-w-0 flex-col gap-6">
-          {selected !== null ? (
-            <Card>
-              <CardHeader className="border-b">
-                <div className="flex flex-wrap items-start justify-between gap-2">
-                  <div className="space-y-1">
-                    <CardTitle>
-                      {selected.agent_name} · {selected.caller_label}
-                    </CardTitle>
-                    <CardDescription>
-                      {formatStartedAt(selected.started_at)} ·{" "}
-                      {formatDuration(selected.duration_seconds)}
-                    </CardDescription>
-                  </div>
-                  <Badge variant="outline">{formatLanguage(selected.language)}</Badge>
-                </div>
-              </CardHeader>
-              <CardContent className="pt-6">
-                <ScrollArea className="h-[min(50vh,28rem)] pr-3">
-                  <ul className="flex flex-col gap-4" aria-label="Transcript">
-                    {selected.transcript.map((turn) => {
-                      const firings = firingsByTurn.get(turn.id) ?? [];
-                      return (
-                        <Fragment key={turn.id}>
-                          <TranscriptBubble turn={turn} />
-                          {firings.map((firing, i) => (
-                            <TranscriptToolMarker key={`${turn.id}-firing-${i}`} firing={firing} />
-                          ))}
-                        </Fragment>
-                      );
-                    })}
-                  </ul>
-                </ScrollArea>
-              </CardContent>
-            </Card>
-          ) : (
+          {selectedId === null ? (
             <Empty
               icon={MessageSquareDashed}
               title="Pick a conversation"
               description="Select a past call from the list to view the transcript and any data extracted during the call."
             />
+          ) : detailLoading ? (
+            <div className="flex items-center justify-center py-20 text-muted-foreground">
+              <Loader2 className="size-5 animate-spin" />
+            </div>
+          ) : selectedHistory !== null ? (
+            <Card>
+              <CardHeader className="border-b">
+                <div className="flex flex-wrap items-start justify-between gap-2">
+                  <div className="space-y-1">
+                    <CardTitle>{selectedMeta?.agent_name ?? selectedHistory.agent_name}</CardTitle>
+                    <CardDescription>
+                      {formatStartedAt(selectedHistory.started_at)}
+                      {selectedMeta?.duration_seconds != null &&
+                        ` · ${formatDuration(selectedMeta.duration_seconds)}`}
+                    </CardDescription>
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent className="pt-6">
+                <ScrollArea className="h-[min(50vh,28rem)] pr-3">
+                  {transcriptTurns.length > 0 ? (
+                    <ul className="flex flex-col gap-4" aria-label="Transcript">
+                      {transcriptTurns.map((turn) => (
+                        <TranscriptBubble key={turn.id} turn={turn} history />
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="py-8 text-center text-sm text-muted-foreground">
+                      No messages recorded for this conversation.
+                    </p>
+                  )}
+                </ScrollArea>
+              </CardContent>
+            </Card>
+          ) : (
+            <p className="py-8 text-center text-sm text-destructive">
+              Failed to load conversation detail.
+            </p>
           )}
         </div>
 
+        {/* Right: extracted data with tool attribution */}
         <aside aria-label="Extracted data" className="min-w-0">
-          {selected !== null ? (
+          {selectedId !== null && (
             <Card>
               <CardHeader>
                 <CardTitle className="text-base">Extracted data</CardTitle>
                 <CardDescription>
-                  Values the agent saved during the call via data extraction tools.
+                  Values the agent saved during the call, attributed to the tool that extracted
+                  them.
                 </CardDescription>
               </CardHeader>
               <CardContent>
-                {extractionRows.length > 0 ? (
-                  <dl className="flex flex-col gap-3">
-                    {extractionRows.map(([key, value]) => (
-                      <div key={key} className="flex flex-col gap-0.5">
-                        <dt className="text-xs text-muted-foreground">{key}</dt>
-                        <dd className="font-mono text-sm break-all">{String(value)}</dd>
-                      </div>
-                    ))}
-                  </dl>
+                {detailLoading ? (
+                  <div className="flex justify-center py-6 text-muted-foreground">
+                    <Loader2 className="size-4 animate-spin" />
+                  </div>
+                ) : selectedHistory && selectedHistory.slot_extractions.length > 0 ? (
+                  <SlotExtractionCard extractions={selectedHistory.slot_extractions} />
                 ) : (
                   <Empty
                     icon={DatabaseZap}
@@ -199,7 +237,7 @@ export function HistoryPage() {
                 )}
               </CardContent>
             </Card>
-          ) : null}
+          )}
         </aside>
       </div>
     </section>


### PR DESCRIPTION
## Summary

- **Auto-create conversation on first message** — backend assigns a `conversation_id` on every `POST /v1/conversations/process` call; frontend no longer needs to create one explicitly
- **Persist all turns to the database** — user and assistant messages, slot extractions (with per-field tool attribution), and tool executions are saved on both the text path (REST) and the voice path (LiveKit worker)
- **Voice persistence fixed** — `OrchestratorAgent.llm_node` now writes to the DB using `AsyncSessionLocal`; room name is forwarded as `conversation_id` so voice and text turns land in the same conversation record; `docker-compose.yml` worker service now overrides `DATABASE_URL` to `postgres:5432` so the container connects correctly
- **Restore previous conversation on reload** — `conversation_id` is persisted to `localStorage` after each turn and restored on mount; `GET /v1/conversations/{id}/history` is called to repopulate the transcript
- **History page wired to real API** — `HistoryPage` fetches live data via `getConversations()` and `getConversationHistory(id)`; `MOCK_CONVERSATIONS` removed
- **Tool attribution transparency** — `SlotExtractionCard` groups extracted fields by `tool_id` and shows "Extracted by: {toolId}" so users can see which tool captured each piece of data
- **Alembic migration** — adds `slot_extractions` table with FK cascade on `conversations.id` and `tool_id` provenance column
- **Test coverage** — CRUD tests for `create_conversation`, `create_slot_extractions`, `create_tool_execution`, `get_conversation_history` against SQLite in-memory; route-level tests asserting slot extraction and tool execution persistence are called with correct arguments

## Test plan

- [x] Send a text message — verify `conversations` and `conversation_messages` rows appear in DB
- [x] Send a voice message — verify same rows appear under the same `conversation_id` as the text turns
- [x] Reload the page — verify transcript is restored from the history endpoint
- [x] Check History page — verify real conversations appear, transcript renders, extracted data panel shows "Extracted by: {toolId}" per field
- [x] Run `poetry run pytest` — all 311 tests pass
- [x] Run `bun run type-check` in `frontend/` — no errors
