### PR TITLE
fix(#169): normalize spoken email addresses before storing slot value

### DIFF
--- a/backend/src/taskorbit/slots/extractor.py
+++ b/backend/src/taskorbit/slots/extractor.py
@@ -10,10 +10,49 @@ from typing import Any
 from taskorbit.slots.models import SlotExtractionResult, SlotValue
 from taskorbit.types import LLMConfig, Message, MessageRole
 
+
+def _normalize_email_value(value: str) -> str:
+    """Normalize a potentially malformed email string before validation.
+
+    Speech transcription (STT) often produces email addresses in spoken form
+    or with trailing punctuation that breaks format validation. This function
+    converts those artifacts to a canonical address so the correct value is
+    stored in SlotValue and echoed in confirmation messages.
+
+    Handles:
+    - Spoken "at the rate" / standalone " at " → "@"
+    - " dot " → "."
+    - Stray spaces around "@" and "." (e.g. "alice @ gmail . com")
+    - Trailing punctuation (period, comma, semicolon)
+    """
+    v = value.strip()
+
+    # Spoken "at the rate" (common STT output for @)
+    v = re.sub(r"\bat\s+the\s+rate\b", "@", v, flags=re.IGNORECASE)
+
+    # Standalone " at " between non-space characters → "@"
+    # Requires a word character on each side to avoid replacing "at" in words.
+    v = re.sub(r"(?<=\S)\s+at\s+(?=\S)", "@", v, flags=re.IGNORECASE)
+
+    # Spoken " dot " → "."
+    v = re.sub(r"\s+dot\s+", ".", v, flags=re.IGNORECASE)
+
+    # Collapse spaces around "@" and "."
+    v = re.sub(r"\s*@\s*", "@", v)
+    v = re.sub(r"\s*\.\s*", ".", v)
+
+    # Strip trailing punctuation left over from sentence endings
+    v = v.rstrip(".,;")
+
+    return v
+
+
 # Minimum format checks per slot type — rejects clearly malformed values so the
 # agent asks the user to repeat them rather than silently storing garbage.
+# TLD segment requires alphabetic characters only (2+ chars) so trailing
+# punctuation that survived normalization is caught rather than silently stored.
 _SLOT_VALIDATORS: dict[str, Callable[[Any], bool]] = {
-    "email": lambda v: isinstance(v, str) and bool(re.match(r"^[^@\s]+@[^@\s]+\.[^@\s]+$", v)),
+    "email": lambda v: isinstance(v, str) and bool(re.match(r"^[^@\s]+@[^@\s]+\.[a-zA-Z]{2,}$", v)),
     "phone": lambda v: isinstance(v, str) and len(re.sub(r"[^\d]", "", v)) >= 7,
     "date": lambda v: isinstance(v, str) and bool(re.match(r"^\d{4}-\d{2}-\d{2}$", v)),
 }
@@ -70,6 +109,14 @@ class SlotExtractor:
             for f in required_inputs
         )
         field_names = ", ".join(f'"{f["name"]}"' for f in required_inputs)
+        has_email = any(f["type"] == "email" for f in required_inputs)
+        email_hint = (
+            "\n- For email fields: convert spoken forms to standard format "
+            '(e.g. "alice at the rate gmail dot com" → "alice@gmail.com"). '
+            "Strip any trailing punctuation."
+            if has_email
+            else ""
+        )
         return (
             "You are a JSON data extraction function. "
             "Your ONLY output must be a valid JSON object — no prose, no markdown, no conversation.\n\n"
@@ -80,7 +127,7 @@ class SlotExtractor:
             "- Use null for any field not yet provided by the user.\n"
             "- Do NOT infer, guess, or assume values.\n"
             "- Do NOT respond to questions or continue the conversation.\n"
-            "- Output ONLY the JSON object, nothing else."
+            f"- Output ONLY the JSON object, nothing else.{email_hint}"
         )
 
     def _parse_response(
@@ -110,6 +157,8 @@ class SlotExtractor:
             if value is None:
                 continue
             slot_type = type_map[name]
+            if slot_type == "email" and isinstance(value, str):
+                value = _normalize_email_value(value)
             validator = _SLOT_VALIDATORS.get(slot_type)
             if validator is not None and not validator(value):
                 continue

--- a/backend/tests/test_slot_extraction.py
+++ b/backend/tests/test_slot_extraction.py
@@ -406,3 +406,148 @@ class TestOrchestratorSlotIntegration:
         assert "Test Agent" in prompt
         assert "- Caller Name: John Doe" in prompt
         assert "Still need to collect: Email Address, Phone Number" in prompt
+
+
+# ============ TESTS FOR EMAIL NORMALIZATION ============
+
+
+from taskorbit.slots.extractor import _SLOT_VALIDATORS, _normalize_email_value  # noqa: E402
+
+
+class TestNormalizeEmailValue:
+    """Unit tests for _normalize_email_value."""
+
+    def test_strips_trailing_period(self):
+        assert _normalize_email_value("alice@gmail.com.") == "alice@gmail.com"
+
+    def test_strips_trailing_comma(self):
+        assert _normalize_email_value("alice@gmail.com,") == "alice@gmail.com"
+
+    def test_strips_trailing_semicolon(self):
+        assert _normalize_email_value("alice@gmail.com;") == "alice@gmail.com"
+
+    def test_spoken_at_the_rate(self):
+        assert _normalize_email_value("alice at the rate gmail dot com") == "alice@gmail.com"
+
+    def test_spoken_standalone_at(self):
+        assert _normalize_email_value("alice at gmail.com") == "alice@gmail.com"
+
+    def test_spoken_dot(self):
+        assert _normalize_email_value("alice@gmail dot com") == "alice@gmail.com"
+
+    def test_spaces_around_at_and_dot(self):
+        assert _normalize_email_value("alice @ gmail . com") == "alice@gmail.com"
+
+    def test_partial_smart_format_trailing_period(self):
+        # STT emits "@" but leaves trailing period from spoken sentence end
+        assert _normalize_email_value("alice@therategmail.com.") == "alice@therategmail.com"
+
+    def test_already_clean_passes_through_unchanged(self):
+        assert _normalize_email_value("alice@gmail.com") == "alice@gmail.com"
+
+    def test_subdomain_preserved(self):
+        assert _normalize_email_value("user@mail.example.co.uk") == "user@mail.example.co.uk"
+
+    def test_hyphenated_domain_preserved(self):
+        assert (
+            _normalize_email_value("first-last@company-name.com") == "first-last@company-name.com"
+        )
+
+    def test_leading_and_trailing_whitespace_stripped(self):
+        assert _normalize_email_value("  alice@gmail.com  ") == "alice@gmail.com"
+
+
+class TestEmailValidator:
+    """Tests for the tightened email validator in _SLOT_VALIDATORS."""
+
+    def test_valid_simple_email(self):
+        assert _SLOT_VALIDATORS["email"]("alice@gmail.com") is True
+
+    def test_valid_subdomain_email(self):
+        assert _SLOT_VALIDATORS["email"]("user@mail.example.co.uk") is True
+
+    def test_valid_hyphenated_email(self):
+        assert _SLOT_VALIDATORS["email"]("first-last@company-name.com") is True
+
+    def test_rejects_trailing_period(self):
+        assert _SLOT_VALIDATORS["email"]("alice@therategmail.com.") is False
+
+    def test_rejects_numeric_tld(self):
+        assert _SLOT_VALIDATORS["email"]("alice@gmail.123") is False
+
+    def test_rejects_no_at(self):
+        assert _SLOT_VALIDATORS["email"]("alicegmail.com") is False
+
+    def test_rejects_spaces(self):
+        assert _SLOT_VALIDATORS["email"]("alice @gmail.com") is False
+
+
+class TestSlotExtractorEmailNormalization:
+    """Integration tests: normalized value ends up in SlotValue.value."""
+
+    @pytest.mark.asyncio
+    async def test_spoken_at_the_rate_stored_normalized(self):
+        async def mock_llm(system_prompt, messages, llm_config):
+            return '{"email_address": "alice at the rate gmail dot com"}'
+
+        extractor = SlotExtractor(
+            llm_fn=mock_llm,
+            llm_config=LLMConfig(provider="openai", model="gpt-4o-mini"),
+        )
+        result = await extractor.extract(
+            [Message(role=MessageRole.USER, content="my email is alice at the rate gmail dot com")],
+            [{"name": "email_address", "type": "email", "required": True}],
+        )
+        assert "email_address" in result.filled
+        assert result.filled["email_address"].value == "alice@gmail.com"
+        assert result.missing == []
+
+    @pytest.mark.asyncio
+    async def test_partial_smart_format_trailing_period_stored_normalized(self):
+        # STT converts "@" but leaves trailing period; extraction LLM echoes it verbatim.
+        async def mock_llm(system_prompt, messages, llm_config):
+            return '{"email_address": "alice@therategmail.com."}'
+
+        extractor = SlotExtractor(
+            llm_fn=mock_llm,
+            llm_config=LLMConfig(provider="openai", model="gpt-4o-mini"),
+        )
+        result = await extractor.extract(
+            [Message(role=MessageRole.USER, content="my email is alice@therategmail.com.")],
+            [{"name": "email_address", "type": "email", "required": True}],
+        )
+        assert "email_address" in result.filled
+        assert result.filled["email_address"].value == "alice@therategmail.com"
+        assert result.missing == []
+
+    @pytest.mark.asyncio
+    async def test_already_clean_email_unchanged(self):
+        async def mock_llm(system_prompt, messages, llm_config):
+            return '{"email_address": "bob@example.org"}'
+
+        extractor = SlotExtractor(
+            llm_fn=mock_llm,
+            llm_config=LLMConfig(provider="openai", model="gpt-4o-mini"),
+        )
+        result = await extractor.extract(
+            [Message(role=MessageRole.USER, content="bob@example.org")],
+            [{"name": "email_address", "type": "email", "required": True}],
+        )
+        assert result.filled["email_address"].value == "bob@example.org"
+
+    @pytest.mark.asyncio
+    async def test_irreparable_email_treated_as_missing(self):
+        # After normalization the value is still invalid → slot stays missing.
+        async def mock_llm(system_prompt, messages, llm_config):
+            return '{"email_address": "notanemail"}'
+
+        extractor = SlotExtractor(
+            llm_fn=mock_llm,
+            llm_config=LLMConfig(provider="openai", model="gpt-4o-mini"),
+        )
+        result = await extractor.extract(
+            [Message(role=MessageRole.USER, content="my email is notanemail")],
+            [{"name": "email_address", "type": "email", "required": True}],
+        )
+        assert "email_address" not in result.filled
+        assert "email_address" in result.missing


### PR DESCRIPTION
Deepgram's smart_format only converts the colloquial "at" to "@" — it doesn't recognize "at the rate", and leaves a trailing sentence-end period uncorrected. The malformed string was flowing straight into SlotValue.value and from there into the system prompt, so the agent could echo back an invalid email in confirmation messages.

Add _normalize_email_value, applied in _parse_response before the validator runs, so the stored slot value is always canonicalized: "at the rate" / standalone "at" -> "@", " dot " -> ".", spaces around @/. collapsed, trailing punctuation stripped.

Also tighten the email validator regex — the TLD segment previously matched any non-space/non-@ character including a trailing period, so malformed addresses like "alice@therategmail.com." silently passed validation. Now requires an alptic TLD.

Applies to both text and voice input since SlotExtractor is shared by process_message and process_message_stream.

Note: this does not attempt to un-merge words already fused by a partial smart_format conversion (e.g. "alice@therategmail.com" stays as-is, not split back into "the rate gmail") — reversing that reliably without false positives on legitimate domains is out of scope for this fix.