### PR TITLE
feat: interchangeable STT/TTS provider selection (#135)

### DIFF
--- a/Documentation/stt-tts-providers.md
+++ b/Documentation/stt-tts-providers.md
@@ -1,0 +1,113 @@
+# Interchangeable STT/TTS Providers
+
+> **Scope.** This guide explains how to choose the speech-to-text and
+> text-to-speech provider per agent (ticket #135). Selection happens in
+> the Agent Config UI; no code or environment change is needed to switch.
+>
+> The dispatch logic lives in
+> `backend/src/taskorbit/livekit_agent/session.py` (`_build_stt` /
+> `_build_tts`).
+
+---
+
+## What this is
+
+Before #135 the voice pipeline was hardwired: Deepgram for STT, ElevenLabs
+for TTS, both configured purely from environment variables. The provider
+dropdowns in the Agent Config UI existed but had a single option, and the
+values were discarded on the way to the voice worker.
+
+Now both vendors are dual-capability and every combination works:
+
+| | TTS: ElevenLabs | TTS: Deepgram (Aura) |
+|---|---|---|
+| **STT: Deepgram** | historical default | works |
+| **STT: ElevenLabs (Scribe)** | works | works |
+
+The selection travels: Agent Config UI -> saved agent -> LiveKit token
+metadata -> voice worker -> plugin construction. Changing providers is a
+dropdown choice, saved with the agent (AC4: no manual pipeline edits).
+
+## Selecting providers in the UI
+
+Pipeline section of the Agent Config page:
+
+- **STT provider**: Deepgram or ElevenLabs. Switching resets the model to
+  the provider default (same mismatch guard as the LLM section, #99).
+- **TTS provider**: ElevenLabs or Deepgram. Same reset rule.
+- **Voice ID** is only shown for ElevenLabs TTS. Deepgram Aura encodes the
+  voice in the model name (`aura-2-<voice>-en`), so there is no separate
+  voice field for it.
+
+## Models and defaults
+
+| Stage | Provider | Default model | Notes |
+|---|---|---|---|
+| STT | Deepgram | `nova-3` | any Deepgram STT model string works |
+| STT | ElevenLabs | `scribe_v2_realtime` | **pinned**: the only Scribe model that streams. Batch models (`scribe_v1`, `scribe_v2`) return finals too late for the worker's turn handling, so the backend rejects them and falls back to the realtime model with a warning |
+| TTS | ElevenLabs | `eleven_multilingual_v2` | any `eleven_*` model string works |
+| TTS | Deepgram | `aura-2-andromeda-en` | voice is part of the model name |
+
+Model fields are free text. A model name that clearly belongs to the other
+provider is replaced with the selected provider's default at session build
+time (warning logged). A wrong model within the correct provider's
+namespace (for example a typo like `eleven_bogus`) fails at the provider
+API during the call; check the worker logs.
+
+## Precedence rules
+
+For a normal call (agent config present in the room metadata) the agent
+config wins over the environment:
+
+- `tts.voice_id` from the config overrides `ELEVENLABS_VOICE_ID`.
+  Before #135 env always won, which made the config field a
+  non-functional placeholder.
+- `stt.model` and `tts.model` from the config override `DEEPGRAM_MODEL`
+  and `ELEVENLABS_MODEL`.
+
+The environment values remain the fallback when no agent config reaches
+the worker (no metadata, parse failure, or participant timeout) and when
+config fields are empty.
+
+## API keys
+
+Both capabilities of a vendor share one key; nothing new is needed:
+
+- `DEEPGRAM_API_KEY` covers Deepgram STT and TTS.
+- `ELEVENLABS_API_KEY` covers ElevenLabs TTS and STT.
+
+Selecting a provider whose key is missing fails the session at startup,
+so keep both keys populated in any environment where users can switch.
+
+## Observability
+
+Every session logs its resolved selection at build time:
+
+```
+stt_selected  provider=elevenlabs model=scribe_v2_realtime
+tts_selected  provider=elevenlabs model=eleven_multilingual_v2 voice_id=... voice_source=config
+```
+
+`voice_source` tells you whether the voice came from the agent config or
+the env fallback. Cross-provider model replacements log
+`stt_model_not_valid_for_provider` / `tts_model_not_valid_for_provider`
+warnings. Metadata problems are triaged: absent metadata logs info,
+invalid metadata logs error (the user's selection is being overridden by
+defaults), timeout/malformed JSON logs warning.
+
+## Known limitations
+
+- **Mid-call agent handoff does not re-apply providers.** The pipeline is
+  built once per session from the initially dispatched agent; after an
+  `agent_transfer` the original agent's STT/TTS (and voice) persist. This
+  extends the known Sprint 8 voice hot-swap limitation.
+- **The text-path TTS route** (`POST /v1/tts/synthesize`, used by typed
+  chat playback) is ElevenLabs-only and is not governed by this
+  selection. Out of scope for #135, which covers the voice pipeline.
+- **`stt.language` is not yet wired**; the Deepgram language comes from
+  `DEEPGRAM_LANGUAGE` and ElevenLabs Scribe auto-detects.
+- The **System Architecture document** (`Documentation/Taskorbit
+  Conversational Agent System Architecture - final.*` and the Runtime
+  Components diagram) depicts the historical fixed pipeline (Deepgram
+  STT -> ElevenLabs TTS). Read that as the default configuration; the
+  stages are provider-selectable as of #135.

--- a/Documentation/stt-tts-providers.md
+++ b/Documentation/stt-tts-providers.md
@@ -89,9 +89,10 @@ tts_selected  provider=elevenlabs model=eleven_multilingual_v2 voice_id=... voic
 ```
 
 `voice_source` tells you whether the voice came from the agent config or
-the env fallback. Cross-provider model replacements log
-`stt_model_not_valid_for_provider` / `tts_model_not_valid_for_provider`
-warnings. Metadata problems are triaged: absent metadata logs info,
+the env fallback. When a configured model does not belong to the selected
+provider it is replaced with that provider's default and a single
+`model_not_valid_for_provider` warning is logged (the `stage` field marks
+it as `stt` or `tts`). Metadata problems are triaged: absent metadata logs info,
 invalid metadata logs error (the user's selection is being overridden by
 defaults), timeout/malformed JSON logs warning.
 

--- a/backend/src/taskorbit/livekit_agent/session.py
+++ b/backend/src/taskorbit/livekit_agent/session.py
@@ -6,10 +6,14 @@ spinning up an actual LiveKit room.
 
 The pipeline is:
 
-    user audio  ─►  Silero VAD  ─►  Deepgram STT  ─►  OrchestratorAgent (llm_node)
-                                                       │
-                                                       ▼
-    user audio out  ◄─  ElevenLabs TTS  ◄──────────  reply text
+    user audio  ─►  Silero VAD  ─►  STT  ─►  OrchestratorAgent (llm_node)
+                                               │
+                                               ▼
+    user audio out  ◄─────  TTS  ◄──────────  reply text
+
+STT and TTS providers are selected per-agent from ``agent_config`` (#135):
+either stage can use Deepgram or ElevenLabs independently. When no config
+is present the historical defaults apply (Deepgram STT, ElevenLabs TTS).
 
 ``allow_interruptions=True`` lets the user cut off agent TTS by speaking again
 (barge-in) once echo cancellation has stabilised.
@@ -25,21 +29,166 @@ from livekit.plugins.elevenlabs import VoiceSettings
 
 from taskorbit.config import Settings, get_settings
 from taskorbit.livekit_agent.llm import OrchestratorAgent
+from taskorbit.logging.setup import get_logger
 from taskorbit.orchestration import ConversationOrchestrator
-from taskorbit.types import AgentConfig
+from taskorbit.types import AgentConfig, STTProvider, TTSProvider
+
+logger = get_logger(__name__)
+
+# Provider-native model defaults used when the configured model string does
+# not belong to the selected provider (e.g. a saved config carries a Deepgram
+# model name but the user switched the provider to ElevenLabs). Prevents a
+# cross-provider model name from crashing the voice pipeline at runtime.
+#
+# "scribe_v2_realtime" is pinned deliberately: the plugin's own default
+# resolves to BATCH scribe_v1 (streaming=False), whose final transcripts
+# arrive only after a full HTTP round trip, too late for the worker's
+# manual endpointing + flush-delay turn handling. The realtime model keeps
+# streaming parity with Deepgram's semantics.
+_ELEVENLABS_STT_DEFAULT_MODEL = "scribe_v2_realtime"
+_DEEPGRAM_TTS_DEFAULT_MODEL = "aura-2-andromeda-en"
+
+
+def _build_stt(cfg: Settings, agent_config: AgentConfig | None) -> deepgram.STT | elevenlabs.STT:
+    """Construct the STT plugin selected by ``agent_config.stt.provider`` (#135).
+
+    Defaults to Deepgram (historical behavior) when no config is present.
+    """
+    stt_cfg = agent_config.stt if agent_config is not None else None
+
+    if stt_cfg is not None and stt_cfg.provider is STTProvider.ELEVENLABS:
+        model_id = stt_cfg.model
+        # Strict equality, not a scribe_ prefix check: scribe_v1/scribe_v2 are
+        # BATCH models (streaming=False) and would break the worker's manual
+        # endpointing turn handling. Only the realtime model is compatible.
+        if model_id != _ELEVENLABS_STT_DEFAULT_MODEL:
+            logger.warning(
+                "stt_model_not_valid_for_provider",
+                provider="elevenlabs",
+                configured_model=model_id,
+                fallback_model=_ELEVENLABS_STT_DEFAULT_MODEL,
+            )
+            model_id = _ELEVENLABS_STT_DEFAULT_MODEL
+        logger.info("stt_selected", provider="elevenlabs", model=model_id)
+        return elevenlabs.STT(
+            api_key=cfg.elevenlabs_api_key,
+            model_id=model_id,
+        )
+
+    model = cfg.deepgram_model
+    if stt_cfg is not None and stt_cfg.model:
+        if stt_cfg.model.startswith("scribe_"):
+            logger.warning(
+                "stt_model_not_valid_for_provider",
+                provider="deepgram",
+                configured_model=stt_cfg.model,
+                fallback_model=model,
+            )
+        else:
+            model = stt_cfg.model
+    logger.info("stt_selected", provider="deepgram", model=model)
+    return deepgram.STT(
+        api_key=cfg.deepgram_api_key,
+        model=model,
+        language=cfg.deepgram_language,
+        smart_format=True,
+        numerals=True,
+        endpointing_ms=400,
+    )
+
+
+def _build_tts(cfg: Settings, agent_config: AgentConfig | None) -> deepgram.TTS | elevenlabs.TTS:
+    """Construct the TTS plugin selected by ``agent_config.tts.provider`` (#135).
+
+    Defaults to ElevenLabs (historical behavior) when no config is present.
+    The agent config's ``voice_id`` takes precedence over the environment's
+    ``ELEVENLABS_VOICE_ID``. Previously env always won, which made the
+    config field a non-functional placeholder.
+    """
+    tts_cfg = agent_config.tts if agent_config is not None else None
+
+    if tts_cfg is not None and tts_cfg.provider is TTSProvider.DEEPGRAM:
+        # Aura voices are encoded in the model name; voice_id is unused here.
+        model = tts_cfg.model
+        if not model.startswith("aura"):
+            logger.warning(
+                "tts_model_not_valid_for_provider",
+                provider="deepgram",
+                configured_model=model,
+                fallback_model=_DEEPGRAM_TTS_DEFAULT_MODEL,
+            )
+            model = _DEEPGRAM_TTS_DEFAULT_MODEL
+        logger.info("tts_selected", provider="deepgram", model=model)
+        return deepgram.TTS(
+            api_key=cfg.deepgram_api_key,
+            model=model,
+            # Pin the plugin defaults explicitly so an upgrade cannot
+            # silently change the audio characteristics.
+            encoding="linear16",
+            sample_rate=24000,
+        )
+
+    voice_id = cfg.elevenlabs_voice_id
+    voice_source = "env"
+    if tts_cfg is not None and tts_cfg.voice_id:
+        voice_id = tts_cfg.voice_id
+        voice_source = "config"
+    model = cfg.elevenlabs_model
+    if tts_cfg is not None and tts_cfg.model:
+        if tts_cfg.model.startswith("eleven_"):
+            model = tts_cfg.model
+        else:
+            logger.warning(
+                "tts_model_not_valid_for_provider",
+                provider="elevenlabs",
+                configured_model=tts_cfg.model,
+                fallback_model=model,
+            )
+    logger.info(
+        "tts_selected",
+        provider="elevenlabs",
+        model=model,
+        voice_id=voice_id,
+        voice_source=voice_source,
+    )
+    return elevenlabs.TTS(
+        api_key=cfg.elevenlabs_api_key,
+        voice_id=voice_id,
+        model=model,
+        # Plugin default is mp3_22050_32 (22 kHz / 32 kbps) which sounds
+        # noticeably different from the REST endpoint used for the greeting
+        # (which returns mp3_44100_128 by default). Match that quality here
+        # so both paths use the same audio characteristics.
+        encoding="mp3_44100_128",
+        voice_settings=VoiceSettings(
+            stability=0.75,
+            similarity_boost=0.75,
+            style=0.0,
+            speed=1.0,
+            use_speaker_boost=True,
+        ),
+    )
 
 
 def build_agent_session(
     *,
     settings: Settings | None = None,
+    agent_config: AgentConfig | None = None,
 ) -> AgentSession[Any]:
     """Construct an ``AgentSession`` from the current settings.
+
+    Pass ``agent_config`` (parsed from participant metadata) so the STT and
+    TTS providers the user selected in the agent configuration are the ones
+    actually constructed (#135). Without it, historical defaults apply.
 
     The orchestrator instance is owned by the returned session via the
     bound ``OrchestratorAgent`` — both share its lifetime. Caller is
     responsible for ``session.start(...)`` and ``session.aclose()``.
     """
     cfg = settings or get_settings()
+
+    stt = _build_stt(cfg, agent_config)
+    tts = _build_tts(cfg, agent_config)
 
     return AgentSession(
         vad=silero.VAD.load(
@@ -49,37 +198,14 @@ def build_agent_session(
             min_silence_duration=1.5,
             prefix_padding_duration=0.4,
         ),
-        stt=deepgram.STT(
-            api_key=cfg.deepgram_api_key,
-            model=cfg.deepgram_model,
-            language=cfg.deepgram_language,
-            smart_format=True,
-            numerals=True,
-            endpointing_ms=400,
-        ),
+        stt=stt,
         # Required by generate_reply() — OrchestratorAgent.llm_node() overrides
         # this fully, so the OpenAI model is never actually called or billed.
         llm=openai.LLM(
             model=cfg.openai_model,
             api_key=cfg.openai_api_key or "sk-placeholder-not-used",
         ),
-        tts=elevenlabs.TTS(
-            api_key=cfg.elevenlabs_api_key,
-            voice_id=cfg.elevenlabs_voice_id,
-            model=cfg.elevenlabs_model,
-            # Plugin default is mp3_22050_32 (22 kHz / 32 kbps) which sounds
-            # noticeably different from the REST endpoint used for the greeting
-            # (which returns mp3_44100_128 by default). Match that quality here
-            # so both paths use the same audio characteristics.
-            encoding="mp3_44100_128",
-            voice_settings=VoiceSettings(
-                stability=0.75,
-                similarity_boost=0.75,
-                style=0.0,
-                speed=1.0,
-                use_speaker_boost=True,
-            ),
-        ),
+        tts=tts,
         # Barge-in: stop agent TTS as soon as the user sustains speech for
         # min_interruption_duration seconds. Brief noises (clicks, coughs)
         # shorter than the threshold do not trigger an interruption.

--- a/backend/src/taskorbit/livekit_agent/session.py
+++ b/backend/src/taskorbit/livekit_agent/session.py
@@ -21,6 +21,7 @@ is present the historical defaults apply (Deepgram STT, ElevenLabs TTS).
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 from livekit.agents import AgentSession
@@ -49,6 +50,62 @@ _ELEVENLABS_STT_DEFAULT_MODEL = "scribe_v2_realtime"
 _DEEPGRAM_TTS_DEFAULT_MODEL = "aura-2-andromeda-en"
 
 
+# Per-provider "does this model belong to me?" predicates. Keeping all four in
+# one place (rather than a different ad-hoc check inside each build branch) is
+# what makes cross-provider detection symmetric: every branch routes its model
+# choice through ``_resolve_model`` with one of these.
+def _is_deepgram_stt_model(model: str) -> bool:
+    # Deepgram STT models are the Nova family (nova-3 is the FE default).
+    # The trailing hyphen also rejects typos like "nova3" that the API
+    # would reject mid-call.
+    return model.startswith("nova-")
+
+
+def _is_elevenlabs_stt_model(model: str) -> bool:
+    # Only the realtime Scribe model streams; the batch models (scribe_v1,
+    # scribe_v2) arrive too late for the worker's manual endpointing.
+    return model == _ELEVENLABS_STT_DEFAULT_MODEL
+
+
+def _is_deepgram_tts_model(model: str) -> bool:
+    # Aura voices encode the voice in the model name (aura-2-<voice>-en).
+    return model.startswith("aura")
+
+
+def _is_elevenlabs_tts_model(model: str) -> bool:
+    return model.startswith("eleven_")
+
+
+def _resolve_model(
+    *,
+    stage: str,
+    provider: str,
+    configured: str | None,
+    is_valid: Callable[[str], bool],
+    fallback: str,
+) -> str:
+    """Return ``configured`` if it is valid for ``provider``, else ``fallback``.
+
+    Single source of truth for cross-provider model detection so all four
+    STT/TTS branches behave identically: a model string that does not belong
+    to the selected provider is replaced with that provider's safe default and
+    a single ``model_not_valid_for_provider`` warning is logged. That warning
+    is the only production signal that an agent was misconfigured, so it must
+    fire on every mismatch (covered by tests).
+    """
+    if configured and is_valid(configured):
+        return configured
+    if configured:
+        logger.warning(
+            "model_not_valid_for_provider",
+            stage=stage,
+            provider=provider,
+            configured_model=configured,
+            fallback_model=fallback,
+        )
+    return fallback
+
+
 def _build_stt(cfg: Settings, agent_config: AgentConfig | None) -> deepgram.STT | elevenlabs.STT:
     """Construct the STT plugin selected by ``agent_config.stt.provider`` (#135).
 
@@ -56,36 +113,27 @@ def _build_stt(cfg: Settings, agent_config: AgentConfig | None) -> deepgram.STT 
     """
     stt_cfg = agent_config.stt if agent_config is not None else None
 
-    if stt_cfg is not None and stt_cfg.provider is STTProvider.ELEVENLABS:
-        model_id = stt_cfg.model
-        # Strict equality, not a scribe_ prefix check: scribe_v1/scribe_v2 are
-        # BATCH models (streaming=False) and would break the worker's manual
-        # endpointing turn handling. Only the realtime model is compatible.
-        if model_id != _ELEVENLABS_STT_DEFAULT_MODEL:
-            logger.warning(
-                "stt_model_not_valid_for_provider",
-                provider="elevenlabs",
-                configured_model=model_id,
-                fallback_model=_ELEVENLABS_STT_DEFAULT_MODEL,
-            )
-            model_id = _ELEVENLABS_STT_DEFAULT_MODEL
+    if stt_cfg is not None and stt_cfg.provider == STTProvider.ELEVENLABS:
+        model_id = _resolve_model(
+            stage="stt",
+            provider="elevenlabs",
+            configured=stt_cfg.model,
+            is_valid=_is_elevenlabs_stt_model,
+            fallback=_ELEVENLABS_STT_DEFAULT_MODEL,
+        )
         logger.info("stt_selected", provider="elevenlabs", model=model_id)
         return elevenlabs.STT(
             api_key=cfg.elevenlabs_api_key,
             model_id=model_id,
         )
 
-    model = cfg.deepgram_model
-    if stt_cfg is not None and stt_cfg.model:
-        if stt_cfg.model.startswith("scribe_"):
-            logger.warning(
-                "stt_model_not_valid_for_provider",
-                provider="deepgram",
-                configured_model=stt_cfg.model,
-                fallback_model=model,
-            )
-        else:
-            model = stt_cfg.model
+    model = _resolve_model(
+        stage="stt",
+        provider="deepgram",
+        configured=stt_cfg.model if stt_cfg is not None else None,
+        is_valid=_is_deepgram_stt_model,
+        fallback=cfg.deepgram_model,
+    )
     logger.info("stt_selected", provider="deepgram", model=model)
     return deepgram.STT(
         api_key=cfg.deepgram_api_key,
@@ -107,17 +155,15 @@ def _build_tts(cfg: Settings, agent_config: AgentConfig | None) -> deepgram.TTS 
     """
     tts_cfg = agent_config.tts if agent_config is not None else None
 
-    if tts_cfg is not None and tts_cfg.provider is TTSProvider.DEEPGRAM:
+    if tts_cfg is not None and tts_cfg.provider == TTSProvider.DEEPGRAM:
         # Aura voices are encoded in the model name; voice_id is unused here.
-        model = tts_cfg.model
-        if not model.startswith("aura"):
-            logger.warning(
-                "tts_model_not_valid_for_provider",
-                provider="deepgram",
-                configured_model=model,
-                fallback_model=_DEEPGRAM_TTS_DEFAULT_MODEL,
-            )
-            model = _DEEPGRAM_TTS_DEFAULT_MODEL
+        model = _resolve_model(
+            stage="tts",
+            provider="deepgram",
+            configured=tts_cfg.model,
+            is_valid=_is_deepgram_tts_model,
+            fallback=_DEEPGRAM_TTS_DEFAULT_MODEL,
+        )
         logger.info("tts_selected", provider="deepgram", model=model)
         return deepgram.TTS(
             api_key=cfg.deepgram_api_key,
@@ -133,17 +179,13 @@ def _build_tts(cfg: Settings, agent_config: AgentConfig | None) -> deepgram.TTS 
     if tts_cfg is not None and tts_cfg.voice_id:
         voice_id = tts_cfg.voice_id
         voice_source = "config"
-    model = cfg.elevenlabs_model
-    if tts_cfg is not None and tts_cfg.model:
-        if tts_cfg.model.startswith("eleven_"):
-            model = tts_cfg.model
-        else:
-            logger.warning(
-                "tts_model_not_valid_for_provider",
-                provider="elevenlabs",
-                configured_model=tts_cfg.model,
-                fallback_model=model,
-            )
+    model = _resolve_model(
+        stage="tts",
+        provider="elevenlabs",
+        configured=tts_cfg.model if tts_cfg is not None else None,
+        is_valid=_is_elevenlabs_tts_model,
+        fallback=cfg.elevenlabs_model,
+    )
     logger.info(
         "tts_selected",
         provider="elevenlabs",

--- a/backend/src/taskorbit/types.py
+++ b/backend/src/taskorbit/types.py
@@ -41,7 +41,11 @@ class ConversationStatus(str, Enum):
 
 
 class STTProvider(str, Enum):
+    """Speech-to-text providers. Both entries support STT and TTS (#135),
+    so either can be selected independently of the TTS choice."""
+
     DEEPGRAM = "deepgram"
+    ELEVENLABS = "elevenlabs"
 
 
 class LLMProvider(str, Enum):
@@ -50,7 +54,11 @@ class LLMProvider(str, Enum):
 
 
 class TTSProvider(str, Enum):
+    """Text-to-speech providers. Mirror of STTProvider — both vendors are
+    dual-capability, enabling the full interchangeable matrix (#135)."""
+
     ELEVENLABS = "elevenlabs"
+    DEEPGRAM = "deepgram"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/src/taskorbit/types.py
+++ b/backend/src/taskorbit/types.py
@@ -54,7 +54,7 @@ class LLMProvider(str, Enum):
 
 
 class TTSProvider(str, Enum):
-    """Text-to-speech providers. Mirror of STTProvider — both vendors are
+    """Text-to-speech providers. Mirror of STTProvider: both vendors are
     dual-capability, enabling the full interchangeable matrix (#135)."""
 
     ELEVENLABS = "elevenlabs"

--- a/backend/src/taskorbit/worker.py
+++ b/backend/src/taskorbit/worker.py
@@ -69,28 +69,49 @@ async def entrypoint(ctx: JobContext) -> None:
         participant = await asyncio.wait_for(ctx.wait_for_participant(), timeout=30.0)
         meta = json.loads(participant.metadata or "{}")
         greeting = str(meta.get("greeting") or "")
-        try:
-            agent_config = AgentConfig.model_validate(meta)
+        if not meta:
+            # No metadata at all (e.g. LiveKit playground / CLI joins): the
+            # defaults are the correct behavior, not a failure.
             logger.info(
-                "worker_agent_config_loaded_from_metadata",
-                agent_id=agent_config.id,
-                agent_name=agent_config.name,
+                "worker_no_participant_metadata",
+                effect="default agent config and STT/TTS providers",
             )
-            logger.info(
-                "worker_agent_config_tools_loaded",
-                tools_count=len(agent_config.tools),
-                tool_types=[t.type for t in agent_config.tools],
-            )
-        except ValidationError as exc:
-            logger.warning(
-                "worker_agent_config_parse_failed",
-                error=str(exc),
-                fallback="_default_agent_config",
-            )
-    except Exception:  # noqa: BLE001
-        pass
+        else:
+            try:
+                agent_config = AgentConfig.model_validate(meta)
+                logger.info(
+                    "worker_agent_config_loaded_from_metadata",
+                    agent_id=agent_config.id,
+                    agent_name=agent_config.name,
+                )
+                logger.info(
+                    "worker_agent_config_tools_loaded",
+                    tools_count=len(agent_config.tools),
+                    tool_types=[t.type for t in agent_config.tools],
+                )
+            except ValidationError as exc:
+                # Error-level on purpose: metadata WAS provided but could not
+                # be used, so the session falls back to DEFAULT STT/TTS
+                # providers (#135), overriding whatever the user selected in
+                # the agent config. Must be loud in logs.
+                logger.error(
+                    "worker_agent_config_parse_failed",
+                    error=str(exc),
+                    fallback="_default_agent_config",
+                    effect="default STT/TTS providers will be used",
+                )
+    except Exception as exc:  # noqa: BLE001
+        # Covers wait_for_participant timeout and malformed-JSON metadata;
+        # both land on default config + providers, so say so in the logs.
+        logger.warning(
+            "worker_participant_metadata_unavailable",
+            error=str(exc),
+            effect="default agent config and STT/TTS providers",
+        )
 
-    session = build_agent_session(settings=cfg)
+    # #135: forward the parsed config so the session constructs the STT/TTS
+    # providers the user selected, instead of always using the env defaults.
+    session = build_agent_session(settings=cfg, agent_config=agent_config)
     agent = build_default_agent(
         settings=cfg,
         agent_config=agent_config,

--- a/backend/tests/test_provider_dispatch.py
+++ b/backend/tests/test_provider_dispatch.py
@@ -14,7 +14,14 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from taskorbit.config import get_settings
-from taskorbit.livekit_agent.session import build_agent_session
+from taskorbit.livekit_agent.session import (
+    _is_deepgram_stt_model,
+    _is_deepgram_tts_model,
+    _is_elevenlabs_stt_model,
+    _is_elevenlabs_tts_model,
+    _resolve_model,
+    build_agent_session,
+)
 from taskorbit.types import AgentConfig, STTConfig, TTSConfig
 
 _ENV_DEEPGRAM_MODEL = "nova-3"
@@ -50,7 +57,12 @@ def _agent_config(stt: STTConfig, tts: TTSConfig) -> AgentConfig:
 
 
 def _build_with_config(config: AgentConfig | None) -> dict[str, MagicMock]:
-    """Run ``build_agent_session`` with every plugin constructor mocked."""
+    """Run ``build_agent_session`` with every plugin constructor mocked.
+
+    The module ``logger`` is patched too so tests can assert that a
+    cross-provider model mismatch logs the ``model_not_valid_for_provider``
+    warning, which is the only production signal of a misconfigured agent.
+    """
     with (
         patch("taskorbit.livekit_agent.session.silero.VAD"),
         patch("taskorbit.livekit_agent.session.deepgram.STT") as dg_stt,
@@ -58,6 +70,7 @@ def _build_with_config(config: AgentConfig | None) -> dict[str, MagicMock]:
         patch("taskorbit.livekit_agent.session.elevenlabs.STT") as el_stt,
         patch("taskorbit.livekit_agent.session.elevenlabs.TTS") as el_tts,
         patch("taskorbit.livekit_agent.session.AgentSession") as session,
+        patch("taskorbit.livekit_agent.session.logger") as logger,
     ):
         build_agent_session(agent_config=config)
     return {
@@ -66,7 +79,26 @@ def _build_with_config(config: AgentConfig | None) -> dict[str, MagicMock]:
         "elevenlabs_stt": el_stt,
         "elevenlabs_tts": el_tts,
         "session": session,
+        "logger": logger,
     }
+
+
+def _model_warnings(logger: MagicMock) -> list[dict]:
+    """Return the kwargs of every ``model_not_valid_for_provider`` warning."""
+    return [
+        call.kwargs
+        for call in logger.warning.call_args_list
+        if call.args and call.args[0] == "model_not_valid_for_provider"
+    ]
+
+
+def _assert_model_warning(logger: MagicMock, *, stage: str, provider: str) -> None:
+    """Assert the misconfiguration warning fired for this stage/provider."""
+    warnings = _model_warnings(logger)
+    assert warnings, "expected a model_not_valid_for_provider warning, none logged"
+    assert any(
+        w.get("stage") == stage and w.get("provider") == provider for w in warnings
+    ), f"expected warning for stage={stage} provider={provider}, got {warnings}"
 
 
 # ---------------------------------------------------------------------------
@@ -153,6 +185,9 @@ def test_elevenlabs_stt_realtime_model_passes_through(provider_settings: None) -
     kwargs = mocks["elevenlabs_stt"].call_args.kwargs
     assert kwargs["model_id"] == "scribe_v2_realtime"
     assert kwargs["api_key"] == "el-key"
+    # A valid model must stay silent, so the warning assertions elsewhere
+    # are meaningful and not vacuously true.
+    assert not _model_warnings(mocks["logger"])
 
 
 @pytest.mark.parametrize("bad_model", ["scribe_v1", "scribe_v2", "nova-3", "whisper-large"])
@@ -169,6 +204,7 @@ def test_elevenlabs_stt_incompatible_model_falls_back_to_realtime(
     )
     mocks = _build_with_config(config)
     assert mocks["elevenlabs_stt"].call_args.kwargs["model_id"] == "scribe_v2_realtime"
+    _assert_model_warning(mocks["logger"], stage="stt", provider="elevenlabs")
 
 
 # ---------------------------------------------------------------------------
@@ -185,6 +221,7 @@ def test_deepgram_stt_model_from_config_overrides_env(provider_settings: None) -
     )
     mocks = _build_with_config(config)
     assert mocks["deepgram_stt"].call_args.kwargs["model"] == "nova-2"
+    assert not _model_warnings(mocks["logger"])
 
 
 def test_deepgram_stt_scribe_model_keeps_env_model(provider_settings: None) -> None:
@@ -198,6 +235,7 @@ def test_deepgram_stt_scribe_model_keeps_env_model(provider_settings: None) -> N
     )
     mocks = _build_with_config(config)
     assert mocks["deepgram_stt"].call_args.kwargs["model"] == _ENV_DEEPGRAM_MODEL
+    _assert_model_warning(mocks["logger"], stage="stt", provider="deepgram")
 
 
 def test_deepgram_stt_no_config_uses_env_defaults(provider_settings: None) -> None:
@@ -246,6 +284,7 @@ def test_deepgram_tts_cross_provider_model_falls_back(provider_settings: None) -
     )
     mocks = _build_with_config(config)
     assert mocks["deepgram_tts"].call_args.kwargs["model"] == "aura-2-andromeda-en"
+    _assert_model_warning(mocks["logger"], stage="tts", provider="deepgram")
 
 
 # ---------------------------------------------------------------------------
@@ -311,3 +350,93 @@ def test_elevenlabs_tts_cross_provider_model_keeps_env_model(provider_settings: 
     )
     mocks = _build_with_config(config)
     assert mocks["elevenlabs_tts"].call_args.kwargs["model"] == _ENV_ELEVENLABS_MODEL
+    _assert_model_warning(mocks["logger"], stage="tts", provider="elevenlabs")
+
+
+# ---------------------------------------------------------------------------
+# Unified cross-provider detection (PR #141 review: closes the Deepgram-STT
+# silent-fallthrough and proves all four branches detect consistently)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "unknown_model", ["scribe_v2_realtime", "eleven_multilingual_v2", "nova3", "garbage-model"]
+)
+def test_deepgram_stt_unknown_model_falls_back_and_warns(
+    provider_settings: None, unknown_model: str
+) -> None:
+    """A model that is not a Deepgram Nova model must NOT be passed verbatim to
+    the Deepgram API (where it would fail silently mid-call). Before the shared
+    detection helper, the Deepgram STT branch only rejected ``scribe_`` names,
+    so these strings slipped through. Now they fall back to env + warn."""
+    config = _agent_config(
+        stt=STTConfig.model_validate(
+            {"provider": "deepgram", "language": "multi", "model": unknown_model}
+        ),
+        tts=TTSConfig(),
+    )
+    mocks = _build_with_config(config)
+    assert mocks["deepgram_stt"].call_args.kwargs["model"] == _ENV_DEEPGRAM_MODEL
+    _assert_model_warning(mocks["logger"], stage="stt", provider="deepgram")
+
+
+def test_provider_predicates() -> None:
+    """The four per-provider model predicates only accept their own models."""
+    assert _is_deepgram_stt_model("nova-3")
+    assert _is_deepgram_stt_model("nova-2")
+    assert not _is_deepgram_stt_model("scribe_v2_realtime")
+    assert not _is_deepgram_stt_model("whisper-large")
+    assert not _is_deepgram_stt_model("nova3")  # typo: missing hyphen
+
+    assert _is_elevenlabs_stt_model("scribe_v2_realtime")
+    assert not _is_elevenlabs_stt_model("scribe_v1")
+    assert not _is_elevenlabs_stt_model("nova-3")
+
+    assert _is_deepgram_tts_model("aura-2-andromeda-en")
+    assert not _is_deepgram_tts_model("eleven_multilingual_v2")
+
+    assert _is_elevenlabs_tts_model("eleven_turbo_v2_5")
+    assert not _is_elevenlabs_tts_model("aura-2-andromeda-en")
+
+
+def test_resolve_model_valid_passes_through_without_warning() -> None:
+    with patch("taskorbit.livekit_agent.session.logger") as logger:
+        result = _resolve_model(
+            stage="stt",
+            provider="deepgram",
+            configured="nova-3",
+            is_valid=_is_deepgram_stt_model,
+            fallback="fallback-model",
+        )
+    assert result == "nova-3"
+    logger.warning.assert_not_called()
+
+
+def test_resolve_model_invalid_falls_back_and_warns() -> None:
+    with patch("taskorbit.livekit_agent.session.logger") as logger:
+        result = _resolve_model(
+            stage="tts",
+            provider="elevenlabs",
+            configured="aura-2-andromeda-en",
+            is_valid=_is_elevenlabs_tts_model,
+            fallback="eleven_multilingual_v2",
+        )
+    assert result == "eleven_multilingual_v2"
+    logger.warning.assert_called_once()
+    assert logger.warning.call_args.args[0] == "model_not_valid_for_provider"
+    assert logger.warning.call_args.kwargs["configured_model"] == "aura-2-andromeda-en"
+
+
+def test_resolve_model_empty_config_falls_back_silently() -> None:
+    """An empty/unset model is not a misconfiguration, just a deferral to the
+    default, so it falls back WITHOUT a warning."""
+    with patch("taskorbit.livekit_agent.session.logger") as logger:
+        result = _resolve_model(
+            stage="stt",
+            provider="deepgram",
+            configured="",
+            is_valid=_is_deepgram_stt_model,
+            fallback="nova-3",
+        )
+    assert result == "nova-3"
+    logger.warning.assert_not_called()

--- a/backend/tests/test_provider_dispatch.py
+++ b/backend/tests/test_provider_dispatch.py
@@ -1,0 +1,313 @@
+"""Tests for the STT/TTS provider-dispatch factory in ``build_agent_session`` (#135).
+
+Covers the full 2x2 provider matrix (deepgram/elevenlabs for either stage,
+independently), the voice_id precedence fix (agent config wins over env),
+and the cross-provider model fallbacks. All plugin constructors are mocked;
+no live API is touched.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from taskorbit.config import get_settings
+from taskorbit.livekit_agent.session import build_agent_session
+from taskorbit.types import AgentConfig, STTConfig, TTSConfig
+
+_ENV_DEEPGRAM_MODEL = "nova-3"
+_ENV_ELEVENLABS_MODEL = "eleven_multilingual_v2"
+_ENV_VOICE_ID = "env-voice-id"
+
+
+@pytest.fixture
+def provider_settings(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Complete env for both vendors so ``get_settings()`` resolves."""
+    monkeypatch.setenv("DEEPGRAM_API_KEY", "dg-key")
+    monkeypatch.setenv("DEEPGRAM_MODEL", _ENV_DEEPGRAM_MODEL)
+    monkeypatch.setenv("DEEPGRAM_LANGUAGE", "multi")
+    monkeypatch.setenv("ELEVENLABS_API_KEY", "el-key")
+    monkeypatch.setenv("ELEVENLABS_VOICE_ID", _ENV_VOICE_ID)
+    monkeypatch.setenv("ELEVENLABS_MODEL", _ENV_ELEVENLABS_MODEL)
+    get_settings.cache_clear()
+    try:
+        yield
+    finally:
+        get_settings.cache_clear()
+
+
+def _agent_config(stt: STTConfig, tts: TTSConfig) -> AgentConfig:
+    return AgentConfig(
+        id="agent-1",
+        name="Matrix Bot",
+        persona="p",
+        greeting="hi",
+        stt=stt,
+        tts=tts,
+    )
+
+
+def _build_with_config(config: AgentConfig | None) -> dict[str, MagicMock]:
+    """Run ``build_agent_session`` with every plugin constructor mocked."""
+    with (
+        patch("taskorbit.livekit_agent.session.silero.VAD"),
+        patch("taskorbit.livekit_agent.session.deepgram.STT") as dg_stt,
+        patch("taskorbit.livekit_agent.session.deepgram.TTS") as dg_tts,
+        patch("taskorbit.livekit_agent.session.elevenlabs.STT") as el_stt,
+        patch("taskorbit.livekit_agent.session.elevenlabs.TTS") as el_tts,
+        patch("taskorbit.livekit_agent.session.AgentSession") as session,
+    ):
+        build_agent_session(agent_config=config)
+    return {
+        "deepgram_stt": dg_stt,
+        "deepgram_tts": dg_tts,
+        "elevenlabs_stt": el_stt,
+        "elevenlabs_tts": el_tts,
+        "session": session,
+    }
+
+
+# ---------------------------------------------------------------------------
+# The 2x2 provider matrix (AC1 + AC2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("stt_provider", "stt_model", "tts_provider", "tts_model", "want_stt", "want_tts"),
+    [
+        (
+            "deepgram",
+            "nova-3",
+            "elevenlabs",
+            "eleven_multilingual_v2",
+            "deepgram_stt",
+            "elevenlabs_tts",
+        ),
+        ("deepgram", "nova-3", "deepgram", "aura-2-andromeda-en", "deepgram_stt", "deepgram_tts"),
+        (
+            "elevenlabs",
+            "scribe_v2_realtime",
+            "elevenlabs",
+            "eleven_multilingual_v2",
+            "elevenlabs_stt",
+            "elevenlabs_tts",
+        ),
+        (
+            "elevenlabs",
+            "scribe_v2_realtime",
+            "deepgram",
+            "aura-2-andromeda-en",
+            "elevenlabs_stt",
+            "deepgram_tts",
+        ),
+    ],
+)
+def test_provider_matrix_constructs_correct_plugins(
+    provider_settings: None,
+    stt_provider: str,
+    stt_model: str,
+    tts_provider: str,
+    tts_model: str,
+    want_stt: str,
+    want_tts: str,
+) -> None:
+    """Each matrix cell constructs exactly the selected plugin pair and wires
+    the instances into the AgentSession."""
+    config = _agent_config(
+        stt=STTConfig.model_validate(
+            {"provider": stt_provider, "language": "multi", "model": stt_model}
+        ),
+        tts=TTSConfig.model_validate(
+            {"provider": tts_provider, "voice_id": "v-1", "model": tts_model}
+        ),
+    )
+    mocks = _build_with_config(config)
+
+    stt_mocks = {"deepgram_stt", "elevenlabs_stt"}
+    tts_mocks = {"deepgram_tts", "elevenlabs_tts"}
+    mocks[want_stt].assert_called_once()
+    mocks[want_tts].assert_called_once()
+    for unused in (stt_mocks - {want_stt}) | (tts_mocks - {want_tts}):
+        mocks[unused].assert_not_called()
+
+    session_kwargs = mocks["session"].call_args.kwargs
+    assert session_kwargs["stt"] is mocks[want_stt].return_value
+    assert session_kwargs["tts"] is mocks[want_tts].return_value
+
+
+# ---------------------------------------------------------------------------
+# ElevenLabs STT model pinning (streaming-compatible models only)
+# ---------------------------------------------------------------------------
+
+
+def test_elevenlabs_stt_realtime_model_passes_through(provider_settings: None) -> None:
+    config = _agent_config(
+        stt=STTConfig.model_validate(
+            {"provider": "elevenlabs", "language": "multi", "model": "scribe_v2_realtime"}
+        ),
+        tts=TTSConfig(),
+    )
+    mocks = _build_with_config(config)
+    kwargs = mocks["elevenlabs_stt"].call_args.kwargs
+    assert kwargs["model_id"] == "scribe_v2_realtime"
+    assert kwargs["api_key"] == "el-key"
+
+
+@pytest.mark.parametrize("bad_model", ["scribe_v1", "scribe_v2", "nova-3", "whisper-large"])
+def test_elevenlabs_stt_incompatible_model_falls_back_to_realtime(
+    provider_settings: None, bad_model: str
+) -> None:
+    """Batch scribe models and cross-provider names both fall back: only
+    scribe_v2_realtime streams, which the worker's turn handling requires."""
+    config = _agent_config(
+        stt=STTConfig.model_validate(
+            {"provider": "elevenlabs", "language": "multi", "model": bad_model}
+        ),
+        tts=TTSConfig(),
+    )
+    mocks = _build_with_config(config)
+    assert mocks["elevenlabs_stt"].call_args.kwargs["model_id"] == "scribe_v2_realtime"
+
+
+# ---------------------------------------------------------------------------
+# Deepgram STT model sourcing
+# ---------------------------------------------------------------------------
+
+
+def test_deepgram_stt_model_from_config_overrides_env(provider_settings: None) -> None:
+    config = _agent_config(
+        stt=STTConfig.model_validate(
+            {"provider": "deepgram", "language": "multi", "model": "nova-2"}
+        ),
+        tts=TTSConfig(),
+    )
+    mocks = _build_with_config(config)
+    assert mocks["deepgram_stt"].call_args.kwargs["model"] == "nova-2"
+
+
+def test_deepgram_stt_scribe_model_keeps_env_model(provider_settings: None) -> None:
+    """A scribe model name on the deepgram provider is cross-provider garbage;
+    keep the env-configured Deepgram model instead."""
+    config = _agent_config(
+        stt=STTConfig.model_validate(
+            {"provider": "deepgram", "language": "multi", "model": "scribe_v1"}
+        ),
+        tts=TTSConfig(),
+    )
+    mocks = _build_with_config(config)
+    assert mocks["deepgram_stt"].call_args.kwargs["model"] == _ENV_DEEPGRAM_MODEL
+
+
+def test_deepgram_stt_no_config_uses_env_defaults(provider_settings: None) -> None:
+    """Without an agent config the historical env-driven construction applies."""
+    mocks = _build_with_config(None)
+    mocks["deepgram_stt"].assert_called_once_with(
+        api_key="dg-key",
+        model=_ENV_DEEPGRAM_MODEL,
+        language="multi",
+        smart_format=True,
+        numerals=True,
+        endpointing_ms=400,
+    )
+    mocks["elevenlabs_stt"].assert_not_called()
+    mocks["deepgram_tts"].assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Deepgram TTS branch
+# ---------------------------------------------------------------------------
+
+
+def test_deepgram_tts_ignores_voice_id_and_pins_audio_format(provider_settings: None) -> None:
+    """Aura voices live in the model name; voice_id must not be forwarded.
+    Encoding and sample rate are pinned against plugin-default drift."""
+    config = _agent_config(
+        stt=STTConfig(),
+        tts=TTSConfig.model_validate(
+            {"provider": "deepgram", "voice_id": "el-style-voice", "model": "aura-2-thalia-en"}
+        ),
+    )
+    mocks = _build_with_config(config)
+    kwargs = mocks["deepgram_tts"].call_args.kwargs
+    assert kwargs["model"] == "aura-2-thalia-en"
+    assert "voice_id" not in kwargs
+    assert kwargs["encoding"] == "linear16"
+    assert kwargs["sample_rate"] == 24000
+
+
+def test_deepgram_tts_cross_provider_model_falls_back(provider_settings: None) -> None:
+    config = _agent_config(
+        stt=STTConfig(),
+        tts=TTSConfig.model_validate(
+            {"provider": "deepgram", "voice_id": "v", "model": "eleven_multilingual_v2"}
+        ),
+    )
+    mocks = _build_with_config(config)
+    assert mocks["deepgram_tts"].call_args.kwargs["model"] == "aura-2-andromeda-en"
+
+
+# ---------------------------------------------------------------------------
+# voice_id precedence (the placeholder bug fix)
+# ---------------------------------------------------------------------------
+
+
+def test_voice_id_config_wins_over_env(provider_settings: None) -> None:
+    """The agent config's voice_id takes precedence over ELEVENLABS_VOICE_ID.
+    Previously env always won, making the config field a placebo."""
+    config = _agent_config(
+        stt=STTConfig(),
+        tts=TTSConfig.model_validate(
+            {
+                "provider": "elevenlabs",
+                "voice_id": "config-voice-id",
+                "model": "eleven_multilingual_v2",
+            }
+        ),
+    )
+    mocks = _build_with_config(config)
+    assert mocks["elevenlabs_tts"].call_args.kwargs["voice_id"] == "config-voice-id"
+
+
+def test_voice_id_empty_config_falls_back_to_env(provider_settings: None) -> None:
+    config = _agent_config(
+        stt=STTConfig(),
+        tts=TTSConfig.model_validate(
+            {"provider": "elevenlabs", "voice_id": "", "model": "eleven_multilingual_v2"}
+        ),
+    )
+    mocks = _build_with_config(config)
+    assert mocks["elevenlabs_tts"].call_args.kwargs["voice_id"] == _ENV_VOICE_ID
+
+
+def test_voice_id_no_config_uses_env(provider_settings: None) -> None:
+    mocks = _build_with_config(None)
+    assert mocks["elevenlabs_tts"].call_args.kwargs["voice_id"] == _ENV_VOICE_ID
+
+
+# ---------------------------------------------------------------------------
+# ElevenLabs TTS model sourcing
+# ---------------------------------------------------------------------------
+
+
+def test_elevenlabs_tts_model_from_config_overrides_env(provider_settings: None) -> None:
+    config = _agent_config(
+        stt=STTConfig(),
+        tts=TTSConfig.model_validate(
+            {"provider": "elevenlabs", "voice_id": "v", "model": "eleven_turbo_v2_5"}
+        ),
+    )
+    mocks = _build_with_config(config)
+    assert mocks["elevenlabs_tts"].call_args.kwargs["model"] == "eleven_turbo_v2_5"
+
+
+def test_elevenlabs_tts_cross_provider_model_keeps_env_model(provider_settings: None) -> None:
+    config = _agent_config(
+        stt=STTConfig(),
+        tts=TTSConfig.model_validate(
+            {"provider": "elevenlabs", "voice_id": "v", "model": "aura-2-thalia-en"}
+        ),
+    )
+    mocks = _build_with_config(config)
+    assert mocks["elevenlabs_tts"].call_args.kwargs["model"] == _ENV_ELEVENLABS_MODEL

--- a/backend/tests/test_types.py
+++ b/backend/tests/test_types.py
@@ -205,3 +205,53 @@ def test_end_call_tool_found_after_validate_without_description() -> None:
     config = AgentConfig.model_validate(raw)
     end_call = next((t for t in config.tools if t.type == ToolType.END_CALL), None)
     assert end_call is not None
+
+
+# ---------------------------------------------------------------------------
+# Interchangeable STT/TTS providers (#135)
+# ---------------------------------------------------------------------------
+
+
+def test_provider_matrix_round_trips() -> None:
+    """Every cell of the 2x2 STT/TTS provider matrix validates and round-trips.
+
+    Both vendors are dual-capability (#135 AC2): deepgram and elevenlabs
+    must each be accepted for either pipeline stage, independently.
+    """
+    import itertools
+
+    for stt_provider, tts_provider in itertools.product(
+        ["deepgram", "elevenlabs"], ["elevenlabs", "deepgram"]
+    ):
+        raw = {
+            "id": "agent-1",
+            "name": "Bot",
+            "persona": "p",
+            "greeting": "hi",
+            "stt": {"provider": stt_provider, "language": "multi", "model": "m"},
+            "tts": {"provider": tts_provider, "voice_id": "v", "model": "m"},
+        }
+        config = AgentConfig.model_validate(raw)
+        assert config.stt.provider.value == stt_provider
+        assert config.tts.provider.value == tts_provider
+        # Round-trip: dump and re-validate without loss.
+        restored = AgentConfig.model_validate(config.model_dump())
+        assert restored.stt.provider == config.stt.provider
+        assert restored.tts.provider == config.tts.provider
+
+
+def test_provider_defaults_unchanged() -> None:
+    """Configs that omit providers keep the historical defaults, so existing
+    saved agents keep working exactly as before (#135 AC4 backward-compat)."""
+    assert STTConfig().provider.value == "deepgram"
+    assert TTSConfig().provider.value == "elevenlabs"
+
+
+def test_unknown_provider_rejected() -> None:
+    """A provider outside the supported set fails Pydantic validation loudly."""
+    import pytest
+
+    with pytest.raises(ValueError):
+        STTConfig.model_validate({"provider": "whisper", "language": "multi", "model": "m"})
+    with pytest.raises(ValueError):
+        TTSConfig.model_validate({"provider": "azure", "voice_id": "v", "model": "m"})

--- a/backend/tests/test_worker.py
+++ b/backend/tests/test_worker.py
@@ -604,6 +604,103 @@ async def test_entrypoint_falls_back_when_metadata_malformed(configured_settings
 
 
 @pytest.mark.asyncio
+async def test_entrypoint_forwards_agent_config_to_session(configured_settings: None) -> None:
+    """The parsed AgentConfig must reach build_agent_session so the session
+    constructs the user-selected STT/TTS providers (#135). Uses NON-default
+    providers to prove the values survive the metadata round-trip; this is the
+    only automated guard on the frontend metadata chain (FE has no test infra).
+    """
+    ctx, _ = _make_ctx()
+    mock_session = _make_session_mock()
+    mock_agent = MagicMock()
+
+    participant = MagicMock()
+    participant.metadata = json.dumps(
+        {
+            "id": "matrix-bot",
+            "name": "MatrixBot",
+            "persona": "p",
+            "greeting": "hi",
+            "stt": {"provider": "elevenlabs", "language": "multi", "model": "scribe_v2_realtime"},
+            "llm": {"provider": "openai", "model": "gpt-4o-mini"},
+            "tts": {"provider": "deepgram", "voice_id": "", "model": "aura-2-andromeda-en"},
+            "tools": [],
+        }
+    )
+    ctx.wait_for_participant = AsyncMock(return_value=participant)
+
+    with (
+        patch(
+            "taskorbit.worker.build_agent_session", return_value=mock_session
+        ) as mock_build_session,
+        patch("taskorbit.worker.build_default_agent", return_value=mock_agent),
+    ):
+        await entrypoint(ctx)
+
+    session_kwargs = mock_build_session.call_args.kwargs
+    forwarded = session_kwargs.get("agent_config")
+    assert forwarded is not None
+    assert forwarded.stt.provider.value == "elevenlabs"
+    assert forwarded.stt.model == "scribe_v2_realtime"
+    assert forwarded.tts.provider.value == "deepgram"
+    assert forwarded.tts.model == "aura-2-andromeda-en"
+
+
+@pytest.mark.asyncio
+async def test_entrypoint_parse_failure_logs_error_and_uses_defaults(
+    configured_settings: None,
+) -> None:
+    """Metadata that is PRESENT but invalid must log at error level (the session
+    silently falls back to default STT/TTS providers, overriding the user's
+    selection, so it has to be loud) and pass agent_config=None onward (#135)."""
+    ctx, _ = _make_ctx()
+    mock_session = _make_session_mock()
+    mock_agent = MagicMock()
+
+    participant = MagicMock()
+    participant.metadata = json.dumps({"unrelated": "shape"})
+    ctx.wait_for_participant = AsyncMock(return_value=participant)
+
+    with (
+        patch(
+            "taskorbit.worker.build_agent_session", return_value=mock_session
+        ) as mock_build_session,
+        patch("taskorbit.worker.build_default_agent", return_value=mock_agent),
+        patch("taskorbit.worker.logger") as mock_logger,
+    ):
+        await entrypoint(ctx)
+
+    assert mock_build_session.call_args.kwargs.get("agent_config") is None
+    error_events = [call.args[0] for call in mock_logger.error.call_args_list]
+    assert "worker_agent_config_parse_failed" in error_events
+
+
+@pytest.mark.asyncio
+async def test_entrypoint_empty_metadata_does_not_log_error(configured_settings: None) -> None:
+    """A participant with NO metadata (LiveKit playground / CLI joins) is a
+    normal defaults case, not a failure: no error-level log may fire (#135)."""
+    ctx, _ = _make_ctx()
+    mock_session = _make_session_mock()
+    mock_agent = MagicMock()
+
+    participant = MagicMock()
+    participant.metadata = ""
+    ctx.wait_for_participant = AsyncMock(return_value=participant)
+
+    with (
+        patch(
+            "taskorbit.worker.build_agent_session", return_value=mock_session
+        ) as mock_build_session,
+        patch("taskorbit.worker.build_default_agent", return_value=mock_agent),
+        patch("taskorbit.worker.logger") as mock_logger,
+    ):
+        await entrypoint(ctx)
+
+    assert mock_build_session.call_args.kwargs.get("agent_config") is None
+    mock_logger.error.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_commit_turn_cancels_stale_task(configured_settings: None) -> None:
     """A second commit_turn arriving before the first completes must cancel the
     first task so generate_reply() is only called once (for the latest turn)."""

--- a/frontend/src/components/agent-config/PipelineSection.tsx
+++ b/frontend/src/components/agent-config/PipelineSection.tsx
@@ -14,7 +14,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-import type { AgentConfig, LlmProvider } from "@/types/agentConfig";
+import type { AgentConfig, LlmProvider, SttProvider, TtsProvider } from "@/types/agentConfig";
 
 type Value = Pick<AgentConfig, "stt" | "tts" | "llm">;
 
@@ -30,6 +30,22 @@ type Props = {
 const LLM_MODEL_DEFAULTS: Record<LlmProvider, string> = {
   openai: "gpt-4o-mini",
   gemini: "gemini-2.5-flash",
+};
+
+// Same reset-on-switch rule for STT/TTS (#135). The elevenlabs STT default
+// must stay scribe_v2_realtime: it is the only Scribe model the voice
+// worker's streaming turn handling supports (batch models are rejected by
+// the backend factory and fall back to it anyway).
+const STT_MODEL_DEFAULTS: Record<SttProvider, string> = {
+  deepgram: "nova-3",
+  elevenlabs: "scribe_v2_realtime",
+};
+
+// Deepgram Aura encodes the voice in the model name (aura-2-<voice>-en),
+// so the Voice ID field only applies to ElevenLabs.
+const TTS_MODEL_DEFAULTS: Record<TtsProvider, string> = {
+  elevenlabs: "eleven_multilingual_v2",
+  deepgram: "aura-2-andromeda-en",
 };
 
 function StageHeader({ icon: Icon, label }: { icon: LucideIcon; label: string }) {
@@ -68,9 +84,13 @@ export function PipelineSection({ value, onChange }: Props) {
               <FieldLabel>Provider</FieldLabel>
               <Select
                 value={value.stt.provider}
-                onValueChange={(v) =>
-                  onChange({ ...value, stt: { ...value.stt, provider: v as "deepgram" } })
-                }
+                onValueChange={(v) => {
+                  const provider = v as SttProvider;
+                  onChange({
+                    ...value,
+                    stt: { ...value.stt, provider, model: STT_MODEL_DEFAULTS[provider] },
+                  });
+                }}
               >
                 <SelectTrigger>
                   <SelectValue />
@@ -78,6 +98,7 @@ export function PipelineSection({ value, onChange }: Props) {
                 <SelectContent>
                   <SelectGroup>
                     <SelectItem value="deepgram">Deepgram</SelectItem>
+                    <SelectItem value="elevenlabs">ElevenLabs</SelectItem>
                   </SelectGroup>
                 </SelectContent>
               </Select>
@@ -90,7 +111,7 @@ export function PipelineSection({ value, onChange }: Props) {
                 onChange={(e) =>
                   onChange({ ...value, stt: { ...value.stt, model: e.target.value } })
                 }
-                placeholder="nova-3"
+                placeholder={STT_MODEL_DEFAULTS[value.stt.provider]}
                 className="font-mono text-sm"
               />
             </Field>
@@ -147,9 +168,13 @@ export function PipelineSection({ value, onChange }: Props) {
               <FieldLabel>Provider</FieldLabel>
               <Select
                 value={value.tts.provider}
-                onValueChange={(v) =>
-                  onChange({ ...value, tts: { ...value.tts, provider: v as "elevenlabs" } })
-                }
+                onValueChange={(v) => {
+                  const provider = v as TtsProvider;
+                  onChange({
+                    ...value,
+                    tts: { ...value.tts, provider, model: TTS_MODEL_DEFAULTS[provider] },
+                  });
+                }}
               >
                 <SelectTrigger>
                   <SelectValue />
@@ -157,6 +182,7 @@ export function PipelineSection({ value, onChange }: Props) {
                 <SelectContent>
                   <SelectGroup>
                     <SelectItem value="elevenlabs">ElevenLabs</SelectItem>
+                    <SelectItem value="deepgram">Deepgram</SelectItem>
                   </SelectGroup>
                 </SelectContent>
               </Select>
@@ -169,22 +195,24 @@ export function PipelineSection({ value, onChange }: Props) {
                 onChange={(e) =>
                   onChange({ ...value, tts: { ...value.tts, model: e.target.value } })
                 }
-                placeholder="eleven_turbo_v2"
+                placeholder={TTS_MODEL_DEFAULTS[value.tts.provider]}
                 className="font-mono text-sm"
               />
             </Field>
-            <Field>
-              <FieldLabel htmlFor={idTtsVoice}>Voice ID</FieldLabel>
-              <Input
-                id={idTtsVoice}
-                value={value.tts.voice_id}
-                onChange={(e) =>
-                  onChange({ ...value, tts: { ...value.tts, voice_id: e.target.value } })
-                }
-                placeholder="rachel"
-                className="font-mono text-sm"
-              />
-            </Field>
+            {value.tts.provider === "elevenlabs" && (
+              <Field>
+                <FieldLabel htmlFor={idTtsVoice}>Voice ID</FieldLabel>
+                <Input
+                  id={idTtsVoice}
+                  value={value.tts.voice_id}
+                  onChange={(e) =>
+                    onChange({ ...value, tts: { ...value.tts, voice_id: e.target.value } })
+                  }
+                  placeholder="JBFqnCBsd6RMkjVDRZzb"
+                  className="font-mono text-sm"
+                />
+              </Field>
+            )}
           </FieldGroup>
         </FieldSet>
       </CardContent>

--- a/frontend/src/lib/livekitAgentMetadata.ts
+++ b/frontend/src/lib/livekitAgentMetadata.ts
@@ -73,7 +73,9 @@ export function buildLiveKitWorkerMetadata(agent: AgentConfig): Record<string, u
     persona: agent.instructions,
     greeting: agent.first_message.message,
     stt: {
-      provider: "deepgram",
+      // #135: pass the user's selection through; this was hardcoded to
+      // "deepgram" before, silently discarding the configured provider.
+      provider: agent.stt.provider,
       language: "multi",
       model: agent.stt.model,
     },
@@ -82,7 +84,8 @@ export function buildLiveKitWorkerMetadata(agent: AgentConfig): Record<string, u
       model: agent.llm.model,
     },
     tts: {
-      provider: "elevenlabs",
+      // #135: same fix as stt.provider above (was hardcoded "elevenlabs").
+      provider: agent.tts.provider,
       voice_id: agent.tts.voice_id,
       model: agent.tts.model,
     },

--- a/frontend/src/lib/userAgentsApi.ts
+++ b/frontend/src/lib/userAgentsApi.ts
@@ -6,7 +6,7 @@
  * (instructions, first_message, agent_id).
  */
 
-import type { AgentConfig, ToolDefinition } from "@/types/agentConfig";
+import type { AgentConfig, SttProvider, ToolDefinition, TtsProvider } from "@/types/agentConfig";
 
 // ---------------------------------------------------------------------------
 // Wire types (backend shape)
@@ -71,9 +71,13 @@ export function backendToFrontendAgent(entry: UserAgentEntry): AgentConfig {
     name: c.name,
     instructions: c.persona ?? "",
     first_message: { type: "text", message: c.greeting ?? "", prompt: "" },
-    stt: { provider: c.stt.provider as "deepgram", model: c.stt.model },
+    stt: { provider: c.stt.provider as SttProvider, model: c.stt.model },
     llm: { provider: (c.llm.provider ?? "openai") as "openai" | "gemini", model: c.llm.model },
-    tts: { provider: c.tts.provider as "elevenlabs", voice_id: c.tts.voice_id, model: c.tts.model },
+    tts: {
+      provider: c.tts.provider as TtsProvider,
+      voice_id: c.tts.voice_id,
+      model: c.tts.model,
+    },
     tools: frontendTools,
     variables: c.variables ?? {},
     engine: c.engine ?? {},

--- a/frontend/src/types/agentConfig.ts
+++ b/frontend/src/types/agentConfig.ts
@@ -13,8 +13,10 @@
  * touches them.
  */
 
-export type SttProvider = "deepgram";
-export type TtsProvider = "elevenlabs";
+// Both vendors are dual-capability (#135): either can serve STT or TTS,
+// selected independently. Mirrors STTProvider/TTSProvider in backend types.py.
+export type SttProvider = "deepgram" | "elevenlabs";
+export type TtsProvider = "elevenlabs" | "deepgram";
 export type LlmProvider = "openai" | "gemini";
 
 export type ParamType = "string" | "number" | "boolean" | "date";


### PR DESCRIPTION
Closes #135

Agents can now use Deepgram or ElevenLabs for STT and TTS independently, selected per agent in the config UI. The selection travels config UI -> saved agent -> room metadata -> worker, where a provider-dispatch factory builds the actual plugins. Switching providers auto-resets the model to that provider's default (same guard as #99). Zero new dependencies, zero new env vars.

All 4 combinations live-verified on the local stack (2026-06-12), including ElevenLabs Scribe realtime STT on a free-tier key. Every session logs its resolved selection (stt_selected / tts_selected) for easy review.

**Behavior change to be aware of:** the agent config now wins over env for voice_id and models (env stays the fallback). Previously env always won, which made the config voice field a non-functional placeholder. Default seed agents still carry the Rachel voice, which 402s on free ElevenLabs keys; swap to a free voice proposed separately.

Tests: 22 new (provider matrix, model pinning, voice precedence, worker metadata round-trip). 
Docs: new provider selection guide.