### PR TITLE
feat(#107): mute/unmute agent voice output

### DIFF
--- a/frontend/src/components/ConversationalChat.tsx
+++ b/frontend/src/components/ConversationalChat.tsx
@@ -265,7 +265,10 @@ export function ConversationalChat() {
 
           if (response.status === "ended") {
             if (replyText) {
-              await playSynthesizedSpeech(replyText, { signal: controller.signal, volumeRef: agentVolumeRef }).catch(() => {});
+              await playSynthesizedSpeech(replyText, {
+                signal: controller.signal,
+                volumeRef: agentVolumeRef,
+              }).catch(() => {});
             }
             call.end();
             return;
@@ -303,7 +306,10 @@ export function ConversationalChat() {
           if (speakable) {
             call.setPhase("speaking");
             try {
-              await playSynthesizedSpeech(replyText, { signal: controller.signal, volumeRef: agentVolumeRef });
+              await playSynthesizedSpeech(replyText, {
+                signal: controller.signal,
+                volumeRef: agentVolumeRef,
+              });
             } catch (audioErr) {
               if ((audioErr as Error).name !== "AbortError") {
                 console.warn("[ConversationalChat] ElevenLabs playback failed", audioErr);
@@ -383,7 +389,10 @@ export function ConversationalChat() {
           if (speakable) {
             call.setPhase("speaking");
             try {
-              await playSynthesizedSpeech(replyText, { signal: controller.signal, volumeRef: agentVolumeRef });
+              await playSynthesizedSpeech(replyText, {
+                signal: controller.signal,
+                volumeRef: agentVolumeRef,
+              });
             } catch (audioErr) {
               if ((audioErr as Error).name !== "AbortError") {
                 console.warn("[ConversationalChat] ElevenLabs playback failed", audioErr);

--- a/frontend/src/components/ConversationalChat.tsx
+++ b/frontend/src/components/ConversationalChat.tsx
@@ -84,7 +84,13 @@ export function ConversationalChat() {
   // Starts true (no call active). Set false on call start, then back to
   // true once the first speaking→idle_in_call transition is detected.
   const [greetingDone, setGreetingDone] = useState(true);
+  const [agentMuted, setAgentMuted] = useState(false);
   const [routedAgent, setRoutedAgent] = useState<string | null>(null);
+  // Stable ref so async playback closures always read the current mute state.
+  const agentVolumeRef = useRef(1);
+  useEffect(() => {
+    agentVolumeRef.current = agentMuted ? 0 : 1;
+  }, [agentMuted]);
   const greetingSeenSpeakingRef = useRef(false);
   const greetingTimeoutRef = useRef<number | null>(null);
   const transcriptEndRef = useRef<HTMLDivElement>(null);
@@ -259,7 +265,7 @@ export function ConversationalChat() {
 
           if (response.status === "ended") {
             if (replyText) {
-              await playSynthesizedSpeech(replyText, { signal: controller.signal }).catch(() => {});
+              await playSynthesizedSpeech(replyText, { signal: controller.signal, volumeRef: agentVolumeRef }).catch(() => {});
             }
             call.end();
             return;
@@ -297,7 +303,7 @@ export function ConversationalChat() {
           if (speakable) {
             call.setPhase("speaking");
             try {
-              await playSynthesizedSpeech(replyText, { signal: controller.signal });
+              await playSynthesizedSpeech(replyText, { signal: controller.signal, volumeRef: agentVolumeRef });
             } catch (audioErr) {
               if ((audioErr as Error).name !== "AbortError") {
                 console.warn("[ConversationalChat] ElevenLabs playback failed", audioErr);
@@ -377,7 +383,7 @@ export function ConversationalChat() {
           if (speakable) {
             call.setPhase("speaking");
             try {
-              await playSynthesizedSpeech(replyText, { signal: controller.signal });
+              await playSynthesizedSpeech(replyText, { signal: controller.signal, volumeRef: agentVolumeRef });
             } catch (audioErr) {
               if ((audioErr as Error).name !== "AbortError") {
                 console.warn("[ConversationalChat] ElevenLabs playback failed", audioErr);
@@ -552,6 +558,8 @@ export function ConversationalChat() {
             onSendText={handleSendText}
             onTriggerConfirmation={handleTriggerConfirmation}
             onMicError={call.setMicError}
+            agentMuted={agentMuted}
+            onAgentMutedChange={setAgentMuted}
           />
         </div>
       ) : isInCall ? null : (
@@ -576,7 +584,7 @@ export function ConversationalChat() {
           video={false}
           onError={handleRoomError}
         >
-          <RoomAudioRenderer />
+          <RoomAudioRenderer volume={agentMuted ? 0 : 1} />
           <VoiceSessionBridge
             status={call.status}
             onPhase={call.setPhase}

--- a/frontend/src/components/ConversationalChat.tsx
+++ b/frontend/src/components/ConversationalChat.tsx
@@ -154,6 +154,13 @@ export function ConversationalChat() {
     };
   }, []);
 
+  // Reset mute state between calls so a new session is never silently muted.
+  useEffect(() => {
+    if (call.status === "idle" || call.status === "ended") {
+      setAgentMuted(false);
+    }
+  }, [call.status]);
+
   // Detect greeting completion: first speaking → idle_in_call transition after
   // a call starts. Unlocks the mic button and triggers continuous mode.
   useEffect(() => {

--- a/frontend/src/components/chat/InCallControls.tsx
+++ b/frontend/src/components/chat/InCallControls.tsx
@@ -17,7 +17,7 @@
  */
 
 import { useEffect, useId, useRef, useState } from "react";
-import { ArrowUp, Mic, PhoneOff, Wand2 } from "lucide-react";
+import { ArrowUp, Mic, PhoneOff, Volume2, VolumeX, Wand2 } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { useMicRecorder } from "@/hooks/useMicRecorder";
@@ -34,6 +34,8 @@ type Props = {
   onSendText: (text: string) => void;
   onTriggerConfirmation: () => void;
   onMicError: (message: string | null) => void;
+  agentMuted: boolean;
+  onAgentMutedChange: (muted: boolean) => void;
 };
 
 export function InCallControls({
@@ -44,6 +46,8 @@ export function InCallControls({
   onSendText,
   onTriggerConfirmation,
   onMicError,
+  agentMuted,
+  onAgentMutedChange,
 }: Props) {
   const mic = useMicRecorder();
   const [draft, setDraft] = useState("");
@@ -338,6 +342,23 @@ export function InCallControls({
           ) : (
             <Mic size={18} />
           )}
+        </button>
+
+        {/* ── Agent output mute toggle ── */}
+        <button
+          type="button"
+          onClick={() => onAgentMutedChange(!agentMuted)}
+          aria-pressed={agentMuted}
+          aria-label={agentMuted ? "Unmute agent output" : "Mute agent output"}
+          className={cn(
+            "flex size-11 shrink-0 items-center justify-center rounded-full border",
+            "transition-all duration-200",
+            agentMuted
+              ? "border-transparent bg-destructive/15 text-destructive hover:bg-destructive hover:text-destructive-foreground"
+              : "border-border bg-card text-foreground hover:bg-muted",
+          )}
+        >
+          {agentMuted ? <VolumeX size={18} /> : <Volume2 size={18} />}
         </button>
 
         {/* ── Demo confirmation (icon-only) ── */}

--- a/frontend/src/lib/ttsApi.ts
+++ b/frontend/src/lib/ttsApi.ts
@@ -15,6 +15,8 @@ export type SynthesizeOptions = {
   signal?: AbortSignal;
   voiceId?: string;
   modelId?: string;
+  /** When provided, the Audio element's volume is synced to this ref every 50 ms. */
+  volumeRef?: { current: number };
 };
 
 export async function synthesizeSpeech(text: string, options?: SynthesizeOptions): Promise<string> {
@@ -52,7 +54,7 @@ export async function playSynthesizedSpeech(
 
   const url = await synthesizeSpeech(trimmed, options);
   try {
-    await playAudioUrl(url, options?.signal);
+    await playAudioUrl(url, options?.signal, options?.volumeRef);
   } finally {
     URL.revokeObjectURL(url);
   }
@@ -132,17 +134,32 @@ export async function playWithWordSync(
   signal?.addEventListener("abort", onAbort, { once: true });
 
   try {
-    await playAudioUrl(url, signal);
+    await playAudioUrl(url, signal, options?.volumeRef);
   } finally {
     signal?.removeEventListener("abort", onAbort);
     URL.revokeObjectURL(url);
   }
 }
 
-function playAudioUrl(url: string, signal?: AbortSignal): Promise<void> {
+function playAudioUrl(
+  url: string,
+  signal?: AbortSignal,
+  volumeRef?: { current: number },
+): Promise<void> {
   return new Promise((resolve, reject) => {
     const audio = new Audio(url);
+    if (volumeRef !== undefined) {
+      audio.volume = Math.max(0, Math.min(1, volumeRef.current));
+    }
+    // Poll the ref so mute changes take effect within 50 ms while already playing.
+    const pollId =
+      volumeRef !== undefined
+        ? setInterval(() => {
+            audio.volume = Math.max(0, Math.min(1, volumeRef.current));
+          }, 50)
+        : undefined;
     const cleanup = () => {
+      if (pollId !== undefined) clearInterval(pollId);
       signal?.removeEventListener("abort", onAbort);
     };
     const onAbort = () => {


### PR DESCRIPTION
Closes #107.

## Summary
Adds a mute/unmute toggle for the agent's audio output, covering both audio paths in the app: the LiveKit voice call (RoomAudioRenderer) and the ElevenLabs text-mode TTS playback.


## Changes

- **`ttsApi.ts`**: `playAudioUrl` (and the two call paths that use it, `playSynthesizedSpeech` and `playWithWordSync`) now accept an optional `volumeRef`. The Audio element's volume is set before playback and polled every 50ms while playing, so muting takes effect on audio that's already playing, not just on the next utterance.
- **`ConversationalChat.tsx`**: adds `agentMuted` state and a stable `agentVolumeRef` (so async playback closures always read the current value rather than a stale closure). Wires `RoomAudioRenderer volume={agentMuted ? 0 : 1}` for the voice path, and passes `volumeRef: agentVolumeRef` to all three `playSynthesizedSpeech` call sites for the text-mode path.
- **`InCallControls.tsx`**: new mute/unmute button between the mic and demo-confirmation buttons, mirroring the existing mic toggle's pattern (`aria-pressed`, conditional Tailwind classes, icon swap). Uses `Volume2`/`VolumeX` from lucide-react; the muted state uses the same destructive-tinted styling as the end-call button so the state is visually unambiguous.

## Testing
- `npx tsc --noEmit` clean.
- Manually verified both paths: started a voice call, muted mid-sentence (audio cuts instantly), unmuted, confirmed the next agent turn plays normally with no session restart. Repeated with text input (ElevenLabs path) — muting mid-playback cuts within the polling interval, unmuting resumes correctly on the next message.
- Confirmed the conversation/transcript continues updating normally while muted — only the audible output is suppressed, intent routing and agent state are untouched.