### PR TITLE
Llm streaming responses frontend integration 

### DIFF
--- a/backend/src/taskorbit/livekit_agent/llm.py
+++ b/backend/src/taskorbit/livekit_agent/llm.py
@@ -289,13 +289,29 @@ class OrchestratorAgent(Agent):
         )
         from taskorbit.types import ToolType as _ToolType
 
-        # Open the DB session before process_message so that manual transfers
-        # and custom-agent DB lookups work in the voice path too.
+        # Stream the orchestrator response: yield str chunks to TTS immediately,
+        # capture the final ConversationResponse for state updates below.
+        # The DB session stays open across the entire stream so that manual
+        # transfers and custom-agent DB lookups work in the voice path.
+        response = None
+        chunk_index = 0
         try:
             async with AsyncSessionLocal() as db:
-                response = await self._orchestrator.process_message(
+                async for item in self._orchestrator.process_message_stream(
                     request, db=db, user_id=self._user_id
-                )
+                ):
+                    if isinstance(item, str):
+                        if chunk_index == 0 and self._t_commit is not None:
+                            _first_chunk_latency = time.perf_counter() - self._t_commit
+                            log.debug(
+                                "llm_first_chunk",
+                                latency_ms=round(_first_chunk_latency * 1000, 1),
+                            )
+                        log.debug("llm_stream_chunk", index=chunk_index, chars=len(item))
+                        chunk_index += 1
+                        yield item
+                    else:
+                        response = item
         except Exception as exc:
             log.error(
                 "voice_turn_orchestrator_failed",
@@ -304,10 +320,13 @@ class OrchestratorAgent(Agent):
             )
             raise
 
-        # Error or clarification responses have no LLM stream in the voice path;
-        # yield the reply text so TTS speaks it instead of staying silent.
-        if response.reply and response.reply.content:
+        # Early-exit paths (clarification, confirmation, handoff block, end-call, error)
+        # produce no str chunks — only a ConversationResponse. Speak the reply via TTS.
+        if chunk_index == 0 and response is not None and response.reply and response.reply.content:
             yield response.reply.content
+
+        if response is None:
+            return
 
         self._locked_intent_name = response.locked_intent_name
         self._completed_workflow_steps = response.completed_workflow_steps

--- a/backend/tests/test_livekit_agent.py
+++ b/backend/tests/test_livekit_agent.py
@@ -126,11 +126,11 @@ def _make_agent(reply: str) -> tuple[OrchestratorAgent, MagicMock]:
     )
     captured: list[Any] = []
 
-    async def _process_message(request: Any, db: Any = None, user_id: Any = None) -> Any:
+    async def _process_message_stream(request: Any, db: Any = None, user_id: Any = None):
         captured.append(request)
-        return response
+        yield response
 
-    orchestrator.process_message = _process_message
+    orchestrator.process_message_stream = _process_message_stream
     orchestrator._captured = captured
     agent = OrchestratorAgent(
         orchestrator=orchestrator,
@@ -275,8 +275,17 @@ async def test_voice_path_propagates_persona_guardrails_into_prompt(
     )
     voice_agent_config = _default_agent_config()
 
+    # process_message_stream uses generate_stream for the main LLM call;
+    # intent detection and slot extraction still go through generate.
+    captured_stream_prompt: list[str] = []
+
+    async def _generate_stream(prompt: str, messages: Any, config: Any):
+        captured_stream_prompt.append(prompt)
+        yield "Sorry, only TechStore."
+
     mock_client = MagicMock()
-    mock_client.generate = AsyncMock(return_value="Sorry, only TechStore.")
+    mock_client.generate = AsyncMock(return_value="")
+    mock_client.generate_stream = _generate_stream
 
     agent = OrchestratorAgent(
         orchestrator=orchestrator,
@@ -289,7 +298,8 @@ async def test_voice_path_propagates_persona_guardrails_into_prompt(
     with patch("taskorbit.integrations.llm.factory.get_llm_client", return_value=mock_client):
         [_ async for _ in agent.llm_node(chat_ctx, [], MagicMock())]
 
-    augmented_prompt = mock_client.generate.call_args.args[0]
+    assert captured_stream_prompt, "generate_stream was not called"
+    augmented_prompt = captured_stream_prompt[0]
     # Asserting against the new imperative headers
     assert "Authorized Scope:" in augmented_prompt
     assert "CORE CONSTRAINT - Forbidden Topics" in augmented_prompt


### PR DESCRIPTION
Fixes #162

## What changed
`llm_node` in `livekit_agent/llm.py` now calls `process_message_stream`
instead of `process_message`. LLM tokens are yielded to the LiveKit TTS
plugin as they arrive, so audio begins playing on the first token rather
than after the full response completes.

Early-exit paths (clarification, confirmation, handoff, end-call) are
unchanged — if no str chunks are yielded, the reply text is still spoken
via a single TTS yield as before.

## Verified in worker logs
stt_processing_complete  latency_ms=304ms

llm_first_chunk          latency_ms=2291ms  ← TTS starts here now

llm_stream_chunk         index=0 chars=4

llm_stream_chunk         index=1 chars=3

voice_turn_complete      latency_ms=2410ms

Previously TTS could not start until `voice_turn_complete`. Now it starts
at `llm_first_chunk` — the user hears audio ~2 seconds earlier per turn.

Debug logs are `log.debug` level and silenced in production (default
`LOG_LEVEL=INFO`). Useful for future debugging.

