### PR TITLE
feat(observability): Grafana OS model monitoring integration (#139)

### DIFF
--- a/backend/src/taskorbit/integrations/llm/ollama_client.py
+++ b/backend/src/taskorbit/integrations/llm/ollama_client.py
@@ -241,9 +241,8 @@ class OllamaClient:
             ).inc()
             raise LLMAPIError("Ollama returned an empty response")
 
-        usage = data.get("usage") or {}
-        prompt_tokens = usage.get("prompt_tokens", 0)
-        completion_tokens = usage.get("completion_tokens", 0)
+        prompt_tokens = data.get("prompt_eval_count", 0)
+        completion_tokens = data.get("eval_count", 0)
 
         _api_elapsed = time.perf_counter() - _api_start
         _log.info(
@@ -299,6 +298,8 @@ class OllamaClient:
         _api_start = time.perf_counter()
         char_count = 0
         completed = False
+        prompt_tokens = 0
+        completion_tokens = 0
         try:
             async with self._http.stream(
                 "POST",
@@ -320,6 +321,9 @@ class OllamaClient:
                         yield delta
                     if chunk.get("done"):
                         completed = True
+                        # Ollama reports token counts in the final done=true chunk
+                        prompt_tokens = chunk.get("prompt_eval_count", 0)
+                        completion_tokens = chunk.get("eval_count", 0)
                         break
         except httpx.TimeoutException as exc:
             _log.error("llm_stream_failed", provider="ollama", error_type="timeout", error=str(exc))
@@ -349,6 +353,12 @@ class OllamaClient:
                 _m.llm_requests_total.labels(
                     provider="ollama", model=llm_config.model, status="success"
                 ).inc()
+                _m.tokens_used_total.labels(
+                    provider="ollama", model=llm_config.model, token_type="prompt"
+                ).inc(prompt_tokens)
+                _m.tokens_used_total.labels(
+                    provider="ollama", model=llm_config.model, token_type="completion"
+                ).inc(completion_tokens)
             _m.pipeline_latency_seconds.labels(stage="llm_api_ollama").observe(_api_elapsed)
             _m.llm_response_chars.labels(provider="ollama", model=llm_config.model).observe(
                 char_count

--- a/backend/src/taskorbit/observability/metrics.py
+++ b/backend/src/taskorbit/observability/metrics.py
@@ -73,7 +73,15 @@ def configure_default_metrics() -> None:
     # Pre-initialize known label combinations so counters appear as 0 in /metrics
     # from startup rather than being absent until the first LLM call completes.
     m = get_metrics()
-    _providers = [("openai", "gpt-4o-mini"), ("google", "gemini-2.5-flash")]
+    _providers = [
+        ("openai", "gpt-4o-mini"),
+        ("google", "gemini-2.5-flash"),
+        # Open-source providers — pre-initialize with representative default models
+        # so Grafana shows 0 from startup rather than "No data" until first request.
+        # Add a new tuple here when onboarding a new OS provider.
+        ("openrouter", "qwen/qwen3-next-80b-a3b-instruct:free"),
+        ("ollama", "gemma4:26b"),
+    ]
     _llm_statuses = ["success", "auth", "rate_limit", "timeout", "api", "empty_response", "client"]
     for provider, model in _providers:
         for token_type in ("prompt", "completion"):
@@ -85,6 +93,8 @@ def configure_default_metrics() -> None:
         "llm_call",
         "llm_api_openai",
         "llm_api_google",
+        "llm_api_openrouter",
+        "llm_api_ollama",
         "tts_synthesis",
         "tts_ttfb",
         "worker_turn",

--- a/backend/tests/test_ollama_client.py
+++ b/backend/tests/test_ollama_client.py
@@ -204,6 +204,39 @@ async def test_generate_sends_system_prompt_as_first_message() -> None:
     assert messages[0]["content"] == "Be concise."
 
 
+@pytest.mark.asyncio
+async def test_generate_records_token_counts_from_native_fields() -> None:
+    """prompt_eval_count and eval_count (Ollama native fields) are forwarded to metrics.
+
+    Regression guard: the old code read data["usage"]["prompt_tokens"] which does not
+    exist in the Ollama native API, so token counts were always 0.
+    """
+    settings = _make_settings()
+    llm_config = _make_llm_config()
+    client = OllamaClient(llm_config=llm_config, settings=settings)
+
+    resp = MagicMock(spec=httpx.Response)
+    resp.json.return_value = {
+        "message": {"role": "assistant", "content": "hello"},
+        "done": True,
+        "prompt_eval_count": 42,
+        "eval_count": 17,
+    }
+    resp.raise_for_status = MagicMock()
+    client._http = AsyncMock()
+    client._http.post = AsyncMock(return_value=resp)
+
+    mock_metrics = MagicMock()
+    with patch("taskorbit.integrations.llm.ollama_client.get_metrics", return_value=mock_metrics):
+        await client.generate("sys", [], llm_config)
+
+    inc_values = [
+        c.args[0] for c in mock_metrics.tokens_used_total.labels.return_value.inc.call_args_list
+    ]
+    assert 42 in inc_values, f"prompt tokens (42) not recorded; got {inc_values}"
+    assert 17 in inc_values, f"completion tokens (17) not recorded; got {inc_values}"
+
+
 # ---------------------------------------------------------------------------
 # generate() — error mapping
 # ---------------------------------------------------------------------------
@@ -295,6 +328,43 @@ async def test_generate_stream_yields_tokens() -> None:
         tokens.append(token)
 
     assert tokens == ["Hello", " world"]
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_records_token_counts_from_done_chunk() -> None:
+    """Token counts in the final done=True chunk are extracted and recorded.
+
+    Regression guard: the old code broke out of the stream on done=True without
+    reading prompt_eval_count/eval_count, so streaming token counts were always 0.
+    """
+    client = OllamaClient(llm_config=_make_llm_config(), settings=_make_settings())
+
+    lines = [
+        json.dumps({"message": {"content": "Hello"}, "done": False}),
+        json.dumps({"message": {"content": " world"}, "done": False}),
+        json.dumps(
+            {
+                "message": {"content": ""},
+                "done": True,
+                "prompt_eval_count": 55,
+                "eval_count": 22,
+            }
+        ),
+    ]
+    fake_ctx = _FakeStreamContext(lines)
+    client._http = MagicMock()
+    client._http.stream = MagicMock(return_value=fake_ctx)
+
+    mock_metrics = MagicMock()
+    with patch("taskorbit.integrations.llm.ollama_client.get_metrics", return_value=mock_metrics):
+        async for _ in client.generate_stream("sys", [], _make_llm_config()):
+            pass
+
+    inc_values = [
+        c.args[0] for c in mock_metrics.tokens_used_total.labels.return_value.inc.call_args_list
+    ]
+    assert 55 in inc_values, f"prompt tokens (55) not recorded; got {inc_values}"
+    assert 22 in inc_values, f"completion tokens (22) not recorded; got {inc_values}"
 
 
 @pytest.mark.asyncio

--- a/infra/grafana/provisioning/dashboards/os-models.json
+++ b/infra/grafana/provisioning/dashboards/os-models.json
@@ -1,0 +1,439 @@
+{
+  "uid": "taskorbit-os-models",
+  "title": "TaskOrbit — Open-Source Model Monitoring",
+  "description": "Real-time usage, latency, and error metrics for open-source model providers (OpenRouter, Ollama). Issue #139.",
+  "tags": ["taskorbit", "llm", "open-source", "openrouter", "ollama"],
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "15s",
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "graphTooltip": 1,
+  "annotations": { "list": [] },
+  "links": [],
+  "templating": {
+    "list": [
+      {
+        "name": "DS_PROMETHEUS",
+        "type": "datasource",
+        "query": "prometheus",
+        "label": "Prometheus",
+        "hide": 0,
+        "refresh": 1,
+        "includeAll": false,
+        "options": [],
+        "current": {}
+      },
+      {
+        "name": "provider",
+        "type": "query",
+        "label": "Provider",
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "query": {
+          "query": "label_values(taskorbit_llm_requests_total, provider)",
+          "refId": "StandardVariableQuery"
+        },
+        "regex": "openrouter|ollama",
+        "includeAll": true,
+        "allValue": "openrouter|ollama",
+        "multi": false,
+        "current": { "text": "All", "value": "$__all" },
+        "refresh": 2,
+        "sort": 1,
+        "hide": 0
+      },
+      {
+        "name": "model",
+        "type": "query",
+        "label": "Model",
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "query": {
+          "query": "label_values(taskorbit_llm_requests_total{provider=~\"$provider\"}, model)",
+          "refId": "StandardVariableQuery"
+        },
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": false,
+        "current": { "text": "All", "value": "$__all" },
+        "refresh": 2,
+        "sort": 1,
+        "hide": 0
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Total Requests (24h)",
+      "description": "Total LLM calls across all selected open-source providers in the last 24 hours.",
+      "gridPos": { "x": 0, "y": 0, "w": 6, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "textMode": "auto",
+        "orientation": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(increase(taskorbit_llm_requests_total{provider=~\"$provider\", model=~\"$model\"}[24h])) or vector(0)",
+          "legendFormat": "Requests",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Success Rate (1h)",
+      "description": "Fraction of LLM calls that completed successfully in the last hour.",
+      "gridPos": { "x": 6, "y": 0, "w": 6, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "textMode": "auto",
+        "orientation": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 0.9 },
+              { "color": "green", "value": 0.98 }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(rate(taskorbit_llm_requests_total{provider=~\"$provider\", model=~\"$model\", status=\"success\"}[1h])) / sum(rate(taskorbit_llm_requests_total{provider=~\"$provider\", model=~\"$model\"}[1h]))",
+          "legendFormat": "Success Rate",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Total Tokens (24h)",
+      "description": "Prompt and completion tokens consumed across all selected providers in the last 24 hours.",
+      "gridPos": { "x": 12, "y": 0, "w": 6, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "textMode": "auto",
+        "orientation": "horizontal"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "blue", "value": null }]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(increase(taskorbit_tokens_used_total{provider=~\"$provider\", model=~\"$model\", token_type=\"prompt\"}[24h])) or vector(0)",
+          "legendFormat": "Prompt",
+          "refId": "A",
+          "instant": true
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(increase(taskorbit_tokens_used_total{provider=~\"$provider\", model=~\"$model\", token_type=\"completion\"}[24h])) or vector(0)",
+          "legendFormat": "Completion",
+          "refId": "B",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Errors (24h)",
+      "description": "Total failed LLM calls across all selected providers in the last 24 hours.",
+      "gridPos": { "x": 18, "y": 0, "w": 6, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "textMode": "auto",
+        "orientation": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 20 }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(increase(taskorbit_llm_requests_total{provider=~\"$provider\", model=~\"$model\", status!=\"success\"}[24h])) or vector(0)",
+          "legendFormat": "Errors",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "row",
+      "title": "Request Volume",
+      "gridPos": { "x": 0, "y": 4, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Request Rate by Provider & Model",
+      "description": "Per-second LLM call rate broken down by provider and model.",
+      "gridPos": { "x": 0, "y": 5, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 1, "fillOpacity": 5 }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (provider, model) (rate(taskorbit_llm_requests_total{provider=~\"$provider\", model=~\"$model\"}[5m]))",
+          "legendFormat": "{{provider}} / {{model}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Error Rate by Status",
+      "description": "Per-second rate of failed calls broken down by error type (rate_limit, timeout, auth, api, empty_response).",
+      "gridPos": { "x": 12, "y": 5, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 1, "fillOpacity": 10 }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (provider, status) (rate(taskorbit_llm_requests_total{provider=~\"$provider\", model=~\"$model\", status!=\"success\"}[5m]))",
+          "legendFormat": "{{provider}} — {{status}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "row",
+      "title": "Latency",
+      "gridPos": { "x": 0, "y": 13, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "LLM API Latency P50 / P95 / P99",
+      "description": "End-to-end LLM provider API call latency percentiles for open-source model stages (llm_api_openrouter, llm_api_ollama).",
+      "gridPos": { "x": 0, "y": 14, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 0 }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.50, sum by (le, stage) (rate(taskorbit_pipeline_latency_seconds_bucket{stage=~\"llm_api_openrouter|llm_api_ollama\"}[5m])))",
+          "legendFormat": "p50 {{stage}}",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.95, sum by (le, stage) (rate(taskorbit_pipeline_latency_seconds_bucket{stage=~\"llm_api_openrouter|llm_api_ollama\"}[5m])))",
+          "legendFormat": "p95 {{stage}}",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.99, sum by (le, stage) (rate(taskorbit_pipeline_latency_seconds_bucket{stage=~\"llm_api_openrouter|llm_api_ollama\"}[5m])))",
+          "legendFormat": "p99 {{stage}}",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Response Size P95 by Model (chars)",
+      "description": "95th-percentile LLM response character count per provider and model — a proxy for output verbosity.",
+      "gridPos": { "x": 12, "y": 14, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 1, "fillOpacity": 5 }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.95, sum by (le, provider, model) (rate(taskorbit_llm_response_chars_bucket{provider=~\"$provider\", model=~\"$model\"}[5m])))",
+          "legendFormat": "p95 {{provider}} / {{model}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "row",
+      "title": "Token Usage",
+      "gridPos": { "x": 0, "y": 22, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Token Consumption Rate by Model",
+      "description": "Tokens per second consumed, split by prompt and completion, per provider and model.",
+      "gridPos": { "x": 0, "y": 23, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 1, "fillOpacity": 5 }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (provider, model) (rate(taskorbit_tokens_used_total{provider=~\"$provider\", model=~\"$model\", token_type=\"prompt\"}[5m]))",
+          "legendFormat": "prompt — {{provider}} / {{model}}",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (provider, model) (rate(taskorbit_tokens_used_total{provider=~\"$provider\", model=~\"$model\", token_type=\"completion\"}[5m]))",
+          "legendFormat": "completion — {{provider}} / {{model}}",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "Cumulative Tokens Today by Model",
+      "description": "Rolling 24-hour token accumulation per provider, model, and token type.",
+      "gridPos": { "x": 12, "y": 23, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 1, "fillOpacity": 10 }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (provider, model, token_type) (increase(taskorbit_tokens_used_total{provider=~\"$provider\", model=~\"$model\"}[24h]))",
+          "legendFormat": "{{token_type}} — {{provider}} / {{model}}",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Pre-initializes openrouter and ollama label combinations in `metrics.py` so Grafana shows `0` from startup instead of "No data" before the first LLM call
- Adds `infra/grafana/provisioning/dashboards/os-models.json` — a dedicated Grafana dashboard for open-source model providers, auto-loaded by the existing provisioner

## Changes

### `backend/src/taskorbit/observability/metrics.py`
Added `("openrouter", "qwen/qwen3-next-80b-a3b-instruct:free")` and `("ollama", "gemma4:26b")` to `_providers` in `configure_default_metrics()`, and added `llm_api_openrouter` / `llm_api_ollama` to the pipeline stage pre-initialization loop.

### `infra/grafana/provisioning/dashboards/os-models.json`
New dashboard — **TaskOrbit — Open-Source Model Monitoring** — with:
- **4 stat panels**: Total Requests (24h), Success Rate (1h), Total Tokens (24h), Errors (24h)
- **Request Volume row**: Request rate by provider & model, Error rate by status
- **Latency row**: P50/P95/P99 for `llm_api_openrouter` and `llm_api_ollama` stages, Response size P95 by model
- **Token Usage row**: Token consumption rate and cumulative tokens (24h) per provider/model
- Template variables: `DS_PROMETHEUS`, `provider` (regex-filtered to `openrouter|ollama`), `model`

## Acceptance Criteria verification

| AC | Status | Evidence |
|----|--------|---------|
| Metrics collected during execution (token usage, request count, latency, status, error type) | ✓ | Verified live: `llm_requests_total`, `pipeline_latency_seconds`, `llm_response_chars` all populated for `provider="ollama"` after calls to GCP Ollama VM (gemma4:26b). Error types recorded for OpenRouter failures. |
| Prometheus-compatible format consumable by existing monitoring | ✓ | Grafana/Prometheus scraping `/metrics` and displaying all series |
| Grafana dashboard with latency visualization | ✓ | P50=1.75s, P95=2.42s, P99=2.49s visible for `llm_api_ollama` stage |
| Dashboard distinguishes between providers and models | ✓ | Per-provider and per-model series in all panels; Provider + Model template variables filter correctly |
| Ready for OpenRouter, architected for future models | ✓ | Adding a new OS provider = 1 tuple in `_providers` + 2 regex updates in the dashboard |

## Known limitations

- **Ollama token usage**: The `OllamaClient.generate_stream()` path does not record token counts (Ollama's native streaming API does not always return usage data). `tokens_used_total` stays at 0 for Ollama streaming calls. Non-streaming calls do capture tokens.
- **OpenRouter free tier**: Several free model slugs (`meta-llama/llama-3.1-8b-instruct:free`, `qwen/qwen3-next-80b-a3b-instruct:free`) are currently unavailable on OpenRouter's free tier. Error tracking was verified (`status="api"` increments with the exact provider error message). Success-path metrics use the same code path as the verified OpenAI client.

## Test plan

- [x] `curl http://localhost:8000/metrics | grep openrouter` — all 7 status labels present at 0.0 before any call (pre-init works)
- [x] POST to `/v1/conversations/process` with `provider="ollama"` → `status="success"` response from GCP Ollama VM
- [x] `llm_requests_total{provider="ollama", status="success"}` incremented
- [x] `pipeline_latency_seconds_count{stage="llm_api_ollama"}` incremented
- [x] `llm_response_chars_count{provider="ollama"}` incremented
- [x] Grafana dashboard loads at `localhost:3000` → Dashboards → TaskOrbit — Open-Source Model Monitoring
- [x] Provider dropdown shows `ollama` and `openrouter`; timeseries legends show `provider / model` format
- [x] Latency P50/P95/P99 panel shows live data for `llm_api_ollama`

closes #139 