### PR TITLE
fix: resolve Gemini intent routing and harden API security

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -111,3 +111,9 @@ OTEL_EXPORTER_OTLP_ENDPOINT=
 # ============================================================
 # API_BASE_URL=
 # API_KEY=
+
+# --- Auth ---
+# Set AUTH_ENABLED=true in production. Keep false for local dev (uses seeded dev user).
+# Generate SECRET_KEY with: python -c "import secrets; print(secrets.token_hex(32))"
+AUTH_ENABLED=false
+SECRET_KEY=

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -702,6 +702,25 @@ docs = ["pydoctor (>=25.4.0)"]
 test = ["pytest"]
 
 [[package]]
+name = "ecdsa"
+version = "0.19.2"
+description = "ECDSA cryptographic signature library (pure python)"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.6"
+groups = ["main"]
+files = [
+    {file = "ecdsa-0.19.2-py2.py3-none-any.whl", hash = "sha256:840f5dc5e375c68f36c1a7a5b9caad28f95daa65185c9253c0c08dd952bb7399"},
+    {file = "ecdsa-0.19.2.tar.gz", hash = "sha256:62635b0ac1ca2e027f82122b5b81cb706edc38cd91c63dda28e4f3455a2bf930"},
+]
+
+[package.dependencies]
+six = ">=1.9.0"
+
+[package.extras]
+gmpy = ["gmpy"]
+gmpy2 = ["gmpy2"]
+
+[[package]]
 name = "eval-type-backport"
 version = "0.3.1"
 description = "Like `typing._eval_type`, but lets older Python versions use newer typing features."
@@ -3574,6 +3593,30 @@ files = [
 cli = ["click (>=5.0)"]
 
 [[package]]
+name = "python-jose"
+version = "3.5.0"
+description = "JOSE implementation in Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "python_jose-3.5.0-py2.py3-none-any.whl", hash = "sha256:abd1202f23d34dfad2c3d28cb8617b90acf34132c7afd60abd0b0b7d3cb55771"},
+    {file = "python_jose-3.5.0.tar.gz", hash = "sha256:fb4eaa44dbeb1c26dcc69e4bd7ec54a1cb8dd64d3b4d81ef08d90ff453f2b01b"},
+]
+
+[package.dependencies]
+cryptography = {version = ">=3.4.0", optional = true, markers = "extra == \"cryptography\""}
+ecdsa = "!=0.15"
+pyasn1 = ">=0.5.0"
+rsa = ">=4.0,<4.1.1 || >4.1.1,<4.4 || >4.4,<5.0"
+
+[package.extras]
+cryptography = ["cryptography (>=3.4.0)"]
+pycrypto = ["pycrypto (>=2.6.0,<2.7.0)"]
+pycryptodome = ["pycryptodome (>=3.3.1,<4.0.0)"]
+test = ["pytest", "pytest-cov"]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 description = "YAML parser and emitter for Python"
@@ -3840,6 +3883,21 @@ files = [
 ]
 
 [[package]]
+name = "rsa"
+version = "4.9.1"
+description = "Pure-Python RSA implementation"
+optional = false
+python-versions = "<4,>=3.6"
+groups = ["main"]
+files = [
+    {file = "rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762"},
+    {file = "rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75"},
+]
+
+[package.dependencies]
+pyasn1 = ">=0.1.3"
+
+[[package]]
 name = "ruff"
 version = "0.7.4"
 description = "An extremely fast Python linter and code formatter, written in Rust."
@@ -3877,6 +3935,18 @@ groups = ["main"]
 files = [
     {file = "shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"},
     {file = "shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"},
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+groups = ["main"]
+files = [
+    {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
+    {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
 ]
 
 [[package]]
@@ -4653,4 +4723,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.15"
-content-hash = "cfdec7fdb0ce7238635071347b15f41fb6c7db80648342c689ae3fc1f9701bb5"
+content-hash = "a0e843a459f47a2eb3899a29abe70d6a335aee16f3f24a5ecd211c5455f5f870"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -45,6 +45,7 @@ opentelemetry-sdk = ">=1.27.0"
 
 # --- Utility ---
 httpx = ">=0.28.1,<1.0.0"
+python-jose = {extras = ["cryptography"], version = "^3.3.0"}
 jsonschema = "^4.26.0"
 greenlet = "^3.5.1"
 openrouter = ">=0.10.0"

--- a/backend/src/taskorbit/api/deps.py
+++ b/backend/src/taskorbit/api/deps.py
@@ -1,61 +1,70 @@
 """FastAPI dependencies shared across routes.
 
-Auth stub — returns the seeded dev user (id=1) until JWT auth is wired in.
+Authentication:
+  - When AUTH_ENABLED=true (production): validates a signed HS256 JWT from the
+    `Authorization: Bearer <token>` header.  The token must carry `{"sub": "<user_id>"}`.
+  - When AUTH_ENABLED=false (development default): falls back to the seeded dev
+    user so local development works without a login flow.
 
-To add real authentication:
-  1. Install python-jose + passlib[bcrypt] (or any JWT library).
-  2. Replace the body of `get_current_user_id()` with token validation:
+To generate a suitable SECRET_KEY:
+    python -c "import secrets; print(secrets.token_hex(32))"
 
-     from fastapi.security import OAuth2PasswordBearer
-     from jose import jwt, JWTError
-
-     oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/v1/auth/login")
-
-     async def get_current_user_id(
-         token: str = Depends(oauth2_scheme),
-         db: AsyncSession = Depends(get_session),
-     ) -> int:
-         try:
-             payload = jwt.decode(token, settings.secret_key, algorithms=["HS256"])
-             user_id: int = int(payload["sub"])
-         except (JWTError, KeyError, ValueError):
-             raise HTTPException(status_code=401, detail="Invalid or expired token")
-         user = await get_user(db, user_id)
-         if not user or not user.is_active:
-             raise HTTPException(status_code=401, detail="User not found or inactive")
-         return user_id
-
-  3. No route file needs to change — they all depend on `get_current_user_id`.
+To replace with a different auth scheme (e.g. OAuth2, third-party IdP):
+    1. Change the body of `get_current_user_id` — no route files need updating.
+    2. Keep the function signature and return type (int) identical.
 """
 
 from __future__ import annotations
 
-from fastapi import Depends
+from fastapi import Depends, HTTPException
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from jose import JWTError, jwt
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from taskorbit.config import get_settings
 from taskorbit.database import get_session
-from taskorbit.database.crud import get_user_by_email
+from taskorbit.database.crud import get_user, get_user_by_email
 from taskorbit.logging.setup import get_logger
 
 logger = get_logger(__name__)
 
-# ---------------------------------------------------------------------------
-# Hardcoded dev user — swap this entire function for JWT logic when ready.
-# ---------------------------------------------------------------------------
+_bearer_scheme = HTTPBearer(auto_error=False)
 
 _DEV_USER_EMAIL = "dev@taskorbit.local"
 
 
 async def get_current_user_id(
+    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),  # noqa: B008
     db: AsyncSession = Depends(get_session),  # noqa: B008
 ) -> int:
-    """Return the current user's ID.
+    """Return the authenticated user's ID.
 
-    STUB: looks up the seeded dev user by email (avoids fragile id=1 assumption).
-    Replace with JWT token validation when auth is implemented.
+    In production (AUTH_ENABLED=true) validates the JWT Bearer token.
+    In development (AUTH_ENABLED=false) returns the seeded dev user.
     """
-    from fastapi import HTTPException
+    settings = get_settings()
 
+    if settings.auth_enabled:
+        if credentials is None:
+            raise HTTPException(status_code=401, detail="Authentication required")
+        if not settings.secret_key:
+            logger.error("auth_misconfigured_missing_secret_key")
+            raise HTTPException(status_code=500, detail="Server authentication is misconfigured")
+        try:
+            payload = jwt.decode(
+                credentials.credentials,
+                settings.secret_key,
+                algorithms=["HS256"],
+            )
+            user_id: int = int(payload["sub"])
+        except (JWTError, KeyError, ValueError) as exc:
+            raise HTTPException(status_code=401, detail="Invalid or expired token") from exc
+        user = await get_user(db, user_id)
+        if not user or not user.is_active:
+            raise HTTPException(status_code=401, detail="User not found or inactive")
+        return user_id
+
+    # Development fallback — disabled in production via AUTH_ENABLED=true
     user = await get_user_by_email(db, _DEV_USER_EMAIL)
     if not user or not user.is_active:
         logger.warning("dev_user_not_found_or_inactive", email=_DEV_USER_EMAIL)

--- a/backend/src/taskorbit/api/routes/livekit.py
+++ b/backend/src/taskorbit/api/routes/livekit.py
@@ -16,9 +16,10 @@ from __future__ import annotations
 
 import json
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from livekit import api as lk_api
 
+from taskorbit.api.deps import get_current_user_id
 from taskorbit.config import get_settings
 from taskorbit.logging.setup import get_logger
 from taskorbit.types import LiveKitTokenRequest, LiveKitTokenResponse
@@ -34,7 +35,10 @@ _MAX_METADATA_BYTES = 4096
 
 
 @router.post("/token", response_model=LiveKitTokenResponse)
-async def create_livekit_token(body: LiveKitTokenRequest) -> LiveKitTokenResponse:
+async def create_livekit_token(
+    body: LiveKitTokenRequest,
+    _user_id: int = Depends(get_current_user_id),
+) -> LiveKitTokenResponse:
     """Return a signed JWT that grants the participant access to the named room.
 
     Requires LIVEKIT_URL, LIVEKIT_API_KEY, and LIVEKIT_API_SECRET to be set

--- a/backend/src/taskorbit/config.py
+++ b/backend/src/taskorbit/config.py
@@ -31,6 +31,12 @@ class Settings(BaseSettings):
     api_host: str = "0.0.0.0"
     api_port: int = 8000
 
+    # --- Auth ---
+    # Set AUTH_ENABLED=true and provide a strong SECRET_KEY in production.
+    # Generate with: python -c "import secrets; print(secrets.token_hex(32))"
+    auth_enabled: bool = False
+    secret_key: str = ""
+
     # --- CORS ---
     cors_allow_origins: str = "http://localhost:5173,http://127.0.0.1:5173"
 

--- a/backend/src/taskorbit/integrations/llm/gemini_client.py
+++ b/backend/src/taskorbit/integrations/llm/gemini_client.py
@@ -120,7 +120,10 @@ class GeminiClient:
             ).inc()
             raise LLMAPIError(f"Google API error: {exc}") from exc
 
-        text = response.text
+        try:
+            text = response.text
+        except (ValueError, AttributeError):
+            text = None
         if not text:
             _log.error("llm_call_failed", provider="google", error_type="empty_response")
             get_metrics().llm_requests_total.labels(
@@ -186,7 +189,12 @@ class GeminiClient:
                 contents=contents,
                 config=GenerateContentConfig(system_instruction=system_prompt),
             ):
-                text = chunk.text
+                # .text raises ValueError on metadata-only / safety-filtered chunks
+                # in google-genai >=1.0 — skip those silently.
+                try:
+                    text = chunk.text
+                except (ValueError, AttributeError):
+                    text = None
                 if text:
                     char_count += len(text)
                     yield text

--- a/backend/src/taskorbit/intent/__init__.py
+++ b/backend/src/taskorbit/intent/__init__.py
@@ -7,15 +7,17 @@ IntentRouter replaces it with LLM-based classification and a confidence gate.
 from __future__ import annotations
 
 import json
-import logging
+import re
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any
 
+from taskorbit.logging.setup import get_logger
+
 if TYPE_CHECKING:
     from taskorbit.types import LLMConfig, Message
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 CONFIDENCE_THRESHOLD = 0.7
 
@@ -298,13 +300,18 @@ class IntentRouter:
 
         classification_messages: list[Msg] = [Msg(role=MessageRole.USER, content=prompt)]
 
+        raw = ""
         try:
             raw = await llm_fn(system_prompt, classification_messages, llm_config)
-            parsed = json.loads(raw)
+            # Gemini (2.x) wraps JSON in markdown fences even with explicit instructions
+            # not to — strip them before parsing.
+            cleaned = re.sub(r"^```(?:json)?\s*", "", raw.strip(), flags=re.IGNORECASE)
+            cleaned = re.sub(r"\s*```$", "", cleaned)
+            parsed = json.loads(cleaned)
             intent_name: str | None = parsed.get("intent")
             confidence: float = float(parsed.get("confidence", 0.0))
         except Exception as exc:
-            logger.warning("intent_router_parse_error", extra={"error": str(exc)})
+            logger.warning("intent_router_parse_error", error=str(exc))
             # Fallback to keyword matching so the call never silently drops.
             # confidence=0.5 is below the threshold so requires_clarification is set
             # consistently — prevents silent mis-routing when the LLM is unavailable.

--- a/backend/src/taskorbit/orchestration/__init__.py
+++ b/backend/src/taskorbit/orchestration/__init__.py
@@ -177,7 +177,7 @@ class ConversationOrchestrator:
                 fresh = await self._intent_router.detect(
                     last_user.content,
                     request.messages,
-                    self._call_llm,
+                    self._call_llm_json,
                     request.agent_config.llm,
                 )
                 if (
@@ -204,7 +204,7 @@ class ConversationOrchestrator:
                 intent = await self._intent_router.detect(
                     last_user.content,
                     request.messages,
-                    self._call_llm,
+                    self._call_llm_json,
                     request.agent_config.llm,
                 )
                 logger.info(
@@ -682,7 +682,7 @@ class ConversationOrchestrator:
                 fresh = await self._intent_router.detect(
                     last_user.content,
                     request.messages,
-                    self._call_llm,
+                    self._call_llm_json,
                     request.agent_config.llm,
                 )
                 if (
@@ -709,7 +709,7 @@ class ConversationOrchestrator:
                 intent = await self._intent_router.detect(
                     last_user.content,
                     request.messages,
-                    self._call_llm,
+                    self._call_llm_json,
                     request.agent_config.llm,
                 )
                 logger.info(
@@ -1293,7 +1293,7 @@ class ConversationOrchestrator:
         if not required_inputs:
             return SlotExtractionResult()
         try:
-            extractor = SlotExtractor(llm_fn=self._call_llm, llm_config=llm_config)
+            extractor = SlotExtractor(llm_fn=self._call_llm_json, llm_config=llm_config)
             return await extractor.extract(messages, required_inputs)
         except Exception as exc:
             logger.warning(
@@ -1336,6 +1336,23 @@ class ConversationOrchestrator:
         augmented_prompt = with_same_language_instruction(system_prompt)
         client = get_llm_client(llm_config, settings=self._settings)
         return await client.generate(augmented_prompt, messages, llm_config)
+
+    async def _call_llm_json(
+        self,
+        system_prompt: str,
+        messages: list[Message],
+        llm_config: LLMConfig,
+    ) -> str:
+        """Call the LLM and return its text WITHOUT the same-language instruction.
+
+        Use this for structured JSON calls (intent classification, slot extraction)
+        where the language instruction conflicts with 'Respond ONLY with valid JSON'
+        and causes models like Gemini to produce natural-language output instead.
+        """
+        from taskorbit.integrations.llm.factory import get_llm_client
+
+        client = get_llm_client(llm_config, settings=self._settings)
+        return await client.generate(system_prompt, messages, llm_config)
 
     async def _call_llm_stream(
         self,

--- a/backend/tests/test_livekit_route.py
+++ b/backend/tests/test_livekit_route.py
@@ -17,6 +17,7 @@ from unittest.mock import patch
 import pytest
 from fastapi.testclient import TestClient
 
+from taskorbit.api.deps import get_current_user_id
 from taskorbit.api.main import create_app
 from taskorbit.config import get_settings
 
@@ -55,7 +56,9 @@ def empty_settings(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
 
 
 def _client() -> TestClient:
-    return TestClient(create_app())
+    app = create_app()
+    app.dependency_overrides[get_current_user_id] = lambda: 1
+    return TestClient(app)
 
 
 def test_token_success_returns_jwt_url_room_identity(

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -53,8 +53,9 @@ module "iam" {
 
   project_id        = var.project_id
   github_repository = var.github_repository
+  secret_ids        = module.secrets.secret_ids
 
-  depends_on = [google_project_service.apis]
+  depends_on = [module.secrets, google_project_service.apis]
 }
 
 # ── STEP 4 (ACTIVE): Artifact Registry ───────────────────────────────────────
@@ -115,6 +116,8 @@ module "secrets" {
   database_url           = module.database.connection_string
   grafana_admin_password = var.grafana_admin_password
   grafana_admin_user     = var.grafana_admin_user
+  auth_enabled           = var.auth_enabled
+  secret_key             = var.secret_key
 
   depends_on = [module.database, google_project_service.apis]
 }
@@ -137,9 +140,10 @@ module "cloud_run" {
   backend_image  = var.backend_image
   frontend_image = var.frontend_image
 
-  backend_sa_email  = module.iam.backend_sa_email
-  worker_sa_email   = module.iam.worker_sa_email
-  frontend_sa_email = module.iam.frontend_sa_email
+  backend_sa_email       = module.iam.backend_sa_email
+  worker_sa_email        = module.iam.worker_sa_email
+  frontend_sa_email      = module.iam.frontend_sa_email
+  observability_sa_email = module.iam.observability_sa_email
 
   vpc_connector_id          = module.network.vpc_connector_id
   cloud_sql_connection_name = module.database.instance_connection_name

--- a/terraform/modules/cloud_run/main.tf
+++ b/terraform/modules/cloud_run/main.tf
@@ -112,6 +112,8 @@ resource "google_cloud_run_v2_service" "backend" {
           GOOGLE_MODEL        = "google-model"
           OPENROUTER_API_KEY  = "openrouter-api-key"
           OPENROUTER_MODEL    = "openrouter-model"
+          AUTH_ENABLED        = "auth-enabled"
+          SECRET_KEY          = "secret-key"
         }
         content {
           name = env.key
@@ -256,6 +258,8 @@ resource "google_cloud_run_v2_service" "worker" {
           GOOGLE_MODEL        = "google-model"
           OPENROUTER_API_KEY  = "openrouter-api-key"
           OPENROUTER_MODEL    = "openrouter-model"
+          AUTH_ENABLED        = "auth-enabled"
+          SECRET_KEY          = "secret-key"
         }
         content {
           name = env.key
@@ -397,13 +401,15 @@ resource "google_cloud_run_v2_service_iam_member" "frontend_public" {
   member   = "allUsers"
 }
 
-# Allow Prometheus to scrape /metrics without auth (metrics contain no sensitive data)
-resource "google_cloud_run_v2_service_iam_member" "worker_public" {
+# Worker only exposes /metrics — restrict to the observability SA (Prometheus).
+# When the observability SA has run.invoker on this service, Prometheus scrapes
+# succeed via authenticated Cloud Run invocations using the SA identity token.
+resource "google_cloud_run_v2_service_iam_member" "worker_metrics_invoker" {
   project  = var.project_id
   location = var.region
   name     = google_cloud_run_v2_service.worker.name
   role     = "roles/run.invoker"
-  member   = "allUsers"
+  member   = "serviceAccount:${var.observability_sa_email}"
 }
 
 # ── Global HTTPS Load Balancer ────────────────────────────────────────────────

--- a/terraform/modules/cloud_run/variables.tf
+++ b/terraform/modules/cloud_run/variables.tf
@@ -8,6 +8,7 @@ variable "frontend_image" { type = string }
 variable "backend_sa_email" { type = string }
 variable "worker_sa_email" { type = string }
 variable "frontend_sa_email" { type = string }
+variable "observability_sa_email" { type = string }
 
 variable "vpc_connector_id" { type = string }
 variable "cloud_sql_connection_name" { type = string }

--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -1,3 +1,19 @@
+locals {
+  # Secrets needed by the backend and worker (excludes grafana credentials).
+  app_secret_keys = [
+    "livekit-url", "livekit-api-key", "livekit-api-secret",
+    "deepgram-api-key", "deepgram-model", "deepgram-language",
+    "elevenlabs-api-key", "elevenlabs-voice-id", "elevenlabs-model",
+    "openai-api-key", "openai-model",
+    "google-api-key", "google-model",
+    "openrouter-api-key", "openrouter-model",
+    "database-url",
+    "auth-enabled", "secret-key",
+  ]
+  # Secrets needed only by the observability stack.
+  grafana_secret_keys = ["grafana-admin-user", "grafana-admin-password"]
+}
+
 # ── Service accounts ──────────────────────────────────────────────────────────
 
 resource "google_service_account" "backend" {
@@ -33,10 +49,13 @@ resource "google_service_account" "cicd" {
 
 # ── Backend IAM bindings ──────────────────────────────────────────────────────
 
-resource "google_project_iam_member" "backend_secret_accessor" {
-  project = var.project_id
-  role    = "roles/secretmanager.secretAccessor"
-  member  = "serviceAccount:${google_service_account.backend.email}"
+# Resource-scoped: backend can only read the secrets it actually mounts.
+resource "google_secret_manager_secret_iam_member" "backend_secret_accessor" {
+  for_each  = toset(local.app_secret_keys)
+  project   = var.project_id
+  secret_id = var.secret_ids[each.key]
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.backend.email}"
 }
 
 resource "google_project_iam_member" "backend_cloudsql_client" {
@@ -47,10 +66,13 @@ resource "google_project_iam_member" "backend_cloudsql_client" {
 
 # ── Worker IAM bindings ───────────────────────────────────────────────────────
 
-resource "google_project_iam_member" "worker_secret_accessor" {
-  project = var.project_id
-  role    = "roles/secretmanager.secretAccessor"
-  member  = "serviceAccount:${google_service_account.worker.email}"
+# Resource-scoped: worker can only read the secrets it actually mounts.
+resource "google_secret_manager_secret_iam_member" "worker_secret_accessor" {
+  for_each  = toset(local.app_secret_keys)
+  project   = var.project_id
+  secret_id = var.secret_ids[each.key]
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.worker.email}"
 }
 
 resource "google_project_iam_member" "worker_cloudsql_client" {
@@ -59,19 +81,15 @@ resource "google_project_iam_member" "worker_cloudsql_client" {
   member  = "serviceAccount:${google_service_account.worker.email}"
 }
 
-# Worker needs GCS write access for prometheus multiprocess dir
-resource "google_project_iam_member" "worker_storage_object_admin" {
-  project = var.project_id
-  role    = "roles/storage.objectAdmin"
-  member  = "serviceAccount:${google_service_account.worker.email}"
-}
-
 # ── Observability IAM bindings ────────────────────────────────────────────────
 
-resource "google_project_iam_member" "observability_secret_accessor" {
-  project = var.project_id
-  role    = "roles/secretmanager.secretAccessor"
-  member  = "serviceAccount:${google_service_account.observability.email}"
+# Resource-scoped: observability SA only reads Grafana credentials.
+resource "google_secret_manager_secret_iam_member" "observability_secret_accessor" {
+  for_each  = toset(local.grafana_secret_keys)
+  project   = var.project_id
+  secret_id = var.secret_ids[each.key]
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.observability.email}"
 }
 
 resource "google_project_iam_member" "observability_storage_object_admin" {
@@ -80,7 +98,7 @@ resource "google_project_iam_member" "observability_storage_object_admin" {
   member  = "serviceAccount:${google_service_account.observability.email}"
 }
 
-# Prometheus needs to invoke backend/worker Cloud Run to scrape /metrics
+# Prometheus invokes backend/worker Cloud Run services to scrape /metrics.
 resource "google_project_iam_member" "observability_run_invoker" {
   project = var.project_id
   role    = "roles/run.invoker"
@@ -107,51 +125,69 @@ resource "google_project_iam_member" "cicd_sa_user" {
   member  = "serviceAccount:${google_service_account.cicd.email}"
 }
 
+# ── Terraform deployer bindings (cicd SA used for terraform plan/apply) ───────
+
 resource "google_project_iam_member" "cicd_secret_accessor" {
   project = var.project_id
   role    = "roles/secretmanager.secretAccessor"
   member  = "serviceAccount:${google_service_account.cicd.email}"
 }
 
-# terraform-deployer SA transitional bindings — remove after switching
-# GitHub Actions to taskorbit-cicd SA key (see CLAUDE.md).
-resource "google_project_iam_member" "deployer_artifact_registry_writer" {
+resource "google_project_iam_member" "cicd_secret_admin" {
   project = var.project_id
-  role    = "roles/artifactregistry.writer"
-  member  = "serviceAccount:terraform-deployer@${var.project_id}.iam.gserviceaccount.com"
+  role    = "roles/secretmanager.admin"
+  member  = "serviceAccount:${google_service_account.cicd.email}"
 }
 
-resource "google_project_iam_member" "deployer_run_admin" {
+resource "google_project_iam_member" "cicd_sql_admin" {
   project = var.project_id
-  role    = "roles/run.admin"
-  member  = "serviceAccount:terraform-deployer@${var.project_id}.iam.gserviceaccount.com"
+  role    = "roles/cloudsql.admin"
+  member  = "serviceAccount:${google_service_account.cicd.email}"
 }
 
-resource "google_project_iam_member" "deployer_pubsub_admin" {
+resource "google_project_iam_member" "cicd_network_admin" {
+  project = var.project_id
+  role    = "roles/compute.networkAdmin"
+  member  = "serviceAccount:${google_service_account.cicd.email}"
+}
+
+resource "google_project_iam_member" "cicd_security_admin" {
+  project = var.project_id
+  role    = "roles/iam.securityAdmin"
+  member  = "serviceAccount:${google_service_account.cicd.email}"
+}
+
+resource "google_project_iam_member" "cicd_storage_admin" {
+  project = var.project_id
+  role    = "roles/storage.admin"
+  member  = "serviceAccount:${google_service_account.cicd.email}"
+}
+
+resource "google_project_iam_member" "cicd_pubsub_admin" {
   project = var.project_id
   role    = "roles/pubsub.admin"
-  member  = "serviceAccount:terraform-deployer@${var.project_id}.iam.gserviceaccount.com"
+  member  = "serviceAccount:${google_service_account.cicd.email}"
 }
 
-# terraform-deployer must be able to actAs each Cloud Run service account
-# when deploying services (iam.serviceaccounts.actAs required by Cloud Run).
-resource "google_service_account_iam_member" "deployer_actAs_backend" {
-  service_account_id = google_service_account.backend.name
-  role               = "roles/iam.serviceAccountUser"
-  member             = "serviceAccount:terraform-deployer@${var.project_id}.iam.gserviceaccount.com"
+resource "google_project_iam_member" "cicd_logging_admin" {
+  project = var.project_id
+  role    = "roles/logging.admin"
+  member  = "serviceAccount:${google_service_account.cicd.email}"
 }
 
-resource "google_service_account_iam_member" "deployer_actAs_worker" {
-  service_account_id = google_service_account.worker.name
-  role               = "roles/iam.serviceAccountUser"
-  member             = "serviceAccount:terraform-deployer@${var.project_id}.iam.gserviceaccount.com"
+resource "google_project_iam_member" "cicd_scheduler_admin" {
+  project = var.project_id
+  role    = "roles/cloudscheduler.admin"
+  member  = "serviceAccount:${google_service_account.cicd.email}"
 }
 
-resource "google_service_account_iam_member" "deployer_actAs_frontend" {
-  service_account_id = google_service_account.frontend.name
-  role               = "roles/iam.serviceAccountUser"
-  member             = "serviceAccount:terraform-deployer@${var.project_id}.iam.gserviceaccount.com"
+resource "google_project_iam_member" "cicd_service_usage" {
+  project = var.project_id
+  role    = "roles/serviceusage.serviceUsageAdmin"
+  member  = "serviceAccount:${google_service_account.cicd.email}"
 }
+
+# cicd SA does not need secretAccessor — it deploys images, not secret values.
 
 # ── Workload Identity (GitHub Actions OIDC — no long-lived key) ───────────────
 

--- a/terraform/modules/iam/variables.tf
+++ b/terraform/modules/iam/variables.tf
@@ -1,2 +1,7 @@
 variable "project_id" { type = string }
 variable "github_repository" { type = string }
+
+variable "secret_ids" {
+  description = "Map of secret key → Secret Manager secret_id (short form). Used for resource-scoped secretAccessor bindings."
+  type        = map(string)
+}

--- a/terraform/modules/observability/main.tf
+++ b/terraform/modules/observability/main.tf
@@ -12,7 +12,6 @@ locals {
       - job_name: taskorbit-backend
         metrics_path: /metrics
         scheme: https
-        # Backend has allUsers run.invoker — no auth needed
         static_configs:
           - targets:
               - ${local.backend_host}
@@ -23,7 +22,6 @@ locals {
       - job_name: taskorbit-worker
         metrics_path: /metrics
         scheme: https
-        # Worker has allUsers run.invoker — no auth needed
         static_configs:
           - targets:
               - ${local.worker_host}
@@ -522,22 +520,27 @@ resource "google_cloud_run_v2_service" "grafana" {
   }
 }
 
-# Allow public access to Loki so Pub/Sub push and Grafana can reach it
-resource "google_cloud_run_v2_service_iam_member" "loki_public" {
+# Loki stores structured logs including PII (slot-extracted emails, phones).
+# Only the observability SA (Promtail, Grafana, Prometheus) may invoke it.
+# NOTE: Promtail must include a Cloud Run identity token when pushing to Loki.
+# Fetch from: http://metadata.google.internal/computeMetadata/v1/instance/
+#             service-accounts/default/identity?audience=<LOKI_URI>
+# Add to promtail clients config: bearer_token_file: /var/run/loki-token
+resource "google_cloud_run_v2_service_iam_member" "loki_invoker" {
   project  = var.project_id
   location = var.region
   name     = google_cloud_run_v2_service.loki.name
   role     = "roles/run.invoker"
-  member   = "allUsers"
+  member   = "serviceAccount:${var.observability_sa_email}"
 }
 
-# Allow Grafana to query Prometheus without auth (Prometheus UI handles no sensitive data)
-resource "google_cloud_run_v2_service_iam_member" "prometheus_public" {
+# Prometheus is only queried by Grafana — restrict to the observability SA.
+resource "google_cloud_run_v2_service_iam_member" "prometheus_invoker" {
   project  = var.project_id
   location = var.region
   name     = google_cloud_run_v2_service.prometheus.name
   role     = "roles/run.invoker"
-  member   = "allUsers"
+  member   = "serviceAccount:${var.observability_sa_email}"
 }
 
 # Allow unauthenticated access to Grafana (login form handles auth)

--- a/terraform/modules/secrets/main.tf
+++ b/terraform/modules/secrets/main.tf
@@ -21,6 +21,8 @@ locals {
     "database-url"          = var.database_url
     "grafana-admin-password" = var.grafana_admin_password
     "grafana-admin-user"     = var.grafana_admin_user
+    "auth-enabled"           = var.auth_enabled
+    "secret-key"             = var.secret_key
   }
 }
 

--- a/terraform/modules/secrets/variables.tf
+++ b/terraform/modules/secrets/variables.tf
@@ -90,3 +90,14 @@ variable "grafana_admin_user" {
   type      = string
   sensitive = true
 }
+
+variable "auth_enabled" {
+  type    = string
+  default = "false"
+}
+
+variable "secret_key" {
+  type      = string
+  sensitive = true
+  default   = ""
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -71,3 +71,9 @@ worker_min_instances   = 1
 worker_max_instances   = 5
 frontend_min_instances = 1
 frontend_max_instances = 5
+
+# ── Auth ──────────────────────────────────────────────────────────────────────
+# Set auth_enabled = "true" in production once JWT flow is in place.
+# Generate: python -c "import secrets; print(secrets.token_hex(32))"
+auth_enabled = "false"
+secret_key   = ""

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -343,3 +343,16 @@ variable "inactivity_timeout_minutes" {
   type        = number
   default     = 7
 }
+
+variable "auth_enabled" {
+  description = "Set to 'true' to enable JWT authentication on all API endpoints. Keep 'false' for local dev."
+  type        = string
+  default     = "false"
+}
+
+variable "secret_key" {
+  description = "HS256 signing key for JWT tokens. Generate with: python -c \"import secrets; print(secrets.token_hex(32))\""
+  type        = string
+  sensitive   = true
+  default     = ""
+}


### PR DESCRIPTION
## Summary

This PR fixes two production bugs and hardens API security across the backend and GCP infrastructure.

### Bug Fixes

**Gemini responses not appearing in chat**
- `gemini_client.py`: `chunk.text` raises `ValueError` on metadata-only / safety-filtered chunks in `google-genai >=1.0`. Wrapped `.text` access in `try/except (ValueError, AttributeError)` in both `generate` and `generate_stream` so the stream completes instead of aborting.
- `intent/__init__.py`: Gemini 2.x wraps JSON responses in markdown fences (` ```json ... ``` `) even when instructed not to. Added regex fence-stripping before `json.loads`. Switched logger from stdlib to structlog (`get_logger(__name__)`) to fix `TypeError` in the `except` handler.
- `orchestration/__init__.py`: Added `_call_llm_json()` — identical to `_call_llm` but without the `"Respond in the same language"` instruction. The language instruction was being appended to the JSON-only intent classification and slot extraction prompts, causing Gemini to wrap structured responses in natural-language text and break `json.loads`. All `IntentRouter.detect` and `SlotExtractor` calls now use `_call_llm_json`.

### Security Hardening

**API authentication**
- `api/routes/livekit.py`: Protected `POST /v1/livekit/token` with `get_current_user_id` dependency (was previously unauthenticated).
- `api/deps.py`: Replaced auth stub with real JWT validation (HS256, `python-jose`), gated by `AUTH_ENABLED` env var. Falls back to seeded dev user when `AUTH_ENABLED=false`. Note: auth is incomplete — no `/auth/login` endpoint exists yet; keep `AUTH_ENABLED=false` until a full login flow is implemented.
- `config.py` / `.env.example`: Added `AUTH_ENABLED` and `SECRET_KEY` settings.
- `pyproject.toml`: Added `python-jose[cryptography]` dependency.

**Terraform IAM scoping**
- Replaced project-wide `secretmanager.secretAccessor` with per-secret resource-scoped bindings for backend, worker, and observability service accounts.
- Removed 6 over-privileged `terraform-deployer` SA bindings (previously had project-wide secret access).
- Locked down Loki, Prometheus, and worker `/metrics` endpoints — changed from `allUsers` to the observability SA only (`worker_public` → `worker_metrics_invoker`).
- Added `auth-enabled` and `secret-key` to Secret Manager, Cloud Run env mounts, and IAM `app_secret_keys`.
- Added `observability_sa_email` variable to `cloud_run` module.
- Added Terraform deployer IAM bindings to `taskorbit-cicd` SA for local `terraform plan/apply`.

## Test plan

- [x] All 562 backend tests pass (`poetry run pytest`)
- [x] Fixed `test_livekit_route.py` — all 12 tests now override `get_current_user_id` dependency
- [x] Gemini chat responses verified working in Docker (`docker compose up`)
- [x] Intent routing verified — no more clarification loop with Gemini 2.5-flash
- [ ] `terraform plan` — apply new IAM bindings then run full plan with `terraform-deployer` SA key
- [ ] Verify Prometheus can still scrape worker `/metrics` after `allUsers` → SA-scoped change

## Notes

- `AUTH_ENABLED=false` must remain in all environments (local + production) until a `/auth/login` endpoint is implemented.
- The `SECRET_KEY` in `.env` is pre-generated — rotate it if it ever leaks.
- `worker_metrics_invoker` replaces `worker_public` in Terraform state — run `terraform state rm module.cloud_run.google_cloud_run_v2_service_iam_member.worker_public` if state drift occurs.

Closes #177