### PR TITLE
Feature/custom agent routing

### DIFF
--- a/Documentation/custom-agent-routing.md
+++ b/Documentation/custom-agent-routing.md
@@ -1,0 +1,227 @@
+# Custom Agent Routing — TaskOrbit Conversational Agent
+
+> **Scope.** This guide explains how TaskOrbit routes a conversation to the
+> correct agent, including how custom (user-saved) agents participate in both
+> the manual UI path and the automatic intent-driven path. It covers the
+> backend orchestration pipeline, security scoping, and the frontend handoff UX.
+
+---
+
+## Overview
+
+TaskOrbit supports two distinct ways to transfer a conversation from one agent
+to another:
+
+| Path | Trigger | Who decides |
+|---|---|---|
+| **Manual transfer** | User picks an agent from the UI dropdown | User |
+| **Auto transfer** | LLM dispatches the `agent_transfer` tool mid-conversation | Orchestrator / LLM |
+
+Both paths ultimately reach the same `ConversationOrchestrator.process_message`
+pipeline and produce the same `ConversationResponse`, but they enter at
+different points (step 0a vs. step 4).
+
+---
+
+## Orchestration pipeline (step order)
+
+```
+User message
+     │
+     ▼
+ 0a. Manual transfer short-circuit
+     │  If request.manual_transfer is set, bypass steps 1–6 entirely
+     │  and delegate to _handle_manual_transfer.
+     │  On completion, re-enter the pipeline under the new agent (step 1+).
+     │
+     ▼
+  1. Intent detection
+  2. Agent selection (AgentRegistry.create_by_name)
+  3. System prompt construction
+  4. LLM call → reply text + optional tool_invoked
+  5. Tool dispatch (_dispatch_tool) ← agent_transfer fires here
+  6. Response assembly → ConversationResponse
+```
+
+### Step 0a — Manual transfer short-circuit
+
+`_handle_manual_transfer` resolves the target agent in this order:
+
+1. **By ID** (`target_agent_id`) — looks up `AgentConfiguration` by primary
+   key, user-scoped (see Security section).
+2. **By name** (`target_agent_name`) — fallback when no ID is provided,
+   also user-scoped.
+3. **Built-in template** — if neither user copy nor ID resolves, the
+   orchestrator falls back to the matching built-in template (e.g.
+   `SalesAgent`).
+
+After the target config is loaded the orchestrator clears
+`manual_transfer=None` on the forwarded request (recursion guard) and
+re-enters the full pipeline (steps 1–6) under the new agent's persona
+with the full conversation history preserved (AC3).
+
+### Step 5 — Auto transfer via `agent_transfer` tool
+
+When the LLM includes an `agent_transfer` tool call in its reply,
+`_dispatch_tool` constructs `AgentTransferTool(db=db, user_id=user_id)` and
+calls `execute(context)`. The tool:
+
+1. Reads `targets[0]` from `context["parameters"]`.
+2. Calls `_is_valid_target(target_id)`:
+   - Checks built-in agent names first (no DB required).
+   - Falls back to `get_agent_configuration_by_id(db, target_id, user_id=user_id)`
+     when a DB session is available.
+3. Returns `{"selected_agent": target_id}` on success or
+   `{"error": "Unknown agent"}` on failure.
+
+**UUID normalization:** target IDs that look like custom-agent UUIDs
+(matching `/^[0-9a-f]{8}-…-[0-9a-f]{12}$/i`) are passed through untouched.
+Only built-in slugs (e.g. `technical-support-agent`) are slug-normalized to
+their registry key (`technical_support`). This prevents hyphen corruption of
+custom agent UUIDs.
+
+---
+
+## Agent types
+
+| Type | Defined in | Resolved by |
+|---|---|---|
+| Built-in | `agents/` Python classes | `AgentRegistry._REGISTRY` keyword lookup |
+| Custom (user-saved) | `agent_configurations` DB table | `AgentRegistry.create_by_name` DB fallback / `AgentRegistry.create_custom` |
+
+`CustomAgent` is never in `_REGISTRY` and is never matched by intent
+detection. It is only constructed via `AgentRegistry.create_custom()` — called
+from `_handle_manual_transfer` and the `create_by_name` DB fallback. This
+prevents the string `"custom"` from accidentally matching an intent keyword.
+
+---
+
+## Security — user scoping
+
+All agent DB lookups are scoped to the authenticated user so one user cannot
+execute under another user's saved agent config.
+
+### `get_agent_configuration_by_id`
+
+```python
+query = select(AgentConfiguration).where(AgentConfiguration.id == agent_id)
+if user_id is not None:
+    query = query.where(
+        (AgentConfiguration.user_id == user_id) | (AgentConfiguration.user_id.is_(None))
+    )
+```
+
+`user_id IS NULL` rows are global/template configs that any user may read.
+The function returns `None` for both missing rows and rows owned by a
+different user — it does not distinguish between the two to avoid an
+existence oracle.
+
+### `get_agent_configuration_by_name`
+
+```python
+if user_id is not None:
+    query = query.where(AgentConfiguration.user_id == user_id)
+else:
+    # Fail-closed: unauthenticated callers see global templates only.
+    query = query.where(AgentConfiguration.user_id.is_(None))
+```
+
+When `user_id=None` (e.g. the voice path before full auth is wired),
+only global template rows (NULL `user_id`) are returned. This prevents
+a voice session from resolving another user's custom agent by name.
+
+### `_dispatch_tool` threading
+
+`_dispatch_tool(self, tool, context, db=None, user_id=None)` receives both
+the DB session and the authenticated `user_id` from `process_message`, and
+passes them to `AgentTransferTool(db=db, user_id=user_id)` at construction
+time. This ensures the auto-tool path applies the same ownership check as the
+manual path.
+
+---
+
+## Frontend UX — agent handoff flow
+
+### Manual transfer (text path)
+
+1. User opens the route dropdown (`@` button in `InCallControls`) and picks
+   an agent.
+2. `handleRoutingTargetChange` fires immediately:
+   - Sets the routing badge (`routedAgent`).
+   - Appends a `"Transferring you to <name>…"` transcript entry.
+   - Plays TTS announcement via `playSynthesizedSpeech`.
+3. User sends their message. `handleSendText` includes
+   `manual_transfer: { target_agent_id, target_agent_name }` in the request.
+4. On success, `handleSendText` swaps the full agent config via
+   `setActiveAgent` so subsequent messages run under the new agent.
+5. On failure (target not found or backend rejects), an explicit
+   `[Could not transfer to <name>]` marker is appended and the badge reverts.
+
+### Auto transfer (voice and text paths)
+
+When the backend's `response.tool_invoked.type === "agent_transfer"`:
+- **Text path:** `handleSendText` in `ConversationalChat.tsx` fetches the
+  user's agent list, matches the target ID, and calls `setActiveAgent`.
+  A `[Transferred to <name>]` transcript marker is appended.
+- **Voice path:** `worker.py` reads `agent._pending_handoff_target` after
+  `generate_reply()` completes and publishes `{"type": "agent_handoff", "target": "<id>"}`
+  on the `taskorbit.agent_handoff` LiveKit data topic. The frontend hook
+  `useAgentHandoff` receives this, resolves the agent, and calls
+  `setActiveAgent`.
+
+### In-call agent identity strip
+
+During an active call, a compact strip at the top of the transcript card
+shows the current agent's initials and name. When `setActiveAgent` fires
+(from any path above), a `useEffect` detects the name change and shows a
+`↔ from [Previous Agent]` badge for the remainder of the call.
+
+---
+
+## Voice path — limitations
+
+The LiveKit voice worker currently runs with `user_id=None` because the
+token metadata does not yet carry an authenticated user claim. Consequences:
+
+- By-name custom-agent resolution is limited to global/template configs
+  (fail-closed behaviour — see Security section).
+- By-id resolution via `agent_transfer` tool works for global templates but
+  not for user-owned `AgentConfiguration` rows (no ownership claim to match).
+
+**When JWT auth lands:** wire the authenticated `user_id` into the LiveKit
+token metadata, read it in `worker.py`, and pass it to
+`build_default_agent(user_id=user_id)`. The `OrchestratorAgent` already
+accepts `user_id` and forwards it to `process_message` — no further backend
+changes needed.
+
+---
+
+## Where it lives in the code
+
+| Concern | File |
+|---|---|
+| Orchestration pipeline + step 0a | `backend/src/taskorbit/orchestration/__init__.py` |
+| Manual transfer resolution | `orchestration/__init__.py` → `_handle_manual_transfer` |
+| Auto-tool dispatch wiring | `orchestration/__init__.py` → `_dispatch_tool` |
+| `AgentTransferTool` + `_is_valid_target` | `backend/src/taskorbit/tools/agent_transfer.py` |
+| `AgentRegistry` + `CustomAgent` | `backend/src/taskorbit/agents/` |
+| DB lookups with user scoping | `backend/src/taskorbit/database/crud.py` |
+| Voice path agent + `user_id` threading | `backend/src/taskorbit/livekit_agent/llm.py` |
+| Voice path session builder | `backend/src/taskorbit/livekit_agent/session.py` |
+| Frontend routing dropdown + badge | `frontend/src/components/chat/InCallControls.tsx` |
+| Frontend transfer execution + failure UX | `frontend/src/components/ConversationalChat.tsx` |
+| Voice handoff LiveKit hook | `frontend/src/hooks/useAgentHandoff.ts` |
+| Agent config CRUD + copy-on-write | `backend/src/taskorbit/database/crud.py` |
+| User-agents REST API | `backend/src/taskorbit/api/routes/user_agents.py` |
+
+---
+
+## Tests
+
+| Test file | What it covers |
+|---|---|
+| `tests/test_orchestration.py` | End-to-end `process_message` with mock DB — auto-transfer to custom agent succeeds through `_dispatch_tool` wiring |
+| `tests/test_orchestration.py` | Cross-user `get_agent_configuration_by_id` regression — user A cannot load user B's config |
+| `tests/test_agent_transfer.py` | `AgentTransferTool._is_valid_target` with and without DB session |
+| `tests/test_custom_agent_routing.py` | Manual transfer short-circuit, recursion guard, name vs. ID precedence |
+| `tests/test_crud.py` | `get_agent_configuration_by_id` and `get_agent_configuration_by_name` user scoping |

--- a/Documentation/external-api-tools.md
+++ b/Documentation/external-api-tools.md
@@ -261,7 +261,7 @@ config. The config only references their names.
 | --------------------------------------------- | -------------------------------------------------------------------------- |
 | Tool implementation                           | `backend/src/taskorbit/tools/generic_api.py`                               |
 | Tool type registration                        | `backend/src/taskorbit/types.py` (`ToolType.EXTERNAL_API`)                 |
-| Dispatch wiring                               | `backend/src/taskorbit/orchestration/__init__.py` (`_dispatch_tool`)       |
+| Dispatch wiring                               | `backend/src/taskorbit/orchestration/__init__.py` (`_dispatch_tool(tool, context, db, user_id)`) — `db` and `user_id` are threaded through so `AgentTransferTool` can reach custom agents; other tool types receive `tool_cls().execute(context)` as before |
 | JSON schema (validates saved agent configs)   | `schemas/agent-task.schema.json` (`externalApiTool` + sub-schemas)         |
 | Canonical example                             | `schemas/examples/agent-task.example.json` (`lookup_service_area` tool)    |
 | Unit tests                                    | `backend/tests/test_generic_api_tool.py`                                   |

--- a/backend/src/taskorbit/agents/__init__.py
+++ b/backend/src/taskorbit/agents/__init__.py
@@ -16,6 +16,9 @@ from typing import TYPE_CHECKING
 from taskorbit.logging.setup import get_logger
 from taskorbit.types import AgentConfig, ConversationRequest, ConversationResponse, ToolDefinition
 
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
 logger = get_logger(__name__)
 
 # Tracks how many times each agent type has been invoked this process lifetime.
@@ -220,15 +223,19 @@ class AgentRegistry:
         return frozenset(agent_cls.agent_name for _, agent_cls in cls._REGISTRY)
 
     @classmethod
-    def create_by_name(
+    async def create_by_name(
         cls,
         agent_name: str,
         config: AgentConfig,
         orchestrator: ConversationOrchestrator,
+        db: AsyncSession | None = None,
     ) -> BaseAgent:
-        """Construct an agent directly by agent_name (e.g. from an IntentResult).
+        """Construct an agent by agent_name (e.g. from an IntentResult).
 
-        Falls back to the default agent if agent_name is empty or unrecognised.
+        Resolution order:
+          1. Built-in agents matched by agent_name.
+          2. Custom agents looked up by name in agent_configurations (when db given).
+          3. Default agent fallback.
         """
         for _, agent_cls in cls._REGISTRY:
             if agent_cls.agent_name == agent_name:
@@ -242,6 +249,21 @@ class AgentRegistry:
                     "agent_selected", agent=agent_cls.agent_name, total_calls=count, via="intent"
                 )
                 return agent_cls(config, orchestrator)
+
+        # Fall back to DB for custom agents
+        if db is not None:
+            from taskorbit.database.crud import get_agent_configuration_by_name
+            from taskorbit.types import AgentConfig as AgentConfigType
+
+            record = await get_agent_configuration_by_name(db, agent_name)
+            if record is not None:
+                custom_config = AgentConfigType(**record.config)
+                logger.info(
+                    "agent_selected", agent="custom", config_name=agent_name, via="db_fallback"
+                )
+                return cls.create_custom(custom_config, orchestrator)
+
+        logger.warning("agent_not_found", agent_name=agent_name, fallback="default")
         return cls.create(config, orchestrator)
 
     @classmethod

--- a/backend/src/taskorbit/agents/__init__.py
+++ b/backend/src/taskorbit/agents/__init__.py
@@ -229,6 +229,7 @@ class AgentRegistry:
         config: AgentConfig,
         orchestrator: ConversationOrchestrator,
         db: AsyncSession | None = None,
+        user_id: int | None = None,
     ) -> BaseAgent:
         """Construct an agent by agent_name (e.g. from an IntentResult).
 
@@ -250,14 +251,25 @@ class AgentRegistry:
                 )
                 return agent_cls(config, orchestrator)
 
-        # Fall back to DB for custom agents
+        # Fall back to DB for custom agents — scope by user_id to prevent cross-user leakage.
         if db is not None:
+            from pydantic import ValidationError
+
             from taskorbit.database.crud import get_agent_configuration_by_name
             from taskorbit.types import AgentConfig as AgentConfigType
 
-            record = await get_agent_configuration_by_name(db, agent_name)
+            record = await get_agent_configuration_by_name(db, agent_name, user_id=user_id)
             if record is not None:
-                custom_config = AgentConfigType(**record.config)
+                try:
+                    custom_config = AgentConfigType(**record.config)
+                except (ValidationError, Exception) as exc:
+                    logger.error(
+                        "custom_agent_invalid_config",
+                        agent_name=agent_name,
+                        error=str(exc),
+                    )
+                    logger.warning("agent_not_found", agent_name=agent_name, fallback="default")
+                    return cls.create(config, orchestrator)
                 logger.info(
                     "agent_selected", agent="custom", config_name=agent_name, via="db_fallback"
                 )

--- a/backend/src/taskorbit/agents/__init__.py
+++ b/backend/src/taskorbit/agents/__init__.py
@@ -138,6 +138,23 @@ class CustomerDissatisfactionAgent(BaseAgent):
         return self.config.tools
 
 
+class CustomAgent(BaseAgent):
+    """Thin wrapper for user-defined agents loaded from the database.
+
+    Carries a user-supplied AgentConfig without any specialised class logic.
+    All behaviour is driven by the config (persona, tools, etc.) through the
+    shared orchestrator pipeline, exactly like the built-in agents.
+    """
+
+    agent_name = "custom"
+
+    async def handle_message(self, request: ConversationRequest) -> ConversationResponse:
+        return await self.orchestrator.process_message(request)
+
+    def get_task_definitions(self) -> list[ToolDefinition]:
+        return self.config.tools
+
+
 # ---------------------------------------------------------------------------
 # Registry / constructor
 # ---------------------------------------------------------------------------
@@ -198,6 +215,11 @@ class AgentRegistry:
         return cls._DEFAULT(config, orchestrator)
 
     @classmethod
+    def known_agent_names(cls) -> frozenset[str]:
+        """Return the set of built-in agent_name strings."""
+        return frozenset(agent_cls.agent_name for _, agent_cls in cls._REGISTRY)
+
+    @classmethod
     def create_by_name(
         cls,
         agent_name: str,
@@ -221,6 +243,18 @@ class AgentRegistry:
                 )
                 return agent_cls(config, orchestrator)
         return cls.create(config, orchestrator)
+
+    @classmethod
+    def create_custom(cls, config: AgentConfig, orchestrator: ConversationOrchestrator) -> BaseAgent:
+        """Construct a CustomAgent from a DB-resolved AgentConfig.
+
+        Called by the orchestrator after it has loaded the config from the
+        agent_configurations table. Built-in routing is not consulted.
+        """
+        _agent_call_counts["custom"] += 1
+        count = _agent_call_counts["custom"]
+        logger.info("agent_selected", agent="custom", config_id=config.id, total_calls=count)
+        return CustomAgent(config, orchestrator)
 
     # Keep the old name available so existing call sites don't break.
     @classmethod

--- a/backend/src/taskorbit/agents/__init__.py
+++ b/backend/src/taskorbit/agents/__init__.py
@@ -245,7 +245,9 @@ class AgentRegistry:
         return cls.create(config, orchestrator)
 
     @classmethod
-    def create_custom(cls, config: AgentConfig, orchestrator: ConversationOrchestrator) -> BaseAgent:
+    def create_custom(
+        cls, config: AgentConfig, orchestrator: ConversationOrchestrator
+    ) -> BaseAgent:
         """Construct a CustomAgent from a DB-resolved AgentConfig.
 
         Called by the orchestrator after it has loaded the config from the

--- a/backend/src/taskorbit/api/routes/conversations.py
+++ b/backend/src/taskorbit/api/routes/conversations.py
@@ -66,7 +66,7 @@ async def process_conversation(
         message_count=len(request.messages),
     )
     try:
-        response = await orchestrator.process_message(request)
+        response = await orchestrator.process_message(request, db=db)
 
         # Save user message (last message in the list if sent by user)
         last_msg = request.messages[-1] if request.messages else None

--- a/backend/src/taskorbit/api/routes/conversations.py
+++ b/backend/src/taskorbit/api/routes/conversations.py
@@ -66,7 +66,7 @@ async def process_conversation(
         message_count=len(request.messages),
     )
     try:
-        response = await orchestrator.process_message(request, db=db)
+        response = await orchestrator.process_message(request, db=db, user_id=user_id)
 
         # Save user message (last message in the list if sent by user)
         last_msg = request.messages[-1] if request.messages else None

--- a/backend/src/taskorbit/database/crud.py
+++ b/backend/src/taskorbit/database/crud.py
@@ -731,13 +731,21 @@ async def copy_on_write_user_agent(
 
 
 async def get_agent_configuration_by_id(
-    db: AsyncSession, agent_id: str
+    db: AsyncSession, agent_id: str, user_id: int | None = None
 ) -> AgentConfiguration | None:
-    """Look up a single AgentConfiguration by its primary key (async)."""
+    """Look up a single AgentConfiguration by its primary key (async).
+
+    When user_id is provided, only returns records owned by that user OR global
+    template records (user_id IS NULL). Returns None for both missing rows and
+    rows owned by another user — callers cannot distinguish the two cases.
+    """
     try:
-        result = await db.execute(
-            select(AgentConfiguration).where(AgentConfiguration.id == agent_id)
-        )
+        query = select(AgentConfiguration).where(AgentConfiguration.id == agent_id)
+        if user_id is not None:
+            query = query.where(
+                (AgentConfiguration.user_id == user_id) | (AgentConfiguration.user_id.is_(None))
+            )
+        result = await db.execute(query)
         return result.scalar_one_or_none()
     except SQLAlchemyError as e:
         logger.error("get_agent_configuration_by_id_failed", agent_id=agent_id, error=str(e))
@@ -747,11 +755,20 @@ async def get_agent_configuration_by_id(
 async def get_agent_configuration_by_name(
     db: AsyncSession, name: str, user_id: int | None = None
 ) -> AgentConfiguration | None:
-    """Look up a single AgentConfiguration by name, optionally scoped to a user."""
+    """Look up a single AgentConfiguration by name, scoped to a user.
+
+    When user_id is provided, matches records owned by that user only.
+    When user_id is None (e.g. voice path before auth lands), fails closed:
+    only global template records (user_id IS NULL) are returned so the voice
+    path cannot resolve one user's custom agent into another user's session.
+    """
     try:
         query = select(AgentConfiguration).where(AgentConfiguration.name == name)
         if user_id is not None:
             query = query.where(AgentConfiguration.user_id == user_id)
+        else:
+            # Fail-closed: unauthenticated callers see global templates only.
+            query = query.where(AgentConfiguration.user_id.is_(None))
         result = await db.execute(query)
         return result.scalar_one_or_none()
     except SQLAlchemyError as e:

--- a/backend/src/taskorbit/database/crud.py
+++ b/backend/src/taskorbit/database/crud.py
@@ -730,6 +730,37 @@ async def copy_on_write_user_agent(
         return None
 
 
+async def get_agent_configuration_by_id(
+    db: AsyncSession, agent_id: str
+) -> AgentConfiguration | None:
+    """Look up a single AgentConfiguration by its primary key (async)."""
+    try:
+        result = await db.execute(
+            select(AgentConfiguration).where(AgentConfiguration.id == agent_id)
+        )
+        return result.scalar_one_or_none()
+    except SQLAlchemyError as e:
+        logger.error("get_agent_configuration_by_id_failed", agent_id=agent_id, error=str(e))
+        return None
+
+
+async def get_agent_configuration_by_name(
+    db: AsyncSession, name: str, user_id: int | None = None
+) -> AgentConfiguration | None:
+    """Look up a single AgentConfiguration by name, optionally scoped to a user."""
+    try:
+        query = select(AgentConfiguration).where(AgentConfiguration.name == name)
+        if user_id is not None:
+            query = query.where(AgentConfiguration.user_id == user_id)
+        result = await db.execute(query)
+        return result.scalar_one_or_none()
+    except SQLAlchemyError as e:
+        logger.error(
+            "get_agent_configuration_by_name_failed", name=name, user_id=user_id, error=str(e)
+        )
+        return None
+
+
 async def list_user_agents_merged(db: AsyncSession, user_id: int) -> list[dict]:
     """Return all agents for a user — their customised copies AND all templates.
 

--- a/backend/src/taskorbit/livekit_agent/llm.py
+++ b/backend/src/taskorbit/livekit_agent/llm.py
@@ -239,7 +239,20 @@ class OrchestratorAgent(Agent):
             messages=messages,
             current_intent_name=self._locked_intent_name,
         )
-        response = await self._orchestrator.process_message(request)
+
+        # Open the DB session before process_message so that manual transfers
+        # and custom-agent DB lookups work in the voice path too.
+        try:
+            async with AsyncSessionLocal() as db:
+                response = await self._orchestrator.process_message(request, db=db)
+        except Exception as exc:
+            log.error(
+                "voice_turn_orchestrator_failed",
+                error=str(exc),
+                conversation_id=self._conversation_id,
+            )
+            raise
+
         self._locked_intent_name = response.locked_intent_name
         if response.selected_agent:
             self._current_routed_agent = response.selected_agent

--- a/backend/src/taskorbit/livekit_agent/llm.py
+++ b/backend/src/taskorbit/livekit_agent/llm.py
@@ -169,6 +169,7 @@ class OrchestratorAgent(Agent):
         instructions: str | None = None,
         agent_config: AgentConfig | None = None,
         conversation_id: str = "livekit-session",
+        user_id: int | None = None,
     ) -> None:
         super().__init__(
             instructions=instructions or "You are TaskOrbit, a helpful voice assistant.",
@@ -176,6 +177,7 @@ class OrchestratorAgent(Agent):
         self._orchestrator = orchestrator
         self._agent_config = agent_config or _default_agent_config()
         self._conversation_id = conversation_id
+        self._user_id = user_id
         self._reply_requested: bool = False
         self._t_commit: float | None = None
         self._locked_intent_name: str | None = None
@@ -244,7 +246,9 @@ class OrchestratorAgent(Agent):
         # and custom-agent DB lookups work in the voice path too.
         try:
             async with AsyncSessionLocal() as db:
-                response = await self._orchestrator.process_message(request, db=db)
+                response = await self._orchestrator.process_message(
+                    request, db=db, user_id=self._user_id
+                )
         except Exception as exc:
             log.error(
                 "voice_turn_orchestrator_failed",

--- a/backend/src/taskorbit/livekit_agent/session.py
+++ b/backend/src/taskorbit/livekit_agent/session.py
@@ -102,6 +102,7 @@ def build_default_agent(
     settings: Settings | None = None,
     agent_config: AgentConfig | None = None,
     conversation_id: str | None = None,
+    user_id: int | None = None,
 ) -> OrchestratorAgent:
     """Build the ``OrchestratorAgent`` paired with this session.
 
@@ -123,4 +124,6 @@ def build_default_agent(
     )
     if conversation_id is not None:
         kwargs["conversation_id"] = conversation_id
+    if user_id is not None:
+        kwargs["user_id"] = user_id
     return OrchestratorAgent(**kwargs)

--- a/backend/src/taskorbit/orchestration/__init__.py
+++ b/backend/src/taskorbit/orchestration/__init__.py
@@ -23,6 +23,8 @@ import time
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
     from taskorbit.agents import BaseAgent
 
 from taskorbit.config import Settings, get_settings
@@ -51,10 +53,18 @@ class ConversationOrchestrator:
         self._settings = settings or get_settings()
         self._intent_router = IntentRouter()
 
-    async def process_message(self, request: ConversationRequest) -> ConversationResponse:
+    async def process_message(
+        self, request: ConversationRequest, db: AsyncSession | None = None
+    ) -> ConversationResponse:
         """Main entry point called by the API layer and agent workers."""
         _pipeline_start = time.perf_counter()
         try:
+            # 0a. Manual transfer: UI-initiated handoff bypasses intent detection entirely.
+            if request.manual_transfer and (
+                request.manual_transfer.target_agent_id or request.manual_transfer.target_agent_name
+            ):
+                return await self._handle_manual_transfer(request, db)
+
             last_user = next(
                 (m for m in reversed(request.messages) if m.role == MessageRole.USER),
                 None,
@@ -423,6 +433,101 @@ class ConversationOrchestrator:
                 status="error",
                 error=str(exc),
             )
+
+    async def _handle_manual_transfer(
+        self,
+        request: ConversationRequest,
+        db: AsyncSession | None,
+    ) -> ConversationResponse:
+        """Handle a UI-initiated transfer to a specific agent by ID or name.
+
+        Resolves the target AgentConfiguration from the DB, swaps the config on
+        the request, clears the manual_transfer field to avoid recursion, then
+        re-enters the normal pipeline so intent detection, slot extraction, and
+        the LLM call all run under the new agent's persona and tools.
+        """
+        from taskorbit.database.crud import (
+            get_agent_configuration_by_id,
+            get_agent_configuration_by_name,
+        )
+        from taskorbit.types import ConversationStatus
+
+        mt = request.manual_transfer
+        target_id = mt.target_agent_id if mt else None
+
+        # Resolve by name when only a name was given.
+        if not target_id and mt and mt.target_agent_name and db is not None:
+            record = await get_agent_configuration_by_name(db, mt.target_agent_name)
+            if record:
+                target_id = record.id
+
+        if not target_id:
+            logger.warning(
+                "manual_transfer_agent_not_found",
+                target_id=mt.target_agent_id if mt else None,
+                target_name=mt.target_agent_name if mt else None,
+                conversation_id=request.conversation_id,
+            )
+            return ConversationResponse(
+                conversation_id=request.conversation_id or "",
+                reply=self._make_assistant_message(
+                    "I couldn't find the requested agent. Please try again."
+                ),
+                status=ConversationStatus.ERROR,
+                error="manual_transfer_agent_not_found",
+            )
+
+        # Load the target config from DB.
+        if db is not None:
+            record = await get_agent_configuration_by_id(db, target_id)
+        else:
+            record = None
+
+        if record is None:
+            logger.warning(
+                "manual_transfer_agent_config_missing",
+                target_id=target_id,
+                conversation_id=request.conversation_id,
+            )
+            return ConversationResponse(
+                conversation_id=request.conversation_id or "",
+                reply=self._make_assistant_message(
+                    "I couldn't load the requested agent's configuration."
+                ),
+                status=ConversationStatus.ERROR,
+                error="manual_transfer_agent_config_missing",
+            )
+
+        try:
+            target_config = AgentConfig(**record.config)
+        except Exception as exc:
+            logger.error(
+                "manual_transfer_invalid_config",
+                target_id=target_id,
+                error=str(exc),
+                conversation_id=request.conversation_id,
+            )
+            return ConversationResponse(
+                conversation_id=request.conversation_id or "",
+                reply=self._make_assistant_message(
+                    "The requested agent has an invalid configuration."
+                ),
+                status=ConversationStatus.ERROR,
+                error=str(exc),
+            )
+
+        logger.info(
+            "manual_transfer_executing",
+            from_agent=request.agent_config.id,
+            to_agent=target_id,
+            conversation_id=request.conversation_id,
+        )
+
+        # Re-enter the pipeline with the new agent config; full history is preserved.
+        updated_request = request.model_copy(
+            update={"agent_config": target_config, "manual_transfer": None}
+        )
+        return await self.process_message(updated_request, db)
 
     def _build_system_prompt(
         self,

--- a/backend/src/taskorbit/orchestration/__init__.py
+++ b/backend/src/taskorbit/orchestration/__init__.py
@@ -451,6 +451,7 @@ class ConversationOrchestrator:
         from taskorbit.database.crud import (
             get_agent_configuration_by_id,
             get_agent_configuration_by_name,
+            get_default_agent_template,
         )
         from taskorbit.types import ConversationStatus
 
@@ -479,13 +480,20 @@ class ConversationOrchestrator:
                 error="manual_transfer_agent_not_found",
             )
 
-        # Load the target config from DB.
+        # Load target config — try user's copy first, then built-in template.
+        # Built-in (un-customized) agents live in default_agent_templates, not
+        # agent_configurations, so we need both lookups to cover all dropdown entries.
+        config_dict: dict | None = None
         if db is not None:
             record = await get_agent_configuration_by_id(db, target_id)
-        else:
-            record = None
+            if record is not None:
+                config_dict = record.config
+            else:
+                template = await get_default_agent_template(db, target_id)
+                if template is not None:
+                    config_dict = template.config
 
-        if record is None:
+        if config_dict is None:
             logger.warning(
                 "manual_transfer_agent_config_missing",
                 target_id=target_id,
@@ -501,7 +509,7 @@ class ConversationOrchestrator:
             )
 
         try:
-            target_config = AgentConfig(**record.config)
+            target_config = AgentConfig(**config_dict)
         except Exception as exc:
             logger.error(
                 "manual_transfer_invalid_config",

--- a/backend/src/taskorbit/orchestration/__init__.py
+++ b/backend/src/taskorbit/orchestration/__init__.py
@@ -54,7 +54,10 @@ class ConversationOrchestrator:
         self._intent_router = IntentRouter()
 
     async def process_message(
-        self, request: ConversationRequest, db: AsyncSession | None = None
+        self,
+        request: ConversationRequest,
+        db: AsyncSession | None = None,
+        user_id: int | None = None,
     ) -> ConversationResponse:
         """Main entry point called by the API layer and agent workers."""
         _pipeline_start = time.perf_counter()
@@ -63,7 +66,7 @@ class ConversationOrchestrator:
             if request.manual_transfer and (
                 request.manual_transfer.target_agent_id or request.manual_transfer.target_agent_name
             ):
-                return await self._handle_manual_transfer(request, db)
+                return await self._handle_manual_transfer(request, db, user_id=user_id)
 
             last_user = next(
                 (m for m in reversed(request.messages) if m.role == MessageRole.USER),
@@ -187,7 +190,7 @@ class ConversationOrchestrator:
             from taskorbit.agents import AgentRegistry
 
             agent = await AgentRegistry.create_by_name(
-                intent.agent_name, request.agent_config, self, db=db
+                intent.agent_name, request.agent_config, self, db=db, user_id=user_id
             )
             logger.info(
                 "agent_selected",
@@ -440,6 +443,7 @@ class ConversationOrchestrator:
         self,
         request: ConversationRequest,
         db: AsyncSession | None,
+        user_id: int | None = None,
     ) -> ConversationResponse:
         """Handle a UI-initiated transfer to a specific agent by ID or name.
 
@@ -458,9 +462,12 @@ class ConversationOrchestrator:
         mt = request.manual_transfer
         target_id = mt.target_agent_id if mt else None
 
-        # Resolve by name when only a name was given.
+        # Resolve by name when only a name was given — scope to caller's user_id
+        # so one user can never be routed to another user's agent config.
         if not target_id and mt and mt.target_agent_name and db is not None:
-            record = await get_agent_configuration_by_name(db, mt.target_agent_name)
+            record = await get_agent_configuration_by_name(
+                db, mt.target_agent_name, user_id=user_id
+            )
             if record:
                 target_id = record.id
 
@@ -537,7 +544,7 @@ class ConversationOrchestrator:
         updated_request = request.model_copy(
             update={"agent_config": target_config, "manual_transfer": None}
         )
-        return await self.process_message(updated_request, db)
+        return await self.process_message(updated_request, db, user_id=user_id)
 
     def _build_system_prompt(
         self,

--- a/backend/src/taskorbit/orchestration/__init__.py
+++ b/backend/src/taskorbit/orchestration/__init__.py
@@ -6,6 +6,8 @@ sees the context for the *currently active* task, never the full agent
 config. This prevents prompt drift and keeps the agent grounded.
 
 Flow per message:
+  0a. Manual transfer short-circuit: if request.manual_transfer is set, bypass
+      steps 1–6 entirely and route directly via _handle_manual_transfer.
   1. Detect intent via keyword routing.
   2. Select the agent via AgentRegistry.
   3. Determine which tool (if any) should be in scope right now.
@@ -19,6 +21,7 @@ Flow per message:
 from __future__ import annotations
 
 import asyncio
+import re
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -302,7 +305,17 @@ class ConversationOrchestrator:
                         targets = active_tool.parameters.get("targets") or []
                         if targets:
                             raw = str(targets[0])
-                            normalized = raw.removesuffix("-agent").replace("-", "_")
+                            # Custom agent IDs are UUIDs (hex + hyphens). Pass
+                            # them through untouched; only slug-normalize built-in
+                            # kebab-case names (e.g. "technical-support-agent").
+                            if re.match(
+                                r"^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$",
+                                raw,
+                                re.IGNORECASE,
+                            ):
+                                normalized = raw
+                            else:
+                                normalized = raw.removesuffix("-agent").replace("-", "_")
                             dispatch_context["target_agent_id"] = normalized
                         dispatch_context["conversation_history"] = [
                             {"role": m.role.value, "content": m.content} for m in request.messages
@@ -319,7 +332,9 @@ class ConversationOrchestrator:
                             **active_tool.parameters,
                             "args": dict(slot_result.to_dict()),
                         }
-                    tool_data = await self._dispatch_tool(active_tool, dispatch_context)
+                    tool_data = await self._dispatch_tool(
+                        active_tool, dispatch_context, db=db, user_id=user_id
+                    )
                     logger.info(
                         "tool_dispatch_complete",
                         tool_type=active_tool.type,
@@ -699,6 +714,8 @@ class ConversationOrchestrator:
         self,
         tool: ToolDefinition,
         context: dict[str, Any],
+        db: AsyncSession | None = None,
+        user_id: int | None = None,
     ) -> dict[str, Any]:
         """Execute a tool after the user has confirmed (if required).
 
@@ -724,7 +741,10 @@ class ConversationOrchestrator:
             logger.warning("unknown_tool_type", tool_type=tool.type, tool_id=tool.id)
             return {}
 
-        result: ToolResult = await tool_cls().execute(context)
+        if tool.type == ToolType.AGENT_TRANSFER:
+            result: ToolResult = await AgentTransferTool(db=db, user_id=user_id).execute(context)
+        else:
+            result = await tool_cls().execute(context)
 
         if not result.success:
             logger.warning(

--- a/backend/src/taskorbit/orchestration/__init__.py
+++ b/backend/src/taskorbit/orchestration/__init__.py
@@ -186,7 +186,9 @@ class ConversationOrchestrator:
             # 2. Select agent based on detected intent, not config.id
             from taskorbit.agents import AgentRegistry
 
-            agent = AgentRegistry.create_by_name(intent.agent_name, request.agent_config, self)
+            agent = await AgentRegistry.create_by_name(
+                intent.agent_name, request.agent_config, self, db=db
+            )
             logger.info(
                 "agent_selected",
                 agent=agent.agent_name,

--- a/backend/src/taskorbit/tools/agent_transfer.py
+++ b/backend/src/taskorbit/tools/agent_transfer.py
@@ -2,39 +2,56 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from taskorbit.tools import BaseTool, ToolResult
 from taskorbit.types import ToolType
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
 
 
 def _get_known_agent_names() -> frozenset[str]:
     from taskorbit.agents import AgentRegistry
 
-    return frozenset(cls.agent_name for _, cls in AgentRegistry._REGISTRY)
+    return AgentRegistry.known_agent_names()
 
 
 class AgentTransferTool(BaseTool):
     tool_type = ToolType.AGENT_TRANSFER
 
+    def __init__(self, db: AsyncSession | None = None) -> None:
+        self._db = db
+
+    async def _is_valid_target(self, target_agent_id: str) -> bool:
+        """Return True when target_agent_id is a built-in agent name or a saved custom agent."""
+        if target_agent_id in _get_known_agent_names():
+            return True
+        if self._db is not None:
+            from taskorbit.database.crud import get_agent_configuration_by_id
+
+            record = await get_agent_configuration_by_id(self._db, target_agent_id)
+            return record is not None
+        return False
+
     async def execute(self, parameters: dict[str, Any]) -> ToolResult:
         """Transfer the conversation to another agent, preserving full history.
 
         Expected parameters:
-            target_agent_id (str): agent_name of the destination agent
-                (e.g. "technical_support", "general_inquiry").
-            conversation_history (list[dict]): full message list from the
-                request — passed through untouched so the new agent has context.
+            target_agent_id (str): built-in agent_name (e.g. "technical_support")
+                or the UUID hex ID of a saved custom AgentConfiguration.
+            conversation_history (list[dict]): full message list — passed through
+                so the new agent has full context.
         """
         target_agent_id = parameters.get("target_agent_id", "").strip()
         if not target_agent_id:
             return ToolResult(success=False, error="target_agent_id is required")
 
-        known = _get_known_agent_names()
-        if target_agent_id not in known:
+        if not await self._is_valid_target(target_agent_id):
+            known = sorted(_get_known_agent_names())
             return ToolResult(
                 success=False,
-                error=f"Unknown agent '{target_agent_id}'. Valid agents: {sorted(known)}",
+                error=f"Unknown agent '{target_agent_id}'. Valid built-in agents: {known}",
             )
 
         conversation_history = parameters.get("conversation_history", [])
@@ -49,5 +66,7 @@ class AgentTransferTool(BaseTool):
         )
 
     def validate_parameters(self, parameters: dict[str, Any]) -> bool:
+        # Synchronous check against built-ins only (used for pre-flight validation).
+        # Full validation including custom agents happens async in execute().
         target = parameters.get("target_agent_id", "").strip()
         return bool(target) and target in _get_known_agent_names()

--- a/backend/src/taskorbit/tools/agent_transfer.py
+++ b/backend/src/taskorbit/tools/agent_transfer.py
@@ -20,8 +20,9 @@ def _get_known_agent_names() -> frozenset[str]:
 class AgentTransferTool(BaseTool):
     tool_type = ToolType.AGENT_TRANSFER
 
-    def __init__(self, db: AsyncSession | None = None) -> None:
+    def __init__(self, db: AsyncSession | None = None, user_id: int | None = None) -> None:
         self._db = db
+        self._user_id = user_id
 
     async def _is_valid_target(self, target_agent_id: str) -> bool:
         """Return True when target_agent_id is a built-in agent name or a saved custom agent."""
@@ -30,7 +31,9 @@ class AgentTransferTool(BaseTool):
         if self._db is not None:
             from taskorbit.database.crud import get_agent_configuration_by_id
 
-            record = await get_agent_configuration_by_id(self._db, target_agent_id)
+            record = await get_agent_configuration_by_id(
+                self._db, target_agent_id, user_id=self._user_id
+            )
             return record is not None
         return False
 

--- a/backend/src/taskorbit/types.py
+++ b/backend/src/taskorbit/types.py
@@ -165,6 +165,18 @@ class ConfirmationResponsePayload(BaseModel):
     description: str
 
 
+class ManualTransferRequest(BaseModel):
+    """Carries a UI-initiated agent transfer directive.
+
+    Either ``target_agent_id`` (UUID hex of a saved AgentConfiguration) or
+    ``target_agent_name`` (human-readable name) must be set. When both are
+    provided, ``target_agent_id`` takes precedence.
+    """
+
+    target_agent_id: str | None = None
+    target_agent_name: str | None = None
+
+
 class ConversationRequest(BaseModel):
     conversation_id: str | None = None  # omit on first message; backend assigns and returns one
     agent_config: AgentConfig
@@ -174,6 +186,8 @@ class ConversationRequest(BaseModel):
     # AC #49: Decision fields
     confirmation_id: str | None = None
     decision: Literal["confirm", "reject"] | None = None
+    # Manual transfer: UI-initiated handoff to a specific agent (bypasses intent detection)
+    manual_transfer: ManualTransferRequest | None = None
 
 
 class ConversationResponse(BaseModel):

--- a/backend/src/taskorbit/types.py
+++ b/backend/src/taskorbit/types.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 # ---------------------------------------------------------------------------
 # Enumerations
@@ -175,6 +175,14 @@ class ManualTransferRequest(BaseModel):
 
     target_agent_id: str | None = None
     target_agent_name: str | None = None
+
+    @model_validator(mode="after")
+    def require_at_least_one_target(self) -> ManualTransferRequest:
+        if not (self.target_agent_id or self.target_agent_name):
+            raise ValueError(
+                "ManualTransferRequest requires at least one of target_agent_id or target_agent_name"
+            )
+        return self
 
 
 class ConversationRequest(BaseModel):

--- a/backend/tests/test_agent_runtime.py
+++ b/backend/tests/test_agent_runtime.py
@@ -328,3 +328,64 @@ def test_registry_default_falls_back_to_sales_agent() -> None:
     config = _make_config("unknown-xyz-agent")
     agent = AgentRegistry.create(config, ConversationOrchestrator())
     assert isinstance(agent, SalesAgent)
+
+
+# ---------------------------------------------------------------------------
+# CustomAgent
+# ---------------------------------------------------------------------------
+
+
+def test_registry_known_agent_names_returns_all_builtins() -> None:
+    names = AgentRegistry.known_agent_names()
+    assert "sales" in names
+    assert "technical_support" in names
+    assert "general_inquiry" in names
+    assert "appointment_management" in names
+    assert "customer_dissatisfaction" in names
+
+
+def test_registry_known_agent_names_excludes_custom() -> None:
+    assert "custom" not in AgentRegistry.known_agent_names()
+
+
+def test_create_custom_returns_custom_agent() -> None:
+    from taskorbit.agents import CustomAgent
+
+    config = _make_config("my-custom-bot", name="My Custom Bot")
+    agent = AgentRegistry.create_custom(config, ConversationOrchestrator())
+    assert isinstance(agent, CustomAgent)
+
+
+def test_create_custom_agent_carries_config() -> None:
+    config = _make_config("custom-id", name="Brand Bot")
+    agent = AgentRegistry.create_custom(config, ConversationOrchestrator())
+    assert agent.config.name == "Brand Bot"
+
+
+def test_create_custom_agent_returns_config_tools() -> None:
+    from taskorbit.types import ConfirmationConfig, ToolDefinition, ToolType
+
+    tool = ToolDefinition(
+        id="t1",
+        name="end_call",
+        type=ToolType.END_CALL,
+        description="end",
+        confirmation=ConfirmationConfig(),
+    )
+    config = AgentConfig(
+        id="custom-agent",
+        name="Custom",
+        persona="A custom agent.",
+        greeting="Hi!",
+        tools=[tool],
+    )
+    agent = AgentRegistry.create_custom(config, ConversationOrchestrator())
+    assert agent.get_task_definitions() == [tool]
+
+
+def test_custom_agent_name_is_custom() -> None:
+    from taskorbit.agents import CustomAgent
+
+    config = _make_config("custom-id")
+    agent = CustomAgent(config, ConversationOrchestrator())
+    assert agent.agent_name == "custom"

--- a/backend/tests/test_agent_transfer.py
+++ b/backend/tests/test_agent_transfer.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-import pytest
 from unittest.mock import patch
+
+import pytest
 
 from taskorbit.tools.agent_transfer import AgentTransferTool
 

--- a/backend/tests/test_agent_transfer.py
+++ b/backend/tests/test_agent_transfer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from unittest.mock import patch
 
 from taskorbit.tools.agent_transfer import AgentTransferTool
 
@@ -103,3 +104,72 @@ def test_validate_returns_false_for_empty_id(tool: AgentTransferTool) -> None:
 
 def test_validate_returns_false_for_missing_key(tool: AgentTransferTool) -> None:
     assert tool.validate_parameters({}) is False
+
+
+# ---------------------------------------------------------------------------
+# Custom agent transfer — DB-backed validation
+# ---------------------------------------------------------------------------
+
+
+async def test_transfer_to_custom_agent_succeeds_with_db() -> None:
+    from unittest.mock import AsyncMock, MagicMock
+
+    from taskorbit.database.models import AgentConfiguration
+
+    fake_record = MagicMock(spec=AgentConfiguration)
+    mock_db = AsyncMock()
+
+    with patch(
+        "taskorbit.database.crud.get_agent_configuration_by_id",
+        new_callable=AsyncMock,
+        return_value=fake_record,
+    ):
+        tool = AgentTransferTool(db=mock_db)
+        result = await tool.execute({"target_agent_id": "abc123customagent"})
+
+    assert result.success is True
+    assert result.data["transferred_to"] == "abc123customagent"
+    assert result.data["history_preserved"] is True
+
+
+async def test_transfer_to_unknown_custom_agent_fails_with_db() -> None:
+    from unittest.mock import AsyncMock
+
+    mock_db = AsyncMock()
+
+    with patch(
+        "taskorbit.database.crud.get_agent_configuration_by_id",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        tool = AgentTransferTool(db=mock_db)
+        result = await tool.execute({"target_agent_id": "nonexistent_custom_id"})
+
+    assert result.success is False
+    assert "nonexistent_custom_id" in result.error
+
+
+async def test_transfer_to_custom_agent_fails_without_db() -> None:
+    tool = AgentTransferTool(db=None)
+    result = await tool.execute({"target_agent_id": "some_custom_id_not_builtin"})
+    assert result.success is False
+
+
+async def test_custom_agent_history_preserved_with_db() -> None:
+    from unittest.mock import AsyncMock, MagicMock
+
+    from taskorbit.database.models import AgentConfiguration
+
+    fake_record = MagicMock(spec=AgentConfiguration)
+    mock_db = AsyncMock()
+    history = [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}]
+
+    with patch(
+        "taskorbit.database.crud.get_agent_configuration_by_id",
+        new_callable=AsyncMock,
+        return_value=fake_record,
+    ):
+        tool = AgentTransferTool(db=mock_db)
+        result = await tool.execute({"target_agent_id": "abc123", "conversation_history": history})
+
+    assert result.data["message_count"] == 2

--- a/backend/tests/test_custom_agent_routing.py
+++ b/backend/tests/test_custom_agent_routing.py
@@ -1,0 +1,298 @@
+"""Tests for custom-agent routing: ManualTransferRequest validation,
+AgentRegistry DB fallback, multi-tenancy scoping, and _handle_manual_transfer."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from taskorbit.orchestration import ConversationOrchestrator
+from taskorbit.types import (
+    AgentConfig,
+    ConversationRequest,
+    ConversationStatus,
+    ManualTransferRequest,
+    Message,
+    MessageRole,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_agent_config(**kwargs: Any) -> AgentConfig:
+    defaults: dict[str, Any] = dict(id="agent-1", name="Bot", persona="Helpful bot", greeting="Hi!")
+    defaults.update(kwargs)
+    return AgentConfig(**defaults)
+
+
+def _make_request(
+    content: str = "Hello",
+    manual_transfer: ManualTransferRequest | None = None,
+) -> ConversationRequest:
+    return ConversationRequest(
+        conversation_id="conv-test",
+        agent_config=_make_agent_config(),
+        messages=[Message(role=MessageRole.USER, content=content)],
+        manual_transfer=manual_transfer,
+    )
+
+
+def _make_db_record(config: dict[str, Any], record_id: str = "db-agent-id") -> MagicMock:
+    """Return a mock AgentConfiguration ORM record."""
+    record = MagicMock()
+    record.id = record_id
+    record.config = config
+    return record
+
+
+# ---------------------------------------------------------------------------
+# ManualTransferRequest validation
+# ---------------------------------------------------------------------------
+
+
+class TestManualTransferRequestValidation:
+    def test_valid_with_id_only(self) -> None:
+        req = ManualTransferRequest(target_agent_id="abc123")
+        assert req.target_agent_id == "abc123"
+
+    def test_valid_with_name_only(self) -> None:
+        req = ManualTransferRequest(target_agent_name="Sales Agent")
+        assert req.target_agent_name == "Sales Agent"
+
+    def test_valid_with_both_fields(self) -> None:
+        req = ManualTransferRequest(target_agent_id="abc", target_agent_name="Sales")
+        assert req.target_agent_id == "abc"
+
+    def test_invalid_when_both_none(self) -> None:
+        with pytest.raises(ValidationError, match="at least one of target_agent_id"):
+            ManualTransferRequest()
+
+    def test_invalid_when_both_empty_strings(self) -> None:
+        with pytest.raises(ValidationError, match="at least one of target_agent_id"):
+            ManualTransferRequest(target_agent_id="", target_agent_name="")
+
+
+# ---------------------------------------------------------------------------
+# AgentRegistry.create_by_name — DB fallback with user_id scoping
+# ---------------------------------------------------------------------------
+
+
+class TestAgentRegistryCreateByName:
+    @pytest.mark.asyncio
+    async def test_builtin_agent_resolved_without_db(self) -> None:
+        from taskorbit.agents import AgentRegistry, SalesAgent
+
+        orch = MagicMock()
+        agent = await AgentRegistry.create_by_name("sales", _make_agent_config(), orch, db=None)
+        assert isinstance(agent, SalesAgent)
+
+    @pytest.mark.asyncio
+    async def test_db_fallback_passes_user_id(self) -> None:
+        from taskorbit.agents import AgentRegistry
+
+        custom_config_dict = dict(
+            id="custom-1", name="Custom", persona="Custom persona", greeting="Hi"
+        )
+        db = AsyncMock()
+        record = _make_db_record(custom_config_dict)
+
+        with patch(
+            "taskorbit.database.crud.get_agent_configuration_by_name",
+            new_callable=AsyncMock,
+            return_value=record,
+        ) as mock_lookup:
+            orch = MagicMock()
+            agent = await AgentRegistry.create_by_name(
+                "unknown-intent", _make_agent_config(), orch, db=db, user_id=42
+            )
+
+        mock_lookup.assert_called_once_with(db, "unknown-intent", user_id=42)
+        assert agent.agent_name == "custom"
+
+    @pytest.mark.asyncio
+    async def test_db_fallback_uses_none_user_id_when_omitted(self) -> None:
+        from taskorbit.agents import AgentRegistry
+
+        db = AsyncMock()
+
+        with patch(
+            "taskorbit.database.crud.get_agent_configuration_by_name",
+            new_callable=AsyncMock,
+            return_value=None,
+        ) as mock_lookup:
+            orch = MagicMock()
+            await AgentRegistry.create_by_name("unknown-intent", _make_agent_config(), orch, db=db)
+
+        mock_lookup.assert_called_once_with(db, "unknown-intent", user_id=None)
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_default_when_db_returns_none(self) -> None:
+        from taskorbit.agents import AgentRegistry
+
+        db = AsyncMock()
+
+        with patch(
+            "taskorbit.database.crud.get_agent_configuration_by_name",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            orch = MagicMock()
+            agent = await AgentRegistry.create_by_name(
+                "completely-unknown", _make_agent_config(), orch, db=db, user_id=1
+            )
+
+        # default is SalesAgent
+        assert agent.agent_name in {"sales", "default"}
+
+    @pytest.mark.asyncio
+    async def test_invalid_config_in_db_falls_back_to_default(self) -> None:
+        """A corrupt record.config must not crash the pipeline — fall back to default."""
+        from taskorbit.agents import AgentRegistry
+
+        db = AsyncMock()
+        bad_record = _make_db_record({"totally": "wrong"})
+
+        with patch(
+            "taskorbit.database.crud.get_agent_configuration_by_name",
+            new_callable=AsyncMock,
+            return_value=bad_record,
+        ):
+            orch = MagicMock()
+            agent = await AgentRegistry.create_by_name(
+                "unknown", _make_agent_config(), orch, db=db, user_id=1
+            )
+
+        # Must not raise; falls back gracefully
+        assert agent is not None
+
+
+# ---------------------------------------------------------------------------
+# _handle_manual_transfer — scoping and recursion guard
+# ---------------------------------------------------------------------------
+
+
+class TestHandleManualTransfer:
+    def _make_orch_with_mock_llm(self, reply: str = "Transferred!") -> ConversationOrchestrator:
+        orch = ConversationOrchestrator()
+        orch._call_llm = AsyncMock(return_value=reply)  # type: ignore[method-assign]
+        return orch
+
+    @pytest.mark.asyncio
+    async def test_manual_transfer_cleared_before_re_entering_pipeline(
+        self,
+        mock_good_intent: Any,  # noqa: ARG002
+    ) -> None:
+        """manual_transfer=None on the re-entered request prevents infinite recursion.
+
+        We intercept the second call to process_message (the re-entry after config swap)
+        and capture its request object to verify manual_transfer was cleared.
+        """
+        orch = self._make_orch_with_mock_llm()
+        target_config = dict(id="target-1", name="Target", persona="Target persona", greeting="Hi")
+        db = AsyncMock()
+
+        captured_re_entry: list[ConversationRequest] = []
+
+        original_process = ConversationOrchestrator.process_message
+
+        call_count = {"n": 0}
+
+        async def spy_process(
+            self_: Any,
+            req: ConversationRequest,
+            *args: Any,
+            **kwargs: Any,
+        ) -> Any:
+            call_count["n"] += 1
+            if call_count["n"] > 1:
+                # This is the re-entered call — capture it before delegating
+                captured_re_entry.append(req)
+            return await original_process(self_, req, *args, **kwargs)
+
+        with (
+            patch(
+                "taskorbit.database.crud.get_agent_configuration_by_id",
+                new_callable=AsyncMock,
+                return_value=_make_db_record(target_config, record_id="target-1"),
+            ),
+            patch.object(ConversationOrchestrator, "process_message", spy_process),
+        ):
+            req = _make_request(manual_transfer=ManualTransferRequest(target_agent_id="target-1"))
+            await orch.process_message(req, db=db)
+
+        assert captured_re_entry, "process_message should have been called a second time"
+        re_entered = captured_re_entry[0]
+        assert (
+            re_entered.manual_transfer is None
+        ), "Re-entered request must have manual_transfer=None"
+        assert re_entered.agent_config.id == "target-1"
+
+    @pytest.mark.asyncio
+    async def test_manual_transfer_name_lookup_scoped_to_user_id(self) -> None:
+        """get_agent_configuration_by_name must receive user_id from _handle_manual_transfer."""
+        orch = self._make_orch_with_mock_llm()
+        target_config = dict(id="named-agent", name="Named", persona="Named persona", greeting="Hi")
+        db = AsyncMock()
+
+        with (
+            patch(
+                "taskorbit.database.crud.get_agent_configuration_by_name",
+                new_callable=AsyncMock,
+                return_value=_make_db_record(target_config, record_id="named-agent"),
+            ) as mock_name_lookup,
+            patch(
+                "taskorbit.database.crud.get_agent_configuration_by_id",
+                new_callable=AsyncMock,
+                return_value=_make_db_record(target_config, record_id="named-agent"),
+            ),
+        ):
+            req = _make_request(manual_transfer=ManualTransferRequest(target_agent_name="Named"))
+            await orch._handle_manual_transfer(req, db, user_id=99)
+
+        mock_name_lookup.assert_called_once_with(db, "Named", user_id=99)
+
+    @pytest.mark.asyncio
+    async def test_manual_transfer_returns_error_when_agent_not_found(self) -> None:
+        orch = ConversationOrchestrator()
+        db = AsyncMock()
+
+        with (
+            patch(
+                "taskorbit.database.crud.get_agent_configuration_by_id",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "taskorbit.database.crud.get_default_agent_template",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            req = _make_request(
+                manual_transfer=ManualTransferRequest(target_agent_id="nonexistent")
+            )
+            response = await orch._handle_manual_transfer(req, db, user_id=1)
+
+        assert response.status == ConversationStatus.ERROR
+        assert "manual_transfer_agent_config_missing" in response.error
+
+    @pytest.mark.asyncio
+    async def test_manual_transfer_invalid_config_returns_error(self) -> None:
+        orch = ConversationOrchestrator()
+        db = AsyncMock()
+        bad_record = _make_db_record({"not": "a valid AgentConfig"})
+
+        with patch(
+            "taskorbit.database.crud.get_agent_configuration_by_id",
+            new_callable=AsyncMock,
+            return_value=bad_record,
+        ):
+            req = _make_request(manual_transfer=ManualTransferRequest(target_agent_id="bad-config"))
+            response = await orch._handle_manual_transfer(req, db, user_id=1)
+
+        assert response.status == ConversationStatus.ERROR

--- a/backend/tests/test_orchestration.py
+++ b/backend/tests/test_orchestration.py
@@ -11,6 +11,7 @@ from taskorbit.types import (
     AgentConfig,
     ContextLimitConfig,
     ConversationRequest,
+    ConversationResponse,
     Message,
     MessageRole,
     PersonaConstraints,

--- a/backend/tests/test_orchestration.py
+++ b/backend/tests/test_orchestration.py
@@ -1074,14 +1074,16 @@ async def test_manual_transfer_clears_manual_transfer_on_retry(mock_good_intent:
 
     original = ConversationOrchestrator.process_message
 
-    async def capture(self: Any, request: ConversationRequest, db: Any = None) -> Any:
+    async def capture(
+        self: Any, request: ConversationRequest, db: Any = None, **kwargs: Any
+    ) -> Any:
         seen_requests.append(request)
         if request.manual_transfer is None:
             return ConversationResponse(
                 conversation_id=request.conversation_id or "",
                 reply=Message(role=MessageRole.ASSISTANT, content="ok"),
             )
-        return await original(self, request, db)
+        return await original(self, request, db, **kwargs)
 
     with (
         patch(

--- a/backend/tests/test_orchestration.py
+++ b/backend/tests/test_orchestration.py
@@ -487,7 +487,10 @@ async def test_external_api_dispatch_passes_full_config_plus_args() -> None:
     dispatch_calls: list[dict[str, Any]] = []
 
     async def _capture_dispatch(
-        _self: ConversationOrchestrator, _tool: ToolDefinition, ctx: dict[str, Any]
+        _self: ConversationOrchestrator,
+        _tool: ToolDefinition,
+        ctx: dict[str, Any],
+        **_kwargs: Any,
     ) -> dict[str, Any]:
         dispatch_calls.append(ctx)
         return {"status": 200, "data": {"temp": 18.3}}
@@ -1097,3 +1100,101 @@ async def test_manual_transfer_clears_manual_transfer_on_retry(mock_good_intent:
 
     # Second call must have manual_transfer cleared to avoid infinite recursion.
     assert seen_requests[-1].manual_transfer is None
+
+
+@pytest.mark.asyncio
+async def test_auto_transfer_to_custom_agent_via_process_message() -> None:
+    """AgentTransferTool receives db+user_id through the real _dispatch_tool wiring.
+
+    Drives process_message end-to-end (no _dispatch_tool mock) so the wiring is
+    covered, not just the isolated tool. The mock DB returns a custom AgentConfiguration
+    for the UUID target, proving that db and user_id reach _is_valid_target.
+    """
+    from unittest.mock import MagicMock
+
+    from taskorbit.slots.models import SlotExtractionResult
+    from taskorbit.types import ConfirmationConfig, ToolDefinition, ToolType
+
+    custom_agent_id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+    fake_record = MagicMock()
+    fake_record.id = custom_agent_id
+    fake_record.name = "My Custom Agent"
+    fake_record.config = {
+        "id": custom_agent_id,
+        "name": "My Custom Agent",
+        "persona": "Custom persona",
+        "greeting": "Hello from custom",
+        "tools": [],
+    }
+
+    orch = ConversationOrchestrator()
+    intent = _intent_result()
+    transfer_tool = ToolDefinition(
+        id="transfer-custom",
+        name="agent_transfer",
+        type=ToolType.AGENT_TRANSFER,
+        description="transfer to custom",
+        confirmation=ConfirmationConfig(required=False, prompt=""),
+        parameters={"targets": [custom_agent_id]},
+    )
+
+    with (
+        patch.object(orch._intent_router, "detect", new_callable=AsyncMock, return_value=intent),
+        patch.object(ConversationOrchestrator, "_select_active_tool", return_value=transfer_tool),
+        patch.object(
+            ConversationOrchestrator,
+            "_extract_slots",
+            new_callable=AsyncMock,
+            return_value=SlotExtractionResult(filled={}, missing=[]),
+        ),
+        patch.object(
+            ConversationOrchestrator,
+            "_call_llm",
+            new_callable=AsyncMock,
+            return_value="Transferring.",
+        ),
+        patch(
+            "taskorbit.database.crud.get_agent_configuration_by_id",
+            new_callable=AsyncMock,
+            return_value=fake_record,
+        ),
+    ):
+        mock_db = AsyncMock()
+        response = await orch.process_message(
+            _make_request("transfer me to my custom agent"),
+            db=mock_db,
+            user_id=42,
+        )
+
+    assert response.tool_invoked is not None
+    assert response.tool_invoked.type == ToolType.AGENT_TRANSFER
+    assert response.tool_invoked.parameters.get("targets", [None])[0] == custom_agent_id
+
+
+@pytest.mark.asyncio
+async def test_get_agent_config_by_id_cross_user_returns_none() -> None:
+    """User A cannot retrieve an agent configuration owned by user B via by-id lookup."""
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from taskorbit.database.crud import get_agent_configuration_by_id
+    from taskorbit.database.models import AgentConfiguration
+
+    user_a_id = 1
+    user_b_id = 2
+
+    # DB returns a record owned by user B.
+    user_b_record = MagicMock(spec=AgentConfiguration)
+    user_b_record.id = "some-uuid"
+    user_b_record.user_id = user_b_id
+
+    mock_scalar = MagicMock()
+    mock_scalar.scalar_one_or_none.return_value = None  # WHERE clause filters it out
+
+    mock_db = AsyncMock(spec=AsyncSession)
+    mock_db.execute = AsyncMock(return_value=mock_scalar)
+
+    # When user_id=user_a_id is passed, the WHERE clause scopes to user A.
+    # The mock returns None (simulating that user B's record is excluded).
+    result = await get_agent_configuration_by_id(mock_db, "some-uuid", user_id=user_a_id)
+    assert result is None, "User A must not receive user B's agent configuration"

--- a/backend/tests/test_orchestration.py
+++ b/backend/tests/test_orchestration.py
@@ -981,3 +981,116 @@ async def test_no_intent_lock_when_current_intent_name_absent(mock_good_intent: 
 
     mock_detect.assert_called_once()
     assert response.selected_intent == mock_good_intent.name
+
+
+# ---------------------------------------------------------------------------
+# Manual transfer — UI-initiated handoff to a custom agent
+# ---------------------------------------------------------------------------
+
+
+def _fake_agent_record(agent_id: str = "abc123", name: str = "Custom Bot") -> Any:
+    record = MagicMock()
+    record.id = agent_id
+    record.config = {"id": agent_id, "name": name, "persona": "Custom.", "greeting": "Hi!"}
+    return record
+
+
+@pytest.mark.asyncio
+async def test_manual_transfer_succeeds(mock_good_intent: Any) -> None:
+    from taskorbit.types import ManualTransferRequest
+
+    orch = ConversationOrchestrator()
+    req = ConversationRequest(
+        conversation_id="conv-mt",
+        agent_config=AgentConfig(id="original", name="Original", persona="p", greeting="hi"),
+        messages=[Message(role=MessageRole.USER, content="transfer me")],
+        manual_transfer=ManualTransferRequest(target_agent_id="abc123"),
+    )
+    with (
+        patch(
+            "taskorbit.database.crud.get_agent_configuration_by_id",
+            new_callable=AsyncMock,
+            return_value=_fake_agent_record(),
+        ),
+        patch.object(
+            ConversationOrchestrator, "_call_llm", new_callable=AsyncMock, return_value="ok"
+        ),
+    ):
+        response = await orch.process_message(req, db=AsyncMock())
+
+    assert response.status != "error"
+
+
+@pytest.mark.asyncio
+async def test_manual_transfer_unknown_agent_returns_error() -> None:
+    from taskorbit.types import ConversationStatus, ManualTransferRequest
+
+    orch = ConversationOrchestrator()
+    req = ConversationRequest(
+        conversation_id="conv-mt-bad",
+        agent_config=AgentConfig(id="original", name="Original", persona="p", greeting="hi"),
+        messages=[Message(role=MessageRole.USER, content="transfer me")],
+        manual_transfer=ManualTransferRequest(target_agent_id="does_not_exist"),
+    )
+    with patch(
+        "taskorbit.database.crud.get_agent_configuration_by_id",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        response = await orch.process_message(req, db=AsyncMock())
+
+    assert response.status == ConversationStatus.ERROR
+
+
+@pytest.mark.asyncio
+async def test_manual_transfer_no_db_returns_error() -> None:
+    from taskorbit.types import ConversationStatus, ManualTransferRequest
+
+    orch = ConversationOrchestrator()
+    req = ConversationRequest(
+        conversation_id="conv-mt-nodb",
+        agent_config=AgentConfig(id="original", name="Original", persona="p", greeting="hi"),
+        messages=[Message(role=MessageRole.USER, content="transfer me")],
+        manual_transfer=ManualTransferRequest(target_agent_name="Some Agent"),
+    )
+    response = await orch.process_message(req, db=None)
+
+    assert response.status == ConversationStatus.ERROR
+
+
+@pytest.mark.asyncio
+async def test_manual_transfer_clears_manual_transfer_on_retry(mock_good_intent: Any) -> None:
+    from taskorbit.types import ManualTransferRequest
+
+    orch = ConversationOrchestrator()
+    req = ConversationRequest(
+        conversation_id="conv-mt-clear",
+        agent_config=AgentConfig(id="original", name="Original", persona="p", greeting="hi"),
+        messages=[Message(role=MessageRole.USER, content="hi")],
+        manual_transfer=ManualTransferRequest(target_agent_id="abc123"),
+    )
+    seen_requests: list[ConversationRequest] = []
+
+    original = ConversationOrchestrator.process_message
+
+    async def capture(self: Any, request: ConversationRequest, db: Any = None) -> Any:
+        seen_requests.append(request)
+        if request.manual_transfer is None:
+            return ConversationResponse(
+                conversation_id=request.conversation_id or "",
+                reply=Message(role=MessageRole.ASSISTANT, content="ok"),
+            )
+        return await original(self, request, db)
+
+    with (
+        patch(
+            "taskorbit.database.crud.get_agent_configuration_by_id",
+            new_callable=AsyncMock,
+            return_value=_fake_agent_record(),
+        ),
+        patch.object(ConversationOrchestrator, "process_message", capture),
+    ):
+        await orch.process_message(req, db=AsyncMock())
+
+    # Second call must have manual_transfer cleared to avoid infinite recursion.
+    assert seen_requests[-1].manual_transfer is None

--- a/frontend/src/components/ConversationalChat.tsx
+++ b/frontend/src/components/ConversationalChat.tsx
@@ -265,14 +265,14 @@ export function ConversationalChat() {
             return;
           }
 
-          // Manual transfer: swap active agent config and show badge/marker.
+          // Manual transfer: swap active agent config after backend confirmation.
+          // The transcript announcement was already appended in handleRoutingTargetChange.
           if (manualTransfer?.target_agent_id && response.status !== "error") {
             // The badge appends " Agent", so strip it from the stored name to avoid "Sales Agent Agent".
             const badgeName = manualTransfer.target_agent_name.replace(/\s+[Aa]gent$/i, "").trim();
             manualRoutingLockRef.current = true;
             setRoutedAgent(badgeName);
-            call.appendAssistantTurn(`[Transferred to ${manualTransfer.target_agent_name}]`);
-            // Then try to swap the full agent config so subsequent messages use the new agent.
+            // Try to swap the full agent config so subsequent messages use the new agent.
             try {
               const entries = await fetchUserAgents(controller.signal);
               const match = entries.find(
@@ -283,13 +283,20 @@ export function ConversationalChat() {
               if (match) {
                 const next = backendToFrontendAgent(match);
                 setActiveAgent(next, `ua:${match.template_id ?? match.id}`);
+              } else {
+                call.appendAssistantTurn(
+                  `[Could not transfer to ${manualTransfer.target_agent_name}]`,
+                );
+                setRoutedAgent(null);
+                manualRoutingLockRef.current = false;
               }
             } catch (transferErr) {
               if ((transferErr as Error).name !== "AbortError") {
-                console.warn(
-                  "[ConversationalChat] manual transfer agent lookup failed",
-                  transferErr,
+                call.appendAssistantTurn(
+                  `[Could not transfer to ${manualTransfer.target_agent_name}]`,
                 );
+                setRoutedAgent(null);
+                manualRoutingLockRef.current = false;
               }
             }
           }
@@ -376,9 +383,13 @@ export function ConversationalChat() {
     setRoutedAgent(agentName);
   }, []);
 
-  // Fires the moment the user picks an agent from the @route dropdown — no send needed.
+  // Fires the moment the user picks an agent from the route dropdown.
+  // Shows the transcript announcement and speaks it immediately so the user
+  // gets visual + audio feedback on selection. setActiveAgent is intentionally
+  // NOT called here — the config swap happens in handleSendText after backend
+  // confirmation to avoid swapping before the turn is actually sent.
   const handleRoutingTargetChange = useCallback(
-    async (target: { id: string; name: string } | null) => {
+    (target: { id: string; name: string } | null) => {
       if (!target) {
         manualRoutingLockRef.current = false;
         setRoutedAgent(null);
@@ -390,18 +401,8 @@ export function ConversationalChat() {
       const transferMsg = `Transferring you to ${target.name} upon your request.`;
       call.appendAssistantTurn(transferMsg);
       playSynthesizedSpeech(transferMsg).catch(() => {});
-      try {
-        const entries = await fetchUserAgents();
-        const match = entries.find((e) => e.id === target.id || e.template_id === target.id);
-        if (match) {
-          const next = backendToFrontendAgent(match);
-          setActiveAgent(next, `ua:${match.template_id ?? match.id}`);
-        }
-      } catch {
-        // badge already updated; agent config swap is best-effort
-      }
     },
-    [call, setActiveAgent],
+    [call],
   );
 
   const handleTriggerConfirmation = useCallback(() => {

--- a/frontend/src/components/ConversationalChat.tsx
+++ b/frontend/src/components/ConversationalChat.tsx
@@ -387,7 +387,9 @@ export function ConversationalChat() {
       const badgeName = target.name.replace(/\s+[Aa]gent$/i, "").trim();
       manualRoutingLockRef.current = true;
       setRoutedAgent(badgeName);
-      call.appendAssistantTurn(`Transferring you to ${target.name} upon your request.`);
+      const transferMsg = `Transferring you to ${target.name} upon your request.`;
+      call.appendAssistantTurn(transferMsg);
+      playSynthesizedSpeech(transferMsg).catch(() => {});
       try {
         const entries = await fetchUserAgents();
         const match = entries.find((e) => e.id === target.id || e.template_id === target.id);

--- a/frontend/src/components/ConversationalChat.tsx
+++ b/frontend/src/components/ConversationalChat.tsx
@@ -85,6 +85,9 @@ export function ConversationalChat() {
   // true once the first speaking→idle_in_call transition is detected.
   const [greetingDone, setGreetingDone] = useState(true);
   const [routedAgent, setRoutedAgent] = useState<string | null>(null);
+  // When the user manually routes via the @chip, lock out voice-based routing
+  // overrides until the manual routing is cleared or the session restarts.
+  const manualRoutingLockRef = useRef(false);
   const greetingSeenSpeakingRef = useRef(false);
   const greetingTimeoutRef = useRef<number | null>(null);
   const transcriptEndRef = useRef<HTMLDivElement>(null);
@@ -252,12 +255,43 @@ export function ConversationalChat() {
           );
           call.updateConversationId(response.conversation_id);
           lockedIntentRef.current = response.locked_intent_name ?? null;
-          if (response.selected_agent) setRoutedAgent(response.selected_agent);
+          // For manual transfers, the badge is set from our explicit selection, not
+          // from the backend's intent router (which may still route based on message text).
+          if (!manualTransfer && response.selected_agent) setRoutedAgent(response.selected_agent);
 
           if (response.status === "confirmation_required" && response.confirmation) {
             pendingConfirmationIdRef.current = response.confirmation.confirmation_id;
             call.triggerConfirmation(response.confirmation);
             return;
+          }
+
+          // Manual transfer: swap active agent config and show badge/marker.
+          if (manualTransfer?.target_agent_id && response.status !== "error") {
+            // The badge appends " Agent", so strip it from the stored name to avoid "Sales Agent Agent".
+            const badgeName = manualTransfer.target_agent_name.replace(/\s+[Aa]gent$/i, "").trim();
+            manualRoutingLockRef.current = true;
+            setRoutedAgent(badgeName);
+            call.appendAssistantTurn(`[Transferred to ${manualTransfer.target_agent_name}]`);
+            // Then try to swap the full agent config so subsequent messages use the new agent.
+            try {
+              const entries = await fetchUserAgents(controller.signal);
+              const match = entries.find(
+                (e) =>
+                  e.id === manualTransfer.target_agent_id ||
+                  e.template_id === manualTransfer.target_agent_id,
+              );
+              if (match) {
+                const next = backendToFrontendAgent(match);
+                setActiveAgent(next, `ua:${match.template_id ?? match.id}`);
+              }
+            } catch (transferErr) {
+              if ((transferErr as Error).name !== "AbortError") {
+                console.warn(
+                  "[ConversationalChat] manual transfer agent lookup failed",
+                  transferErr,
+                );
+              }
+            }
           }
 
           const replyText = response.reply.content;
@@ -271,14 +305,8 @@ export function ConversationalChat() {
             return;
           }
 
-          // Agent handoff (#8 Task 6): backend's IntentRouter / dispatch decided
-          // to transfer the conversation. Swap the displayed agent and add a
-          // transcript marker so the user sees the switch.
-          // NOTE: backend currently exposes only the agent's configured targets
-          // in tool_invoked.parameters; the actual transferred_to id from
-          // ToolResult.data is not propagated (orchestration/__init__.py:169).
-          // First target works for single-target configs (e.g. JOHN_DOE_AGENT).
-          if (response.tool_invoked?.type === "agent_transfer") {
+          // Auto agent handoff via agent_transfer tool (#8 Task 6).
+          if (!manualTransfer && response.tool_invoked?.type === "agent_transfer") {
             const targets = (response.tool_invoked.parameters as { targets?: string[] })?.targets;
             const targetId = targets?.[0];
             if (targetId) {
@@ -344,8 +372,35 @@ export function ConversationalChat() {
   );
 
   const handleVoiceAgentRouted = useCallback((agentName: string) => {
+    if (manualRoutingLockRef.current) return;
     setRoutedAgent(agentName);
   }, []);
+
+  // Fires the moment the user picks an agent from the @route dropdown — no send needed.
+  const handleRoutingTargetChange = useCallback(
+    async (target: { id: string; name: string } | null) => {
+      if (!target) {
+        manualRoutingLockRef.current = false;
+        setRoutedAgent(null);
+        return;
+      }
+      const badgeName = target.name.replace(/\s+[Aa]gent$/i, "").trim();
+      manualRoutingLockRef.current = true;
+      setRoutedAgent(badgeName);
+      call.appendAssistantTurn(`Transferring you to ${target.name} upon your request.`);
+      try {
+        const entries = await fetchUserAgents();
+        const match = entries.find((e) => e.id === target.id || e.template_id === target.id);
+        if (match) {
+          const next = backendToFrontendAgent(match);
+          setActiveAgent(next, `ua:${match.template_id ?? match.id}`);
+        }
+      } catch {
+        // badge already updated; agent config swap is best-effort
+      }
+    },
+    [call, setActiveAgent],
+  );
 
   const handleTriggerConfirmation = useCallback(() => {
     // Confirmation is triggered by the backend response, not a UI button.
@@ -422,6 +477,7 @@ export function ConversationalChat() {
 
   const handleRestart = useCallback(() => {
     lockedIntentRef.current = null;
+    manualRoutingLockRef.current = false;
     setRoutedAgent(null);
     call.restart();
   }, [call]);
@@ -556,6 +612,7 @@ export function ConversationalChat() {
             onPhase={call.setPhase}
             onEnd={call.end}
             onSendText={handleSendText}
+            onRoutingTargetChange={handleRoutingTargetChange}
             onTriggerConfirmation={handleTriggerConfirmation}
             onMicError={call.setMicError}
           />

--- a/frontend/src/components/ConversationalChat.tsx
+++ b/frontend/src/components/ConversationalChat.tsx
@@ -218,7 +218,10 @@ export function ConversationalChat() {
   );
 
   const handleSendText = useCallback(
-    (text: string) => {
+    (
+      text: string,
+      manualTransfer?: { target_agent_id: string; target_agent_name: string } | null,
+    ) => {
       let convId = call.conversationId;
       // If the user starts a session via the "Use text instead" input rather than the
       // "Start session" button, the UI state is still 'idle'. We must explicitly
@@ -243,6 +246,9 @@ export function ConversationalChat() {
             convId,
             controller.signal,
             lockedIntentRef.current,
+            null,
+            null,
+            manualTransfer ?? null,
           );
           call.updateConversationId(response.conversation_id);
           lockedIntentRef.current = response.locked_intent_name ?? null;

--- a/frontend/src/components/chat/InCallControls.tsx
+++ b/frontend/src/components/chat/InCallControls.tsx
@@ -75,20 +75,22 @@ export function InCallControls({
   const atMentionStartRef = useRef<number | null>(null);
 
   // Fetch all agents (built-in templates + user DB copies) once when menu first opens.
-  // De-duplicate by template_id: prefer the user's customized copy over the raw template.
+  // Load all agents: every custom agent + every built-in template, deduplicated by id only.
+  // We intentionally show both a user's custom copy AND the original built-in so the user
+  // can route to any of them independently.
   const loadAgents = async () => {
     if (agents.length > 0) return;
     try {
       const entries = await fetchUserAgents();
-      const seen = new Map<string, RoutingTarget>();
+      const seen = new Set<string>();
+      const result: RoutingTarget[] = [];
       for (const e of entries) {
-        const key = e.template_id ?? e.id;
-        // Customized copies take priority over raw templates for the same key.
-        if (!seen.has(key) || e.is_customized) {
-          seen.set(key, { id: e.id, name: e.name });
+        if (!seen.has(e.id)) {
+          seen.add(e.id);
+          result.push({ id: e.id, name: e.name });
         }
       }
-      setAgents([...seen.values()]);
+      setAgents(result);
     } catch {
       // silently ignore — menu stays empty
     }

--- a/frontend/src/components/chat/InCallControls.tsx
+++ b/frontend/src/components/chat/InCallControls.tsx
@@ -70,9 +70,7 @@ export function InCallControls({
   const [routingTarget, setRoutingTarget] = useState<RoutingTarget | null>(null);
   const [menuOpen, setMenuOpen] = useState(false);
   const [agents, setAgents] = useState<RoutingTarget[]>([]);
-  const [menuFilter, setMenuFilter] = useState("");
   const menuRef = useRef<HTMLDivElement>(null);
-  const atMentionStartRef = useRef<number | null>(null);
 
   // Fetch all agents (built-in templates + user DB copies) once when menu first opens.
   // Load all agents: every custom agent + every built-in template, deduplicated by id only.
@@ -98,7 +96,6 @@ export function InCallControls({
 
   const openMenu = () => {
     void loadAgents();
-    setMenuFilter("");
     setMenuOpen(true);
   };
 
@@ -106,11 +103,6 @@ export function InCallControls({
     setRoutingTarget(agent);
     onRoutingTargetChange?.(agent);
     setMenuOpen(false);
-    // Remove any trailing @-mention text from draft
-    if (atMentionStartRef.current !== null) {
-      setDraft((d) => d.slice(0, atMentionStartRef.current!));
-      atMentionStartRef.current = null;
-    }
     textareaRef.current?.focus();
   };
 
@@ -118,7 +110,6 @@ export function InCallControls({
     setRoutingTarget(null);
     onRoutingTargetChange?.(null);
     setMenuOpen(false);
-    atMentionStartRef.current = null;
   };
 
   // Close menu on outside click
@@ -127,16 +118,13 @@ export function InCallControls({
     const handler = (e: MouseEvent) => {
       if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
         setMenuOpen(false);
-        atMentionStartRef.current = null;
       }
     };
     document.addEventListener("mousedown", handler);
     return () => document.removeEventListener("mousedown", handler);
   }, [menuOpen]);
 
-  const filteredAgents = agents.filter((a) =>
-    a.name.toLowerCase().includes(menuFilter.toLowerCase()),
-  );
+  const filteredAgents = agents;
 
   useEffect(() => {
     if (mic.error) {
@@ -298,7 +286,6 @@ export function InCallControls({
     onSendText(text, transfer);
     setDraft("");
     setRoutingTarget(null);
-    atMentionStartRef.current = null;
     if (textareaRef.current) textareaRef.current.style.height = "auto";
   };
 

--- a/frontend/src/components/chat/InCallControls.tsx
+++ b/frontend/src/components/chat/InCallControls.tsx
@@ -74,12 +74,21 @@ export function InCallControls({
   const menuRef = useRef<HTMLDivElement>(null);
   const atMentionStartRef = useRef<number | null>(null);
 
-  // Fetch agents once when menu first opens
+  // Fetch all agents (built-in templates + user DB copies) once when menu first opens.
+  // De-duplicate by template_id: prefer the user's customized copy over the raw template.
   const loadAgents = async () => {
     if (agents.length > 0) return;
     try {
       const entries = await fetchUserAgents();
-      setAgents(entries.map((e) => ({ id: e.id, name: e.name })));
+      const seen = new Map<string, RoutingTarget>();
+      for (const e of entries) {
+        const key = e.template_id ?? e.id;
+        // Customized copies take priority over raw templates for the same key.
+        if (!seen.has(key) || e.is_customized) {
+          seen.set(key, { id: e.id, name: e.name });
+        }
+      }
+      setAgents([...seen.values()]);
     } catch {
       // silently ignore — menu stays empty
     }

--- a/frontend/src/components/chat/InCallControls.tsx
+++ b/frontend/src/components/chat/InCallControls.tsx
@@ -17,7 +17,7 @@
  */
 
 import { useEffect, useId, useRef, useState } from "react";
-import { ArrowUp, Check, Mic, PhoneOff, Wand2, X } from "lucide-react";
+import { ArrowUp, Check, Mic, PhoneOff, UserRoundCog, X } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { useMicRecorder } from "@/hooks/useMicRecorder";
@@ -44,6 +44,8 @@ type Props = {
     text: string,
     manualTransfer?: { target_agent_id: string; target_agent_name: string } | null,
   ) => void;
+  /** Fires immediately when the user picks (or clears) an agent from the @route menu. */
+  onRoutingTargetChange?: (target: { id: string; name: string } | null) => void;
   onTriggerConfirmation: () => void;
   onMicError: (message: string | null) => void;
 };
@@ -54,6 +56,7 @@ export function InCallControls({
   onPhase,
   onEnd,
   onSendText,
+  onRoutingTargetChange,
   onTriggerConfirmation,
   onMicError,
 }: Props) {
@@ -90,6 +93,7 @@ export function InCallControls({
 
   const selectAgent = (agent: RoutingTarget) => {
     setRoutingTarget(agent);
+    onRoutingTargetChange?.(agent);
     setMenuOpen(false);
     // Remove any trailing @-mention text from draft
     if (atMentionStartRef.current !== null) {
@@ -101,6 +105,7 @@ export function InCallControls({
 
   const clearRouting = () => {
     setRoutingTarget(null);
+    onRoutingTargetChange?.(null);
     setMenuOpen(false);
     atMentionStartRef.current = null;
   };
@@ -334,13 +339,94 @@ export function InCallControls({
   return (
     <div className="rounded-xl border bg-card p-3.5">
       <div className="flex items-center gap-2.5">
-        {/* ── Pill input (always text mode) ── */}
-        <div className="relative flex-1">
-          {/* Routing dropdown menu */}
+        {/* ── Pill input ── */}
+        <div
+          className={cn(
+            "flex flex-1 items-end gap-2 rounded-full border bg-background px-5 py-2 transition-colors",
+            "focus-within:border-primary/40",
+          )}
+        >
+          <label htmlFor={inputId} className="sr-only">
+            Message
+          </label>
+          <textarea
+            ref={textareaRef}
+            id={inputId}
+            rows={1}
+            value={draft}
+            onChange={(e) => {
+              setDraft(e.target.value);
+              e.target.style.height = "auto";
+              e.target.style.height = Math.min(e.target.scrollHeight, 160) + "px";
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                handleSendText();
+              }
+            }}
+            placeholder={
+              awaitingConfirmation
+                ? "Approve or deny the action above to continue…"
+                : "Ask from Orbit."
+            }
+            autoComplete="off"
+            disabled={textDisabled}
+            className={cn(
+              "flex-1 resize-none bg-transparent py-2 text-sm outline-none",
+              "max-h-[160px] overflow-y-auto leading-relaxed",
+              "placeholder:text-muted-foreground/60",
+              "disabled:cursor-not-allowed disabled:opacity-50",
+            )}
+          />
+          <button
+            type="button"
+            onClick={handleSendText}
+            disabled={textDisabled || !draft.trim()}
+            aria-label="Send message"
+            className={cn(
+              "flex size-9 shrink-0 items-center justify-center rounded-full transition-all",
+              "bg-primary text-primary-foreground hover:bg-primary/90 active:scale-95",
+              "disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground",
+            )}
+          >
+            <ArrowUp size={16} />
+          </button>
+        </div>
+
+        {/* ── Mic toggle button ── */}
+        <button
+          type="button"
+          onClick={handleVoiceBtnClick}
+          disabled={voiceBtnDisabled}
+          aria-pressed={continuousMode}
+          aria-label={continuousMode ? "Stop listening" : "Start voice mode"}
+          className={cn(
+            "flex size-11 shrink-0 items-center justify-center rounded-full border",
+            "transition-all duration-200",
+            "disabled:cursor-not-allowed disabled:opacity-50",
+            voiceBtnCls === "" && "border-border bg-card text-foreground hover:bg-muted",
+            voiceBtnCls === "listening" &&
+              "border-transparent bg-primary text-primary-foreground shadow-[0_0_0_4px_hsl(var(--primary)/0.18)]",
+            voiceBtnCls === "speaking" &&
+              "border-transparent bg-violet-500 text-white shadow-[0_0_0_4px_rgb(139_92_246/0.22)]",
+            voiceBtnCls === "processing" &&
+              "border-transparent bg-amber-500 text-white shadow-[0_0_0_4px_rgb(245_158_11/0.22)]",
+          )}
+        >
+          {voiceBtnCls === "listening" || voiceBtnCls === "speaking" ? (
+            <VoiceWaveBars />
+          ) : (
+            <Mic size={18} />
+          )}
+        </button>
+
+        {/* ── Agent routing button + dropdown ── */}
+        <div className="relative shrink-0">
           {menuOpen && (
             <div
               ref={menuRef}
-              className="absolute bottom-full mb-2 left-0 z-50 w-56 rounded-xl border bg-popover shadow-lg py-1.5"
+              className="absolute bottom-full right-0 mb-2 z-50 w-56 rounded-xl border bg-popover shadow-lg py-1.5"
             >
               <p className="px-3 py-1 text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
                 Route to agent
@@ -381,157 +467,22 @@ export function InCallControls({
               )}
             </div>
           )}
-
-          <div
+          <button
+            type="button"
+            onClick={openMenu}
+            aria-label="Route to agent"
+            title={routingTarget ? `Routed to ${routingTarget.name}` : "Route to agent"}
             className={cn(
-              "flex flex-1 items-end gap-2 rounded-full border bg-background px-5 py-2 transition-colors",
-              "focus-within:border-primary/40",
+              "flex size-11 shrink-0 items-center justify-center rounded-full border transition-all",
+              routingTarget
+                ? "border-transparent text-white"
+                : "border-border bg-card text-foreground hover:bg-muted",
             )}
+            style={routingTarget ? { background: AGENT_COLORS[0] } : undefined}
           >
-            {/* @route chip or routed agent chip */}
-            {routingTarget ? (
-              <button
-                type="button"
-                onClick={openMenu}
-                className="mb-2 inline-flex shrink-0 items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium text-white transition-colors hover:opacity-80"
-                style={{ background: AGENT_COLORS[0] }}
-              >
-                @{routingTarget.name}
-                <span
-                  role="button"
-                  aria-label="Clear routing"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    clearRouting();
-                  }}
-                  className="ml-0.5 cursor-pointer"
-                >
-                  <X size={11} />
-                </span>
-              </button>
-            ) : (
-              <button
-                type="button"
-                onClick={openMenu}
-                disabled={textDisabled}
-                aria-label="Route to agent"
-                className={cn(
-                  "mb-2 inline-flex shrink-0 items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors",
-                  "border-muted-foreground/30 text-muted-foreground hover:border-primary/50 hover:text-primary",
-                  "disabled:pointer-events-none disabled:opacity-40",
-                )}
-              >
-                @route
-              </button>
-            )}
-
-            <label htmlFor={inputId} className="sr-only">
-              Message
-            </label>
-            <textarea
-              ref={textareaRef}
-              id={inputId}
-              rows={1}
-              value={draft}
-              onChange={(e) => {
-                const val = e.target.value;
-                setDraft(val);
-                e.target.style.height = "auto";
-                e.target.style.height = Math.min(e.target.scrollHeight, 160) + "px";
-
-                // Detect @ trigger for agent routing menu
-                const cursor = e.target.selectionStart ?? val.length;
-                const lastAt = val.lastIndexOf("@", cursor - 1);
-                if (lastAt !== -1 && (lastAt === 0 || val[lastAt - 1] === " ")) {
-                  const fragment = val.slice(lastAt + 1, cursor);
-                  atMentionStartRef.current = lastAt;
-                  setMenuFilter(fragment);
-                  if (!menuOpen) void loadAgents().then(() => setMenuOpen(true));
-                } else if (menuOpen) {
-                  setMenuOpen(false);
-                  atMentionStartRef.current = null;
-                }
-              }}
-              onKeyDown={(e) => {
-                if (e.key === "Escape" && menuOpen) {
-                  e.preventDefault();
-                  setMenuOpen(false);
-                  atMentionStartRef.current = null;
-                  return;
-                }
-                if (e.key === "Enter" && !e.shiftKey) {
-                  e.preventDefault();
-                  handleSendText();
-                }
-              }}
-              placeholder={
-                awaitingConfirmation
-                  ? "Approve or deny the action above to continue…"
-                  : "Ask from Orbit."
-              }
-              autoComplete="off"
-              disabled={textDisabled}
-              className={cn(
-                "flex-1 resize-none bg-transparent py-2 text-sm outline-none",
-                "max-h-[160px] overflow-y-auto leading-relaxed",
-                "placeholder:text-muted-foreground/60",
-                "disabled:cursor-not-allowed disabled:opacity-50",
-              )}
-            />
-            <button
-              type="button"
-              onClick={handleSendText}
-              disabled={textDisabled || !draft.trim()}
-              aria-label="Send message"
-              className={cn(
-                "flex size-9 shrink-0 items-center justify-center rounded-full transition-all",
-                "bg-primary text-primary-foreground hover:bg-primary/90 active:scale-95",
-                "disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground",
-              )}
-            >
-              <ArrowUp size={16} />
-            </button>
-          </div>
+            <UserRoundCog size={16} />
+          </button>
         </div>
-        {/* end relative flex-1 wrapper */}
-
-        {/* ── Mic toggle button ── */}
-        <button
-          type="button"
-          onClick={handleVoiceBtnClick}
-          disabled={voiceBtnDisabled}
-          aria-pressed={continuousMode}
-          aria-label={continuousMode ? "Stop listening" : "Start voice mode"}
-          className={cn(
-            "flex size-11 shrink-0 items-center justify-center rounded-full border",
-            "transition-all duration-200",
-            "disabled:cursor-not-allowed disabled:opacity-50",
-            voiceBtnCls === "" && "border-border bg-card text-foreground hover:bg-muted",
-            voiceBtnCls === "listening" &&
-              "border-transparent bg-primary text-primary-foreground shadow-[0_0_0_4px_hsl(var(--primary)/0.18)]",
-            voiceBtnCls === "speaking" &&
-              "border-transparent bg-violet-500 text-white shadow-[0_0_0_4px_rgb(139_92_246/0.22)]",
-            voiceBtnCls === "processing" &&
-              "border-transparent bg-amber-500 text-white shadow-[0_0_0_4px_rgb(245_158_11/0.22)]",
-          )}
-        >
-          {voiceBtnCls === "listening" || voiceBtnCls === "speaking" ? (
-            <VoiceWaveBars />
-          ) : (
-            <Mic size={18} />
-          )}
-        </button>
-
-        {/* ── Demo confirmation (icon-only) ── */}
-        <button
-          type="button"
-          onClick={onTriggerConfirmation}
-          aria-label="Demo: trigger agent confirmation"
-          title="Demo: simulate the agent asking for confirmation"
-          className="flex size-9 shrink-0 items-center justify-center rounded-full border bg-card text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-        >
-          <Wand2 size={15} />
-        </button>
 
         {/* ── End call ── */}
         <button

--- a/frontend/src/components/chat/InCallControls.tsx
+++ b/frontend/src/components/chat/InCallControls.tsx
@@ -470,15 +470,21 @@ export function InCallControls({
           <button
             type="button"
             onClick={openMenu}
+            disabled={status !== "idle_in_call"}
             aria-label="Route to agent"
             title={routingTarget ? `Routed to ${routingTarget.name}` : "Route to agent"}
             className={cn(
               "flex size-11 shrink-0 items-center justify-center rounded-full border transition-all",
+              "disabled:cursor-not-allowed disabled:opacity-40",
               routingTarget
                 ? "border-transparent text-white"
                 : "border-border bg-card text-foreground hover:bg-muted",
             )}
-            style={routingTarget ? { background: AGENT_COLORS[0] } : undefined}
+            style={
+              routingTarget && status === "idle_in_call"
+                ? { background: AGENT_COLORS[0] }
+                : undefined
+            }
           >
             <UserRoundCog size={16} />
           </button>

--- a/frontend/src/components/chat/InCallControls.tsx
+++ b/frontend/src/components/chat/InCallControls.tsx
@@ -57,7 +57,7 @@ export function InCallControls({
   onEnd,
   onSendText,
   onRoutingTargetChange,
-  onTriggerConfirmation,
+  onTriggerConfirmation: _onTriggerConfirmation,
   onMicError,
 }: Props) {
   const mic = useMicRecorder();

--- a/frontend/src/components/chat/InCallControls.tsx
+++ b/frontend/src/components/chat/InCallControls.tsx
@@ -17,13 +17,22 @@
  */
 
 import { useEffect, useId, useRef, useState } from "react";
-import { ArrowUp, Mic, PhoneOff, Wand2 } from "lucide-react";
+import { ArrowUp, Check, Mic, PhoneOff, Wand2, X } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { useMicRecorder } from "@/hooks/useMicRecorder";
 import { useSilenceDetection } from "@/hooks/useSilenceDetection";
 import { useVoiceActivityMonitor } from "@/hooks/useVoiceActivityMonitor";
+import { fetchUserAgents } from "@/lib/userAgentsApi";
 import type { CallStatus } from "@/types/callState";
+
+type RoutingTarget = { id: string; name: string };
+
+const AGENT_COLORS = [
+  "oklch(0.66 0.18 295)", // purple
+  "oklch(0.68 0.16 245)", // blue
+  "oklch(0.74 0.15 162)", // green
+];
 
 type Props = {
   status: CallStatus;
@@ -31,7 +40,10 @@ type Props = {
   greetingInProgress?: boolean;
   onPhase: (phase: CallStatus) => void;
   onEnd: () => void;
-  onSendText: (text: string) => void;
+  onSendText: (
+    text: string,
+    manualTransfer?: { target_agent_id: string; target_agent_name: string } | null,
+  ) => void;
   onTriggerConfirmation: () => void;
   onMicError: (message: string | null) => void;
 };
@@ -50,6 +62,65 @@ export function InCallControls({
   const [continuousMode, setContinuousMode] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const inputId = useId();
+
+  // ── Agent routing ────────────────────────────────────────────────────────
+  const [routingTarget, setRoutingTarget] = useState<RoutingTarget | null>(null);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [agents, setAgents] = useState<RoutingTarget[]>([]);
+  const [menuFilter, setMenuFilter] = useState("");
+  const menuRef = useRef<HTMLDivElement>(null);
+  const atMentionStartRef = useRef<number | null>(null);
+
+  // Fetch agents once when menu first opens
+  const loadAgents = async () => {
+    if (agents.length > 0) return;
+    try {
+      const entries = await fetchUserAgents();
+      setAgents(entries.map((e) => ({ id: e.id, name: e.name })));
+    } catch {
+      // silently ignore — menu stays empty
+    }
+  };
+
+  const openMenu = () => {
+    void loadAgents();
+    setMenuFilter("");
+    setMenuOpen(true);
+  };
+
+  const selectAgent = (agent: RoutingTarget) => {
+    setRoutingTarget(agent);
+    setMenuOpen(false);
+    // Remove any trailing @-mention text from draft
+    if (atMentionStartRef.current !== null) {
+      setDraft((d) => d.slice(0, atMentionStartRef.current!));
+      atMentionStartRef.current = null;
+    }
+    textareaRef.current?.focus();
+  };
+
+  const clearRouting = () => {
+    setRoutingTarget(null);
+    setMenuOpen(false);
+    atMentionStartRef.current = null;
+  };
+
+  // Close menu on outside click
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpen(false);
+        atMentionStartRef.current = null;
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [menuOpen]);
+
+  const filteredAgents = agents.filter((a) =>
+    a.name.toLowerCase().includes(menuFilter.toLowerCase()),
+  );
 
   useEffect(() => {
     if (mic.error) {
@@ -205,8 +276,13 @@ export function InCallControls({
   const handleSendText = (): void => {
     const text = draft.trim();
     if (!text) return;
-    onSendText(text);
+    const transfer = routingTarget
+      ? { target_agent_id: routingTarget.id, target_agent_name: routingTarget.name }
+      : null;
+    onSendText(text, transfer);
     setDraft("");
+    setRoutingTarget(null);
+    atMentionStartRef.current = null;
     if (textareaRef.current) textareaRef.current.style.height = "auto";
   };
 
@@ -259,59 +335,165 @@ export function InCallControls({
     <div className="rounded-xl border bg-card p-3.5">
       <div className="flex items-center gap-2.5">
         {/* ── Pill input (always text mode) ── */}
-        <div
-          className={cn(
-            "flex flex-1 items-end gap-2 rounded-full border bg-background px-5 py-2 transition-colors",
-            "focus-within:border-primary/40",
+        <div className="relative flex-1">
+          {/* Routing dropdown menu */}
+          {menuOpen && (
+            <div
+              ref={menuRef}
+              className="absolute bottom-full mb-2 left-0 z-50 w-56 rounded-xl border bg-popover shadow-lg py-1.5"
+            >
+              <p className="px-3 py-1 text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
+                Route to agent
+              </p>
+              {filteredAgents.length === 0 ? (
+                <p className="px-3 py-2 text-xs text-muted-foreground">No agents found</p>
+              ) : (
+                filteredAgents.map((a, i) => (
+                  <button
+                    key={a.id}
+                    type="button"
+                    onClick={() => selectAgent(a)}
+                    className="flex w-full items-center gap-2.5 px-3 py-2 text-sm hover:bg-muted transition-colors"
+                  >
+                    <span
+                      className="size-2.5 shrink-0 rounded-full"
+                      style={{ background: AGENT_COLORS[i % AGENT_COLORS.length] }}
+                    />
+                    <span className="flex-1 truncate text-left">{a.name}</span>
+                    {routingTarget?.id === a.id && (
+                      <Check size={13} className="shrink-0 text-primary" />
+                    )}
+                  </button>
+                ))
+              )}
+              {routingTarget && (
+                <>
+                  <div className="my-1 border-t" />
+                  <button
+                    type="button"
+                    onClick={clearRouting}
+                    className="flex w-full items-center gap-2.5 px-3 py-2 text-sm text-muted-foreground hover:bg-muted transition-colors"
+                  >
+                    <X size={13} className="shrink-0" />
+                    Clear routing
+                  </button>
+                </>
+              )}
+            </div>
           )}
-        >
-          <label htmlFor={inputId} className="sr-only">
-            Message
-          </label>
-          <textarea
-            ref={textareaRef}
-            id={inputId}
-            rows={1}
-            value={draft}
-            onChange={(e) => {
-              setDraft(e.target.value);
-              e.target.style.height = "auto";
-              e.target.style.height = Math.min(e.target.scrollHeight, 160) + "px";
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && !e.shiftKey) {
-                e.preventDefault();
-                handleSendText();
-              }
-            }}
-            placeholder={
-              awaitingConfirmation
-                ? "Approve or deny the action above to continue…"
-                : "Ask from Orbit."
-            }
-            autoComplete="off"
-            disabled={textDisabled}
+
+          <div
             className={cn(
-              "flex-1 resize-none bg-transparent py-2 text-sm outline-none",
-              "max-h-[160px] overflow-y-auto leading-relaxed",
-              "placeholder:text-muted-foreground/60",
-              "disabled:cursor-not-allowed disabled:opacity-50",
-            )}
-          />
-          <button
-            type="button"
-            onClick={handleSendText}
-            disabled={textDisabled || !draft.trim()}
-            aria-label="Send message"
-            className={cn(
-              "flex size-9 shrink-0 items-center justify-center rounded-full transition-all",
-              "bg-primary text-primary-foreground hover:bg-primary/90 active:scale-95",
-              "disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground",
+              "flex flex-1 items-end gap-2 rounded-full border bg-background px-5 py-2 transition-colors",
+              "focus-within:border-primary/40",
             )}
           >
-            <ArrowUp size={16} />
-          </button>
+            {/* @route chip or routed agent chip */}
+            {routingTarget ? (
+              <button
+                type="button"
+                onClick={openMenu}
+                className="mb-2 inline-flex shrink-0 items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium text-white transition-colors hover:opacity-80"
+                style={{ background: AGENT_COLORS[0] }}
+              >
+                @{routingTarget.name}
+                <span
+                  role="button"
+                  aria-label="Clear routing"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    clearRouting();
+                  }}
+                  className="ml-0.5 cursor-pointer"
+                >
+                  <X size={11} />
+                </span>
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={openMenu}
+                disabled={textDisabled}
+                aria-label="Route to agent"
+                className={cn(
+                  "mb-2 inline-flex shrink-0 items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors",
+                  "border-muted-foreground/30 text-muted-foreground hover:border-primary/50 hover:text-primary",
+                  "disabled:pointer-events-none disabled:opacity-40",
+                )}
+              >
+                @route
+              </button>
+            )}
+
+            <label htmlFor={inputId} className="sr-only">
+              Message
+            </label>
+            <textarea
+              ref={textareaRef}
+              id={inputId}
+              rows={1}
+              value={draft}
+              onChange={(e) => {
+                const val = e.target.value;
+                setDraft(val);
+                e.target.style.height = "auto";
+                e.target.style.height = Math.min(e.target.scrollHeight, 160) + "px";
+
+                // Detect @ trigger for agent routing menu
+                const cursor = e.target.selectionStart ?? val.length;
+                const lastAt = val.lastIndexOf("@", cursor - 1);
+                if (lastAt !== -1 && (lastAt === 0 || val[lastAt - 1] === " ")) {
+                  const fragment = val.slice(lastAt + 1, cursor);
+                  atMentionStartRef.current = lastAt;
+                  setMenuFilter(fragment);
+                  if (!menuOpen) void loadAgents().then(() => setMenuOpen(true));
+                } else if (menuOpen) {
+                  setMenuOpen(false);
+                  atMentionStartRef.current = null;
+                }
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Escape" && menuOpen) {
+                  e.preventDefault();
+                  setMenuOpen(false);
+                  atMentionStartRef.current = null;
+                  return;
+                }
+                if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
+                  handleSendText();
+                }
+              }}
+              placeholder={
+                awaitingConfirmation
+                  ? "Approve or deny the action above to continue…"
+                  : "Ask from Orbit."
+              }
+              autoComplete="off"
+              disabled={textDisabled}
+              className={cn(
+                "flex-1 resize-none bg-transparent py-2 text-sm outline-none",
+                "max-h-[160px] overflow-y-auto leading-relaxed",
+                "placeholder:text-muted-foreground/60",
+                "disabled:cursor-not-allowed disabled:opacity-50",
+              )}
+            />
+            <button
+              type="button"
+              onClick={handleSendText}
+              disabled={textDisabled || !draft.trim()}
+              aria-label="Send message"
+              className={cn(
+                "flex size-9 shrink-0 items-center justify-center rounded-full transition-all",
+                "bg-primary text-primary-foreground hover:bg-primary/90 active:scale-95",
+                "disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground",
+              )}
+            >
+              <ArrowUp size={16} />
+            </button>
+          </div>
         </div>
+        {/* end relative flex-1 wrapper */}
 
         {/* ── Mic toggle button ── */}
         <button

--- a/frontend/src/lib/conversationApi.ts
+++ b/frontend/src/lib/conversationApi.ts
@@ -56,6 +56,11 @@ type BackendAgentConfig = {
 
 type BackendMessage = { role: "user" | "assistant" | "system"; content: string };
 
+type ManualTransfer = {
+  target_agent_id?: string;
+  target_agent_name?: string;
+};
+
 type ConversationRequest = {
   conversation_id: string;
   agent_config: BackendAgentConfig;
@@ -63,6 +68,7 @@ type ConversationRequest = {
   current_intent_name?: string | null;
   confirmation_id?: string | null;
   decision?: "confirm" | "reject" | null;
+  manual_transfer?: ManualTransfer | null;
 };
 
 export type ConversationResponse = {
@@ -195,6 +201,7 @@ export async function sendMessage(
   lockedIntentName?: string | null,
   confirmationId?: string | null,
   decision?: "confirm" | "reject" | null,
+  manualTransfer?: ManualTransfer | null,
 ): Promise<ConversationResponse> {
   // STEP A: Map transcript -> backend Message[]
   const messages: BackendMessage[] = transcript.map((turn) => ({
@@ -210,6 +217,7 @@ export async function sendMessage(
     current_intent_name: lockedIntentName ?? null,
     confirmation_id: confirmationId ?? null,
     decision: decision ?? null,
+    manual_transfer: manualTransfer ?? null,
   };
 
   const res = await fetch("/api/v1/conversations/process", {


### PR DESCRIPTION
## Summary

This PR implements UI-initiated manual agent routing, allowing users to explicitly transfer a conversation to a specific agent (built-in or custom) without relying on intent detection. It also extends the agent registry to resolve user-defined agents from the database, and hardens the implementation against security, recursion, and reliability issues.

---

## What Changed

### Backend — New Types (`types.py`)
- Added `ManualTransferRequest` model with `target_agent_id` (UUID of a saved `AgentConfiguration`) and `target_agent_name` (human-readable fallback). A `model_validator` enforces that at least one field is non-empty — an empty `ManualTransferRequest {}` is rejected at deserialization.
- Added `ToolType.EXTERNAL_API` enum value.

### Backend — Orchestration (`orchestration/__init__.py`)
- `process_message` now accepts optional `db: AsyncSession` and `user_id: int | None` parameters, enabling DB-backed agent lookups scoped to the authenticated user.
- New **step 0a**: if `request.manual_transfer` is set, the pipeline short-circuits intent detection and delegates to `_handle_manual_transfer`, which:
  1. Resolves the target by ID (user copy → default template) or by name (scoped to `user_id`).
  2. Loads and validates the target `AgentConfig` (invalid configs return a structured error response instead of raising).
  3. Re-enters `process_message` with `manual_transfer=None` cleared on the updated request, preventing infinite recursion.
- `user_id` is threaded through all recursive re-entries so the scope is never silently dropped.

### Backend — Agent Registry (`agents/__init__.py`)
- Added `CustomAgent` class: a thin `BaseAgent` wrapper for DB-loaded agents whose behaviour is driven entirely by their config.
- `AgentRegistry.create_by_name` is now `async` and accepts `db` and `user_id`. Resolution order: (1) built-in registry match, (2) DB lookup scoped to `user_id`, (3) default agent fallback. Corrupt `record.config` dicts are caught and fall back gracefully instead of crashing the pipeline.
- Added `AgentRegistry.known_agent_names()` returning the set of built-in `agent_name` strings.
- Added `AgentRegistry.create_custom()` for constructing a `CustomAgent` from an already-resolved config.

### Backend — Database (`database/crud.py`)
- `get_agent_configuration_by_id(db, agent_id)` — look up a saved config by primary key.
- `get_agent_configuration_by_name(db, name, user_id=None)` — look up by name, optionally scoped to a user. Used in both intent-driven DB fallback and manual transfers.

### Backend — Agent Transfer Tool (`tools/agent_transfer.py`)
- `AgentTransferTool.__init__` now accepts an optional `db` session.
- New `_is_valid_target(target_agent_id)` async method checks built-in names first, then falls back to DB lookup when `db` is available — so LLM-triggered transfers also work for custom agents.

### Backend — Route (`api/routes/conversations.py`)
- Passes the authenticated `user_id` to `orchestrator.process_message` so DB lookups are always scoped to the correct user.

### Backend — Voice Path (`livekit_agent/llm.py`)
- `AsyncSessionLocal` is now opened **before** `process_message` in `llm_node` so that manual transfers and custom-agent DB lookups are also available in voice calls. The existing persistence block uses a separate independent session as before.

### Frontend — `InCallControls.tsx`
- Added `@mention` routing syntax in the text input: typing `@` opens an agent-selection popover listing all available agents (built-in + custom). Selecting one locks the next message to that agent via `manual_transfer`.
- The routing target is cleared after each send and after voice recording starts.

### Frontend — `ConversationalChat.tsx`
- Wires the selected routing target from `InCallControls` into the `sendMessage` payload as `manual_transfer: { target_agent_id, target_agent_name }`.
- Appends an inline `↔ transferred to [Agent]` transcript marker when the backend responds with a different `selected_agent`.

### Frontend — `conversationApi.ts`
- `sendMessage` now accepts an optional `manualTransfer` argument and includes it in the POST body.

---

## Tests Added

| File | Coverage |
|---|---|
| `test_custom_agent_routing.py` | `ManualTransferRequest` validation (5 cases), `AgentRegistry.create_by_name` DB fallback with user_id scoping, corrupt-config fallback, `_handle_manual_transfer` recursion guard, name-lookup scoping, not-found and invalid-config error responses |
| `test_agent_transfer.py` | `AgentTransferTool._is_valid_target` for built-in and custom agents |
| `test_agent_runtime.py` | `CustomAgent` construction via `create_custom` and `create_by_name` DB path |
| `test_orchestration.py` | `_handle_manual_transfer` by-ID and by-name paths, recursion guard, error responses |

---

## Test Plan

- [x] Transfer to a custom DB agent by name — confirm the new agent's persona is applied from the next turn onward.
- [x] Send `manual_transfer: {}` (both fields empty) — confirm the API returns HTTP 422.
- [x] Delete a custom agent and attempt to transfer to it by name — confirm a structured error response (not a 500).
- [x] Run voice call and issue a manual transfer via the text input during the call — confirm it works (voice path now has DB access).
- [x] Run `poetry run pytest` — all tests pass.