### PR TITLE
fix: clear user-facing errors on LLM provider failures

### DIFF
--- a/Documentation/llm-providers.md
+++ b/Documentation/llm-providers.md
@@ -32,7 +32,7 @@ All classes live in `backend/src/taskorbit/integrations/llm/errors.py`.
 |---|---|---|
 | `LLMError` | `Exception` | Base for all provider-layer failures. Catch this to handle "the provider failed for some reason." |
 | `LLMConfigError` | `LLMError` | Static config problem (missing API key, unknown provider, unsupported model). Detected before the request is sent. |
-| `LLMTimeoutError` | `LLMError` | Request exceeded the per-call timeout (default 8s for the chat call). |
+| `LLMTimeoutError` | `LLMError` | Request exceeded the per-call timeout. Values are per-provider: OpenAI 8s (`openai_client._REQUEST_TIMEOUT_SECONDS`), Gemini 10s (`gemini_client._REQUEST_TIMEOUT_MS`), Ollama 300s (`ollama_client._REQUEST_TIMEOUT_SECONDS`). OpenRouter timeouts surface from the SDK's `EdgeNetworkTimeoutResponseError`. |
 | `LLMRateLimitError` | `LLMAPIError` | Provider returned HTTP 429 or an equivalent overload signal. Covers both transient throttling and quota-exhausted-billing on providers that share the 429 code (e.g. OpenAI). |
 | `LLMAuthError` | `LLMAPIError` | Provider returned HTTP 401 or 403 (invalid, revoked, or forbidden key). |
 | `LLMAPIError` | `LLMError` | Any other provider-side error (5xx, malformed responses, empty content, unknown SDK errors). |
@@ -49,11 +49,22 @@ handle every provider with one set of `except` blocks.
 
 | SDK / signal | OpenAI | Gemini | OpenRouter | Ollama |
 |---|---|---|---|---|
-| 401 / 403 (auth) | `openai.AuthenticationError` | `genai_errors.ClientError` (401/403) | `ForbiddenResponseError`, `UnauthorizedResponseError` | `httpx.HTTPStatusError` (401) |
+| Auth | `openai.AuthenticationError` (401) | `genai_errors.ClientError` (401/403) | `ForbiddenResponseError`, `UnauthorizedResponseError` | `httpx.HTTPStatusError` (401 only; 403 currently falls through to `LLMAPIError`) |
 | 429 / overload | `openai.RateLimitError` | `genai_errors.ClientError` (429) | `TooManyRequestsResponseError`, `ProviderOverloadedResponseError` | (n/a for local) |
 | Timeout | `openai.APITimeoutError` | `genai_errors.ClientError` (408) | `EdgeNetworkTimeoutResponseError` | `httpx.TimeoutException` |
 | Other API error | `openai.APIError` (base) | `genai_errors.APIError` | `OpenRouterError` (base) | `httpx.HTTPStatusError` (other), `httpx.HTTPError` |
 | Empty response | mapped locally | mapped locally | mapped locally | mapped locally |
+
+The `generate_stream` method delegates to `generate` on OpenRouter (its
+free-tier SSE returns empty chunks), so the mapping above applies to
+both entry points on that provider. For OpenAI, Gemini, and Ollama the
+streaming methods have their own dedicated `except` chains that mirror
+the non-streaming mapping.
+
+The OpenRouter client also wraps `exc.body` through the
+`_bounded_detail` helper (500-char cap) before it enters logs or the
+user-visible LLMError message, so an oversized upstream error body
+cannot bloat observability or the `ConversationResponse.error` field.
 
 The mapping is verified by per-client tests: `test_openai_client.py`,
 `test_gemini_client.py`, `test_openrouter_client.py`,
@@ -67,21 +78,44 @@ Both `process_message` (text) and `process_message_stream` (stream) in
 `backend/src/taskorbit/orchestration/__init__.py` wrap the whole turn
 with the same handler chain, in this order:
 
-1. `LLMConfigError` -> config-specific error response.
-2. `TimeoutError`, `LLMTimeoutError` -> timeout-specific error response.
+1. `LLMConfigError` -> config-specific error response (label `llm_config`).
+2. `TimeoutError`, `LLMTimeoutError` -> timeout-specific error response
+   (label `llm_timeout`). The caught exception is logged as `error=str(exc)`
+   so on-call can tell which SDK raised it.
 3. `LLMError` (base) -> provider-agnostic error response for auth, rate
-   limit, other API errors, and any future `LLMError` subclass.
-4. `UnicodeEncodeError`, `Exception` -> the last-resort generic fallback.
+   limit, other API errors, and any future `LLMError` subclass
+   (label `llm_provider_error`).
+4. `UnicodeEncodeError` -> encoding-specific error response
+   (label `encoding_error`).
+5. `ValueError` -> invalid-input error response (label `invalid_input`).
+6. `Exception` -> last-resort generic fallback (label `runtime_error`).
 
-Handler order matters: `LLMConfigError` and `LLMTimeoutError` must be
-listed before the `LLMError` base, and `LLMError` must be listed before
-`Exception`, otherwise the more specific handlers become unreachable.
+Handler order matters: `LLMConfigError` and `LLMTimeoutError` both
+inherit from `LLMError`, so their handlers MUST come before the
+`LLMError` base handler, otherwise config errors would silently
+downgrade to the generic `llm_provider_error` label and lose their
+dedicated user message. This contract is defended by an inline comment
+above the chain in both paths and by the regression test
+`test_handler_ordering_llm_config_still_routes_to_llm_config_bucket`
+in `test_orchestration.py`.
 
 The user-facing reply for handler (3) is deliberately generic ("having
 trouble reaching my language model provider right now"). The exact
 failure detail (rate limit, auth, provider name, upstream reason) is
 carried in the `error` field of `ConversationResponse` and in the log,
 so on-call has full context without exposing internals to end users.
+
+The polite reply reaches every entry point:
+- `POST /v1/conversations/process` returns it in `response.reply.content`.
+- `POST /v1/conversations/stream` forwards it in the SSE error event as
+  `{"type": "error", "message": <technical>, "reply": <polite>}`, and
+  persists the assistant reply to the DB for symmetry with `/process`.
+- LiveKit voice worker (`livekit_agent/llm.py`) speaks the polite reply
+  through TTS on both early-exit errors and mid-stream provider failures
+  (previously a mid-stream error caused a half-sentence trail-off into
+  silence), and preserves `_locked_intent_name` /
+  `_completed_workflow_steps` on error responses so a transient blip
+  does not strand the session mid-workflow.
 
 The intent router's own LLM call is wrapped by
 `backend/src/taskorbit/intent/__init__.py` and re-raises `LLMError` up
@@ -91,27 +125,37 @@ never see the provider error message.
 
 ## Metric labels
 
-Two labels on `taskorbit_conversation_errors_total{error_type=...}` are
-relevant to LLM failures. Both are registered in the allow-list in
+Every label value on `taskorbit_conversation_errors_total{error_type=...}`
+is pre-registered in the allow-list in
 `backend/src/taskorbit/observability/metrics.py::configure_default_metrics`
 so Prometheus exposes them from the first scrape, even before a matching
 error has been seen.
 
 | Label | Emitted by | Covers |
 |---|---|---|
-| `llm_timeout` | orchestrator (2) | Both Python `TimeoutError` and `LLMTimeoutError` from any provider. |
-| `llm_provider_error` | orchestrator (3) | Every non-timeout `LLMError` subclass: auth, rate limit, any other API error. |
-| `llm_config` | orchestrator (1) | Static configuration errors caught before the request is sent. |
+| `llm_config` | orchestrator handler (1) | Static configuration errors caught before the request is sent. |
+| `llm_timeout` | orchestrator handler (2) | Both Python `TimeoutError` and `LLMTimeoutError` from any provider. |
+| `llm_provider_error` | orchestrator handler (3) | Every non-timeout `LLMError` subclass: auth, rate limit, any other API error. |
+| `encoding_error` | orchestrator handler (4) | `UnicodeEncodeError` on the reply path (rare). |
+| `invalid_input` | orchestrator handler (5) | `ValueError` raised inside the turn (malformed structured input). |
+| `runtime_error` | orchestrator handler (6) | Last-resort generic bucket for any other `Exception`. |
+| `unhandled` | FastAPI middleware in `api/main.py` | Exceptions that escape the orchestrator entirely and reach the app-level error handler. |
 
 The provider-side clients also emit `taskorbit_llm_requests_total{provider,
 model, status}` with `status` in `{success, auth, rate_limit, timeout,
 api}`. Query both counters together to distinguish "our orchestrator
-caught it" from "the provider returned it."
+caught it" from "the provider returned it." OpenRouter's client uses
+`status="auth"` for both the pre-#197 `ForbiddenResponseError` path and
+the new `UnauthorizedResponseError` path so alerts do not need to
+enumerate SDK-specific subclasses.
 
 ## Adding a new provider
 
-1. Add a subclass of `LLMClient` (see `base.py`) in a new
-   `<provider>_client.py` under `backend/src/taskorbit/integrations/llm/`.
+1. Add a class that satisfies the `LLMClient` Protocol (see `base.py`) in a
+   new `<provider>_client.py` under `backend/src/taskorbit/integrations/llm/`.
+   `LLMClient` is a `typing.Protocol`, so no explicit inheritance is needed;
+   implementing `generate` and `generate_stream` with the required
+   signatures is enough. Use `runtime_checkable` if you need `isinstance`.
 2. Inside `generate` and `generate_stream`, catch the SDK's own exception
    types and re-raise them as the appropriate `LLMError` subclass
    (`LLMAuthError`, `LLMRateLimitError`, `LLMTimeoutError`, `LLMAPIError`).

--- a/Documentation/llm-providers.md
+++ b/Documentation/llm-providers.md
@@ -1,0 +1,128 @@
+# LLM Providers and Error Handling
+
+> **Scope.** This guide documents the LLM provider abstraction, the error
+> taxonomy shared across providers, and how the orchestrator turns provider
+> failures into user-facing responses and Prometheus metrics (ticket #197).
+>
+> The abstraction lives in `backend/src/taskorbit/integrations/llm/`. The
+> orchestrator's handlers live in `backend/src/taskorbit/orchestration/__init__.py`.
+
+---
+
+## What this covers
+
+Before #197, any LLM provider failure that was not `LLMConfigError` or a
+Python built-in `TimeoutError` fell through the orchestrator's `except
+Exception` and produced a generic "An unexpected error occurred." reply.
+The most visible symptom (that triggered #197) was OpenAI conversations
+returning that fallback whenever the account's quota was exhausted or a
+transient auth issue hit, because those surfaced as `LLMAuthError` or
+`LLMRateLimitError` and the orchestrator did not catch them.
+
+Now every provider maps its SDK-specific failure modes to a shared
+`LLMError` hierarchy, both orchestration paths (text and stream) catch
+`LLMError` and return a clear, provider-agnostic response with a specific
+metric label.
+
+## Error taxonomy
+
+All classes live in `backend/src/taskorbit/integrations/llm/errors.py`.
+
+| Class | Base | Raised when |
+|---|---|---|
+| `LLMError` | `Exception` | Base for all provider-layer failures. Catch this to handle "the provider failed for some reason." |
+| `LLMConfigError` | `LLMError` | Static config problem (missing API key, unknown provider, unsupported model). Detected before the request is sent. |
+| `LLMTimeoutError` | `LLMError` | Request exceeded the per-call timeout (default 8s for the chat call). |
+| `LLMRateLimitError` | `LLMAPIError` | Provider returned HTTP 429 or an equivalent overload signal. Covers both transient throttling and quota-exhausted-billing on providers that share the 429 code (e.g. OpenAI). |
+| `LLMAuthError` | `LLMAPIError` | Provider returned HTTP 401 or 403 (invalid, revoked, or forbidden key). |
+| `LLMAPIError` | `LLMError` | Any other provider-side error (5xx, malformed responses, empty content, unknown SDK errors). |
+
+`LLMRateLimitError` and `LLMAuthError` intentionally inherit from
+`LLMAPIError` so a caller that only cares about "some API-side problem"
+can catch the base and still cover the specific subclasses.
+
+## Provider -> `LLMError` mapping
+
+Each client normalises its vendor SDK's exceptions to the shared taxonomy
+before the exception leaves the client. This is what lets the orchestrator
+handle every provider with one set of `except` blocks.
+
+| SDK / signal | OpenAI | Gemini | OpenRouter | Ollama |
+|---|---|---|---|---|
+| 401 / 403 (auth) | `openai.AuthenticationError` | `genai_errors.ClientError` (401/403) | `ForbiddenResponseError`, `UnauthorizedResponseError` | `httpx.HTTPStatusError` (401) |
+| 429 / overload | `openai.RateLimitError` | `genai_errors.ClientError` (429) | `TooManyRequestsResponseError`, `ProviderOverloadedResponseError` | (n/a for local) |
+| Timeout | `openai.APITimeoutError` | `genai_errors.ClientError` (408) | `EdgeNetworkTimeoutResponseError` | `httpx.TimeoutException` |
+| Other API error | `openai.APIError` (base) | `genai_errors.APIError` | `OpenRouterError` (base) | `httpx.HTTPStatusError` (other), `httpx.HTTPError` |
+| Empty response | mapped locally | mapped locally | mapped locally | mapped locally |
+
+The mapping is verified by per-client tests: `test_openai_client.py`,
+`test_gemini_client.py`, `test_openrouter_client.py`,
+`test_ollama_client.py`. Whenever a new SDK error type needs to be
+handled, add the mapping in the client and add a test that instantiates
+that SDK error and asserts the raised `LLMError` subclass.
+
+## Orchestrator behaviour
+
+Both `process_message` (text) and `process_message_stream` (stream) in
+`backend/src/taskorbit/orchestration/__init__.py` wrap the whole turn
+with the same handler chain, in this order:
+
+1. `LLMConfigError` -> config-specific error response.
+2. `TimeoutError`, `LLMTimeoutError` -> timeout-specific error response.
+3. `LLMError` (base) -> provider-agnostic error response for auth, rate
+   limit, other API errors, and any future `LLMError` subclass.
+4. `UnicodeEncodeError`, `Exception` -> the last-resort generic fallback.
+
+Handler order matters: `LLMConfigError` and `LLMTimeoutError` must be
+listed before the `LLMError` base, and `LLMError` must be listed before
+`Exception`, otherwise the more specific handlers become unreachable.
+
+The user-facing reply for handler (3) is deliberately generic ("having
+trouble reaching my language model provider right now"). The exact
+failure detail (rate limit, auth, provider name, upstream reason) is
+carried in the `error` field of `ConversationResponse` and in the log,
+so on-call has full context without exposing internals to end users.
+
+The intent router's own LLM call is wrapped by
+`backend/src/taskorbit/intent/__init__.py` and re-raises `LLMError` up
+to these handlers. Without that re-raise, intent-detection failures
+would be masked as a low-confidence clarification and the user would
+never see the provider error message.
+
+## Metric labels
+
+Two labels on `taskorbit_conversation_errors_total{error_type=...}` are
+relevant to LLM failures. Both are registered in the allow-list in
+`backend/src/taskorbit/observability/metrics.py::configure_default_metrics`
+so Prometheus exposes them from the first scrape, even before a matching
+error has been seen.
+
+| Label | Emitted by | Covers |
+|---|---|---|
+| `llm_timeout` | orchestrator (2) | Both Python `TimeoutError` and `LLMTimeoutError` from any provider. |
+| `llm_provider_error` | orchestrator (3) | Every non-timeout `LLMError` subclass: auth, rate limit, any other API error. |
+| `llm_config` | orchestrator (1) | Static configuration errors caught before the request is sent. |
+
+The provider-side clients also emit `taskorbit_llm_requests_total{provider,
+model, status}` with `status` in `{success, auth, rate_limit, timeout,
+api}`. Query both counters together to distinguish "our orchestrator
+caught it" from "the provider returned it."
+
+## Adding a new provider
+
+1. Add a subclass of `LLMClient` (see `base.py`) in a new
+   `<provider>_client.py` under `backend/src/taskorbit/integrations/llm/`.
+2. Inside `generate` and `generate_stream`, catch the SDK's own exception
+   types and re-raise them as the appropriate `LLMError` subclass
+   (`LLMAuthError`, `LLMRateLimitError`, `LLMTimeoutError`, `LLMAPIError`).
+   Preserve the original message via `from exc`.
+3. Emit `llm_requests_total` with the correct `status` label for each
+   failure branch (see any existing client for the pattern).
+4. Wire the client into `factory.py::get_llm_client` behind the provider
+   enum value.
+5. Add a test module `test_<provider>_client.py` that instantiates each
+   SDK error and asserts the raised `LLMError` subclass. Match the
+   pattern in `test_openai_client.py`.
+6. If you are introducing a new metric label, register it in
+   `observability/metrics.py::configure_default_metrics` and add a row
+   to the table above.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The frontend ships a ChatGPT-style mic button: tap to record, **Stop** mutes wit
 
 5. Open <http://localhost:5173>, click **Start session**, allow the mic prompt, then tap the mic to start a turn.
 
-See [`backend/README.md`](backend/README.md) and [`frontend/README.md`](frontend/README.md) for module-level details, and [`Documentation/livekit-cloud-setup.md`](Documentation/livekit-cloud-setup.md) for the full LiveKit setup walkthrough.
+See [`backend/README.md`](backend/README.md) and [`frontend/README.md`](frontend/README.md) for module-level details, [`Documentation/livekit-cloud-setup.md`](Documentation/livekit-cloud-setup.md) for the full LiveKit setup walkthrough, and [`Documentation/llm-providers.md`](Documentation/llm-providers.md) for the LLM provider abstraction, error taxonomy, and metric labels.
 
 ---
 

--- a/backend/src/taskorbit/api/routes/conversations.py
+++ b/backend/src/taskorbit/api/routes/conversations.py
@@ -165,7 +165,13 @@ async def _sse_generator(
       data: {"type": "done", "intent": "...", "status": "...", "selected_agent": "...",
               "slots": {...}, "missing_slots": [...], "conversation_id": "...",
               "reply": "..." (when no chunks were streamed)}
-      data: {"type": "error", "message": "..."}
+      data: {"type": "error", "message": "<technical>", "reply": "<polite>"}
+
+    On error events, `reply` carries the polite user-facing text from
+    ConversationResponse.reply (#197). The FE should render `reply` in the
+    assistant bubble and treat `message` as debug detail for on-call.
+    `reply` is null only when the orchestrator's error path predates the
+    polite-reply pattern.
     """
     # Persist user message upfront so it survives client disconnects.
     last_msg = request.messages[-1] if request.messages else None
@@ -202,7 +208,25 @@ async def _sse_generator(
         return
 
     if meta.status == "error":
-        yield f"data: {json.dumps({'type': 'error', 'message': meta.error or 'Unknown error'})}\n\n"
+        # Forward the polite user-facing reply (from ConversationResponse.reply,
+        # #197) alongside the technical error string so the FE can render the
+        # polite text in the assistant bubble instead of a raw provider error.
+        reply_text = meta.reply.content if meta.reply else None
+        yield f"data: {json.dumps({'type': 'error', 'message': meta.error or 'Unknown error', 'reply': reply_text})}\n\n"
+        # Persist the polite reply so conversation history is symmetric across
+        # error turns (matches the /process endpoint's persist-on-error).
+        if meta.reply:
+            saved = await create_conversation_message(
+                db=db,
+                conversation_id=request.conversation_id,
+                role=meta.reply.role.value,
+                content=meta.reply.content,
+            )
+            if saved is None:
+                logger.error(
+                    "sse_failed_to_save_assistant_error_message",
+                    conversation_id=request.conversation_id,
+                )
         return
 
     # Persist assistant reply after successful full stream

--- a/backend/src/taskorbit/integrations/llm/gemini_client.py
+++ b/backend/src/taskorbit/integrations/llm/gemini_client.py
@@ -113,6 +113,22 @@ class GeminiClient:
                 provider="google", model=llm_config.model, status="client"
             ).inc()
             raise LLMAPIError(f"Google API client error: {exc}") from exc
+        except genai_errors.UnknownApiResponseError as exc:
+            # UnknownApiResponseError inherits from ValueError (not APIError),
+            # so it slips past `except genai_errors.APIError`. Fires when the
+            # SDK cannot parse the API response into its known schema (protocol
+            # drift, unexpected shape, malformed JSON boundary). Parity extension
+            # of Vineesh's #197 review to Gemini.
+            _log.error(
+                "llm_call_failed",
+                provider="google",
+                error_type="unknown_response",
+                error=str(exc),
+            )
+            get_metrics().llm_requests_total.labels(
+                provider="google", model=llm_config.model, status="unknown_response"
+            ).inc()
+            raise LLMAPIError(f"Google API returned unparseable response: {exc}") from exc
         except genai_errors.APIError as exc:
             _log.error("llm_call_failed", provider="google", error_type="api", error=str(exc))
             get_metrics().llm_requests_total.labels(
@@ -233,6 +249,19 @@ class GeminiClient:
                 provider="google", model=llm_config.model, status="client"
             ).inc()
             raise LLMAPIError(f"Google API client error: {exc}") from exc
+        except genai_errors.UnknownApiResponseError as exc:
+            # See generate() for the rationale. UnknownApiResponseError is a
+            # ValueError, not an APIError, so it needs its own catch.
+            _log.error(
+                "llm_stream_failed",
+                provider="google",
+                error_type="unknown_response",
+                error=str(exc),
+            )
+            get_metrics().llm_requests_total.labels(
+                provider="google", model=llm_config.model, status="unknown_response"
+            ).inc()
+            raise LLMAPIError(f"Google API returned unparseable response: {exc}") from exc
         except genai_errors.APIError as exc:
             _log.error("llm_stream_failed", provider="google", error_type="api", error=str(exc))
             get_metrics().llm_requests_total.labels(

--- a/backend/src/taskorbit/integrations/llm/ollama_client.py
+++ b/backend/src/taskorbit/integrations/llm/ollama_client.py
@@ -163,6 +163,13 @@ class OllamaClient:
             raise LLMAPIError(
                 f"Failed to list models at Ollama endpoint {self._base_url}: {exc}"
             ) from exc
+        except ValueError as exc:
+            # response.json() raises json.JSONDecodeError (a ValueError) when
+            # Ollama returns a malformed body, e.g. a reverse-proxy HTML error
+            # page fronting the endpoint or a truncated body on a socket close
+            # that still parses as HTTP 200. httpx catches above do not cover
+            # this. Parity extension of Vineesh's #197 review to Ollama.
+            raise LLMAPIError(f"Ollama returned malformed JSON at {self._base_url}: {exc}") from exc
 
         available = [m.get("name", "") for m in data.get("models", [])]
         if model not in available:
@@ -232,6 +239,16 @@ class OllamaClient:
                 provider="ollama", model=llm_config.model, status="api"
             ).inc()
             raise LLMAPIError(f"Ollama API error: {exc}") from exc
+        except ValueError as exc:
+            # response.json() raises json.JSONDecodeError (a ValueError) when
+            # Ollama returns a malformed body, e.g. a reverse-proxy HTML error
+            # page or a truncated body. Parity extension of Vineesh's #197
+            # review to Ollama.
+            _log.error("llm_call_failed", provider="ollama", error_type="decode", error=str(exc))
+            get_metrics().llm_requests_total.labels(
+                provider="ollama", model=llm_config.model, status="decode_error"
+            ).inc()
+            raise LLMAPIError(f"Ollama returned malformed JSON: {exc}") from exc
 
         text = data.get("message", {}).get("content", "")
         if not text:

--- a/backend/src/taskorbit/integrations/llm/openai_client.py
+++ b/backend/src/taskorbit/integrations/llm/openai_client.py
@@ -111,6 +111,17 @@ class OpenAIClient:
                 provider="openai", model=llm_config.model, status="api"
             ).inc()
             raise LLMAPIError(f"OpenAI API error: {exc}") from exc
+        except openai.OpenAIError as exc:
+            # Catches OpenAI SDK errors that do not inherit from APIError,
+            # notably ContentFilterFinishReasonError and LengthFinishReasonError.
+            # Routing them into LLMAPIError gives them the llm_provider_error
+            # metric label + polite reply, matching how OpenRouter handles the
+            # same class of edge cases (#197 follow-up on Vineesh's review).
+            _log.error("llm_call_failed", provider="openai", error_type="api", error=str(exc))
+            get_metrics().llm_requests_total.labels(
+                provider="openai", model=llm_config.model, status="api"
+            ).inc()
+            raise LLMAPIError(f"OpenAI SDK error: {exc}") from exc
 
         text = response.choices[0].message.content if response.choices else None
         if not text:
@@ -206,6 +217,14 @@ class OpenAIClient:
                 provider="openai", model=llm_config.model, status="api"
             ).inc()
             raise LLMAPIError(f"OpenAI API error: {exc}") from exc
+        except openai.OpenAIError as exc:
+            # See generate() for the rationale. Catches non-APIError SDK errors
+            # so they map to llm_provider_error rather than the generic bucket.
+            _log.error("llm_stream_failed", provider="openai", error_type="api", error=str(exc))
+            get_metrics().llm_requests_total.labels(
+                provider="openai", model=llm_config.model, status="api"
+            ).inc()
+            raise LLMAPIError(f"OpenAI SDK error: {exc}") from exc
 
         char_count = 0
         usage_chunk = None
@@ -222,6 +241,11 @@ class OpenAIClient:
         except openai.APIError as exc:
             _log.error("llm_stream_failed", provider="openai", error_type="api", error=str(exc))
             raise LLMAPIError(f"OpenAI streaming error: {exc}") from exc
+        except openai.OpenAIError as exc:
+            # Mid-stream non-APIError SDK errors (ContentFilter, Length)
+            # surface here after chunks have already started flowing.
+            _log.error("llm_stream_failed", provider="openai", error_type="api", error=str(exc))
+            raise LLMAPIError(f"OpenAI streaming SDK error: {exc}") from exc
         finally:
             await stream.close()
             _api_elapsed = time.perf_counter() - _api_start

--- a/backend/src/taskorbit/integrations/llm/openrouter_client.py
+++ b/backend/src/taskorbit/integrations/llm/openrouter_client.py
@@ -21,6 +21,7 @@ from openrouter import OpenRouter
 from openrouter.errors import (
     EdgeNetworkTimeoutResponseError,
     ForbiddenResponseError,
+    NoResponseError,
     OpenRouterError,
     ProviderOverloadedResponseError,
     TooManyRequestsResponseError,
@@ -120,6 +121,20 @@ class OpenRouterClient:
                 provider="openrouter", model=llm_config.model, status="timeout"
             ).inc()
             raise LLMTimeoutError(f"OpenRouter request timed out: {exc}") from exc
+        except NoResponseError as exc:
+            # NoResponseError is the only SDK class that does not inherit from
+            # OpenRouterError, so neither the specific subclass catches above
+            # nor the broad OpenRouterError backstop below would catch it.
+            # Fires on transport-layer failures (TCP reset, DNS, TLS handshake,
+            # upstream close-before-headers). Semantically a timeout, so we
+            # map to LLMTimeoutError for consistent user-facing behaviour.
+            _log.error(
+                "llm_call_failed", provider="openrouter", error_type="no_response", error=str(exc)
+            )
+            get_metrics().llm_requests_total.labels(
+                provider="openrouter", model=llm_config.model, status="no_response"
+            ).inc()
+            raise LLMTimeoutError(f"OpenRouter returned no response: {exc}") from exc
         except (TooManyRequestsResponseError, ProviderOverloadedResponseError) as exc:
             # str(exc) is just "Provider returned error", exc.body carries the
             # actual reason (e.g. "model X is temporarily rate-limited upstream,

--- a/backend/src/taskorbit/integrations/llm/openrouter_client.py
+++ b/backend/src/taskorbit/integrations/llm/openrouter_client.py
@@ -22,6 +22,9 @@ from openrouter.errors import (
     EdgeNetworkTimeoutResponseError,
     ForbiddenResponseError,
     OpenRouterError,
+    ProviderOverloadedResponseError,
+    TooManyRequestsResponseError,
+    UnauthorizedResponseError,
 )
 
 from taskorbit.config import Settings
@@ -29,7 +32,7 @@ from taskorbit.logging.setup import get_logger
 from taskorbit.observability.metrics import get_metrics
 from taskorbit.types import LLMConfig, Message
 
-from .errors import LLMAPIError, LLMAuthError, LLMTimeoutError
+from .errors import LLMAPIError, LLMAuthError, LLMRateLimitError, LLMTimeoutError
 from .messages import to_openai_messages
 
 _log = get_logger(__name__)
@@ -88,6 +91,12 @@ class OpenRouterClient:
                 provider="openrouter", model=llm_config.model, status="auth"
             ).inc()
             raise LLMAuthError(f"OpenRouter authentication failed: {exc}") from exc
+        except UnauthorizedResponseError as exc:
+            _log.error("llm_call_failed", provider="openrouter", error_type="auth", error=str(exc))
+            get_metrics().llm_requests_total.labels(
+                provider="openrouter", model=llm_config.model, status="auth"
+            ).inc()
+            raise LLMAuthError(f"OpenRouter authentication failed: {exc}") from exc
         except EdgeNetworkTimeoutResponseError as exc:
             _log.error(
                 "llm_call_failed", provider="openrouter", error_type="timeout", error=str(exc)
@@ -96,12 +105,25 @@ class OpenRouterClient:
                 provider="openrouter", model=llm_config.model, status="timeout"
             ).inc()
             raise LLMTimeoutError(f"OpenRouter request timed out: {exc}") from exc
+        except (TooManyRequestsResponseError, ProviderOverloadedResponseError) as exc:
+            # str(exc) is just "Provider returned error" — exc.body carries the
+            # actual reason ("model X is temporarily rate-limited upstream,
+            # retry shortly"), essential for diagnosing flaky :free models (#197).
+            detail = getattr(exc, "body", None) or str(exc)
+            _log.error(
+                "llm_call_failed", provider="openrouter", error_type="rate_limit", error=detail
+            )
+            get_metrics().llm_requests_total.labels(
+                provider="openrouter", model=llm_config.model, status="rate_limit"
+            ).inc()
+            raise LLMRateLimitError(f"OpenRouter rate-limited: {detail}") from exc
         except OpenRouterError as exc:
-            _log.error("llm_call_failed", provider="openrouter", error_type="api", error=str(exc))
+            detail = getattr(exc, "body", None) or str(exc)
+            _log.error("llm_call_failed", provider="openrouter", error_type="api", error=detail)
             get_metrics().llm_requests_total.labels(
                 provider="openrouter", model=llm_config.model, status="api"
             ).inc()
-            raise LLMAPIError(f"OpenRouter API error: {exc}") from exc
+            raise LLMAPIError(f"OpenRouter API error: {detail}") from exc
 
         raw_content = result.choices[0].message.content if result.choices else None
         if isinstance(raw_content, list):

--- a/backend/src/taskorbit/integrations/llm/openrouter_client.py
+++ b/backend/src/taskorbit/integrations/llm/openrouter_client.py
@@ -40,6 +40,21 @@ _log = get_logger(__name__)
 _HTTP_REFERER = "https://taskorbit.app"
 _APP_TITLE = "TaskOrbit"
 
+_MAX_DETAIL_CHARS = 500
+
+
+def _bounded_detail(exc: OpenRouterError) -> str:
+    """Prefer ``exc.body`` (the SDK's raw response text) when populated,
+    otherwise fall back to ``str(exc)``. Truncated at ``_MAX_DETAIL_CHARS``
+    so an oversized upstream error body cannot bloat logs or the
+    user-visible LLMError message.
+    """
+    detail = getattr(exc, "body", None) or str(exc)
+    detail_str = str(detail)
+    if len(detail_str) > _MAX_DETAIL_CHARS:
+        return detail_str[:_MAX_DETAIL_CHARS] + "...[truncated]"
+    return detail_str
+
 
 class OpenRouterClient:
     """LLM client backed by the official openrouter Python SDK.
@@ -106,10 +121,12 @@ class OpenRouterClient:
             ).inc()
             raise LLMTimeoutError(f"OpenRouter request timed out: {exc}") from exc
         except (TooManyRequestsResponseError, ProviderOverloadedResponseError) as exc:
-            # str(exc) is just "Provider returned error" — exc.body carries the
-            # actual reason ("model X is temporarily rate-limited upstream,
+            # str(exc) is just "Provider returned error", exc.body carries the
+            # actual reason (e.g. "model X is temporarily rate-limited upstream,
             # retry shortly"), essential for diagnosing flaky :free models (#197).
-            detail = getattr(exc, "body", None) or str(exc)
+            # Cap to 500 chars so an unexpectedly large body cannot bloat logs
+            # or the user-visible error string.
+            detail = _bounded_detail(exc)
             _log.error(
                 "llm_call_failed", provider="openrouter", error_type="rate_limit", error=detail
             )
@@ -118,7 +135,7 @@ class OpenRouterClient:
             ).inc()
             raise LLMRateLimitError(f"OpenRouter rate-limited: {detail}") from exc
         except OpenRouterError as exc:
-            detail = getattr(exc, "body", None) or str(exc)
+            detail = _bounded_detail(exc)
             _log.error("llm_call_failed", provider="openrouter", error_type="api", error=detail)
             get_metrics().llm_requests_total.labels(
                 provider="openrouter", model=llm_config.model, status="api"

--- a/backend/src/taskorbit/intent/__init__.py
+++ b/backend/src/taskorbit/intent/__init__.py
@@ -12,6 +12,7 @@ from collections.abc import Callable, Coroutine
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any
 
+from taskorbit.integrations.llm.errors import LLMError
 from taskorbit.logging.setup import get_logger
 
 if TYPE_CHECKING:
@@ -314,11 +315,18 @@ class IntentRouter:
             parsed = json.loads(cleaned)
             intent_name: str | None = parsed.get("intent")
             confidence: float = float(parsed.get("confidence", 0.0))
+        except LLMError:
+            # Provider failures (auth, quota, timeout, API error) must surface to
+            # the caller so the orchestration error handlers can return a clear
+            # message and the correct metric label. Masking them as a low-confidence
+            # clarification made a real outage (e.g. an exhausted OpenAI quota, #197)
+            # look identical to a genuine "please clarify", hiding the problem.
+            raise
         except Exception as exc:
             logger.warning("intent_router_parse_error", error=str(exc))
-            # Fallback to keyword matching so the call never silently drops.
-            # confidence=0.5 is below the threshold so requires_clarification is set
-            # consistently — prevents silent mis-routing when the LLM is unavailable.
+            # Genuine parse/format issues (malformed JSON, etc.) fall back to keyword
+            # matching so the call never silently drops. confidence=0.5 is below the
+            # threshold so requires_clarification is set consistently.
             return replace(
                 self._fallback.detect(prompt),
                 confidence=0.5,

--- a/backend/src/taskorbit/livekit_agent/llm.py
+++ b/backend/src/taskorbit/livekit_agent/llm.py
@@ -432,26 +432,38 @@ class OrchestratorAgent(Agent):
             )
             raise
 
-        # Early-exit paths (clarification, confirmation, handoff block, end-call, error)
-        # produce no str chunks — only a ConversationResponse. Speak the reply via TTS.
-        if chunk_index == 0 and response is not None and response.reply and response.reply.content:
-            yield response.reply.content
+        # Speak the ConversationResponse.reply via TTS when it carries the
+        # user-facing text. Two cases:
+        #  1) Early-exit paths (clarification, confirmation, handoff block,
+        #     end-call, error-before-any-chunk) produce no str chunks, so
+        #     chunk_index == 0 and the reply is all we have.
+        #  2) Mid-stream provider failure (#197): chunks already flowed to TTS,
+        #     then the orchestrator yielded status="error" with a polite reply.
+        #     Without this branch the user hears half a sentence then silence.
+        if response is not None and response.reply and response.reply.content:
+            if chunk_index == 0 or response.status == "error":
+                yield response.reply.content
 
         if response is None:
             return
 
-        self._locked_intent_name = response.locked_intent_name
-        self._completed_workflow_steps = response.completed_workflow_steps
-        if (
-            response.status in {"confirmation_required", "workflow_confirmation_required"}
-            and response.confirmation
-        ):
-            self._pending_confirmation_id = response.confirmation.confirmation_id
-        else:
-            self._pending_confirmation_id = None
+        # On error responses (#197) the orchestrator emits a bare
+        # ConversationResponse with defaults for workflow-state fields.
+        # Preserving the incoming state avoids stranding the session mid-flow
+        # after a transient provider blip.
+        if response.status != "error":
+            self._locked_intent_name = response.locked_intent_name
+            self._completed_workflow_steps = response.completed_workflow_steps
+            if (
+                response.status in {"confirmation_required", "workflow_confirmation_required"}
+                and response.confirmation
+            ):
+                self._pending_confirmation_id = response.confirmation.confirmation_id
+            else:
+                self._pending_confirmation_id = None
 
-        if response.selected_agent:
-            self._current_routed_agent = response.selected_agent
+            if response.selected_agent:
+                self._current_routed_agent = response.selected_agent
 
         # Persist the voice turn to the database so conversation history is
         # available regardless of whether the user interacted via text or voice.

--- a/backend/src/taskorbit/observability/metrics.py
+++ b/backend/src/taskorbit/observability/metrics.py
@@ -109,6 +109,7 @@ def configure_default_metrics() -> None:
         "runtime_error",
         "llm_config",
         "llm_provider_error",
+        "unhandled",
     ):
         m.conversation_errors_total.labels(error_type=error_type)
     for handler in ("/v1/conversations/process", "/v1/tts/synthesize"):

--- a/backend/src/taskorbit/observability/metrics.py
+++ b/backend/src/taskorbit/observability/metrics.py
@@ -108,6 +108,7 @@ def configure_default_metrics() -> None:
         "invalid_input",
         "runtime_error",
         "llm_config",
+        "llm_provider_error",
     ):
         m.conversation_errors_total.labels(error_type=error_type)
     for handler in ("/v1/conversations/process", "/v1/tts/synthesize"):

--- a/backend/src/taskorbit/orchestration/__init__.py
+++ b/backend/src/taskorbit/orchestration/__init__.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 
 from taskorbit.agents import AgentRegistry
 from taskorbit.config import Settings, get_settings
-from taskorbit.integrations.llm.errors import LLMConfigError
+from taskorbit.integrations.llm.errors import LLMConfigError, LLMError, LLMTimeoutError
 from taskorbit.integrations.llm.scope_check import is_message_in_scope
 from taskorbit.intent import _KNOWN_INTENTS, IntentResult, IntentRouter
 from taskorbit.logging.setup import get_logger
@@ -682,7 +682,7 @@ class ConversationOrchestrator:
                 status="error",
                 error=str(exc),
             )
-        except TimeoutError:
+        except (TimeoutError, LLMTimeoutError):
             get_metrics().conversation_errors_total.labels(error_type="llm_timeout").inc()
             logger.warning("llm_timeout", conversation_id=request.conversation_id)
             return ConversationResponse(
@@ -692,6 +692,26 @@ class ConversationOrchestrator:
                 ),
                 status="error",
                 error=f"LLM call timed out after {self._settings.llm_timeout_seconds} seconds.",
+            )
+        except LLMError as exc:
+            # Provider failures (auth, quota/rate-limit, API outage) surfaced by the
+            # intent router and LLM call sites (#197). Distinct label + message so a
+            # real outage is never mistaken for a clarification or generic error.
+            get_metrics().conversation_errors_total.labels(error_type="llm_provider_error").inc()
+            logger.error(
+                "llm_provider_error",
+                error=str(exc),
+                conversation_id=request.conversation_id,
+                hint="Check provider status, API key validity, and remaining quota.",
+            )
+            return ConversationResponse(
+                conversation_id=request.conversation_id,
+                reply=self._make_assistant_message(
+                    "I'm having trouble reaching my language model provider right now. "
+                    "Please try again in a moment."
+                ),
+                status="error",
+                error=str(exc),
             )
         except UnicodeEncodeError as exc:
             get_metrics().conversation_errors_total.labels(error_type="encoding_error").inc()
@@ -1246,7 +1266,7 @@ class ConversationOrchestrator:
                 status="error",
                 error=str(exc),
             )
-        except TimeoutError:
+        except (TimeoutError, LLMTimeoutError):
             get_metrics().conversation_errors_total.labels(error_type="llm_timeout").inc()
             logger.warning("llm_timeout", conversation_id=request.conversation_id)
             yield ConversationResponse(
@@ -1256,6 +1276,25 @@ class ConversationOrchestrator:
                 ),
                 status="error",
                 error=f"LLM call timed out after {self._settings.llm_timeout_seconds} seconds.",
+            )
+        except LLMError as exc:
+            # Provider failures (auth, quota/rate-limit, API outage) surfaced by the
+            # intent router and LLM call sites (#197) — mirror of process_message.
+            get_metrics().conversation_errors_total.labels(error_type="llm_provider_error").inc()
+            logger.error(
+                "llm_provider_error",
+                error=str(exc),
+                conversation_id=request.conversation_id,
+                hint="Check provider status, API key validity, and remaining quota.",
+            )
+            yield ConversationResponse(
+                conversation_id=request.conversation_id,
+                reply=self._make_assistant_message(
+                    "I'm having trouble reaching my language model provider right now. "
+                    "Please try again in a moment."
+                ),
+                status="error",
+                error=str(exc),
             )
         except UnicodeEncodeError as exc:
             get_metrics().conversation_errors_total.labels(error_type="encoding_error").inc()
@@ -1577,6 +1616,10 @@ class ConversationOrchestrator:
         try:
             extractor = SlotExtractor(llm_fn=self._call_llm_json, llm_config=llm_config)
             return await extractor.extract(messages, required_inputs)
+        except LLMError:
+            # Provider failures must surface (#197) — treating them as "all slots
+            # missing" would make the agent re-ask for data the user already gave.
+            raise
         except Exception as exc:
             logger.warning(
                 "slot_extraction_error",

--- a/backend/src/taskorbit/orchestration/__init__.py
+++ b/backend/src/taskorbit/orchestration/__init__.py
@@ -666,6 +666,11 @@ class ConversationOrchestrator:
                 completed_workflow_steps=updated_completed_steps,
             )
 
+        # Handler-order note (#197): LLMConfigError and LLMTimeoutError both
+        # inherit from LLMError. The subclass handlers must stay BEFORE the
+        # LLMError base handler, otherwise config errors would silently
+        # downgrade to the generic "llm_provider_error" label and lose their
+        # dedicated user message. See test_handler_ordering_regression.
         except LLMConfigError as exc:
             get_metrics().conversation_errors_total.labels(error_type="llm_config").inc()
             logger.error(
@@ -682,9 +687,13 @@ class ConversationOrchestrator:
                 status="error",
                 error=str(exc),
             )
-        except (TimeoutError, LLMTimeoutError):
+        except (TimeoutError, LLMTimeoutError) as exc:
             get_metrics().conversation_errors_total.labels(error_type="llm_timeout").inc()
-            logger.warning("llm_timeout", conversation_id=request.conversation_id)
+            logger.warning(
+                "llm_timeout",
+                error=str(exc),
+                conversation_id=request.conversation_id,
+            )
             return ConversationResponse(
                 conversation_id=request.conversation_id,
                 reply=self._make_assistant_message(
@@ -1250,6 +1259,11 @@ class ConversationOrchestrator:
                 completed_workflow_steps=updated_completed_steps,
             )
 
+        # Handler-order note (#197): LLMConfigError and LLMTimeoutError both
+        # inherit from LLMError. The subclass handlers must stay BEFORE the
+        # LLMError base handler, otherwise config errors would silently
+        # downgrade to the generic "llm_provider_error" label and lose their
+        # dedicated user message. See test_handler_ordering_regression.
         except LLMConfigError as exc:
             get_metrics().conversation_errors_total.labels(error_type="llm_config").inc()
             logger.error(
@@ -1266,9 +1280,13 @@ class ConversationOrchestrator:
                 status="error",
                 error=str(exc),
             )
-        except (TimeoutError, LLMTimeoutError):
+        except (TimeoutError, LLMTimeoutError) as exc:
             get_metrics().conversation_errors_total.labels(error_type="llm_timeout").inc()
-            logger.warning("llm_timeout", conversation_id=request.conversation_id)
+            logger.warning(
+                "llm_timeout",
+                error=str(exc),
+                conversation_id=request.conversation_id,
+            )
             yield ConversationResponse(
                 conversation_id=request.conversation_id,
                 reply=self._make_assistant_message(

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -8,6 +8,25 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _no_real_llm_json_calls():
+    """Keep orchestrator JSON calls (slot extraction, intent routing) off the network.
+
+    _call_llm_json previously hit the real provider during slot extraction and
+    the resulting errors (e.g. OpenAI 429 insufficient_quota) were silently
+    swallowed — the exact masking #197 removes. Now that provider errors surface,
+    an unmocked call would fail the turn, so default to an empty JSON object
+    (= no slots found). Tests that need provider failures or custom JSON
+    re-patch the method inside their own scope.
+    """
+    from taskorbit.orchestration import ConversationOrchestrator
+
+    with patch.object(
+        ConversationOrchestrator, "_call_llm_json", new_callable=AsyncMock, return_value="{}"
+    ):
+        yield
+
+
 @pytest.fixture
 def mock_good_intent():
     """Patch IntentRouter.detect to return a valid intent result.

--- a/backend/tests/test_call_llm_wiring.py
+++ b/backend/tests/test_call_llm_wiring.py
@@ -175,6 +175,7 @@ async def test_persona_guardrails_flow_through_to_llm_prompt(
 @pytest.mark.asyncio
 async def test_no_persona_guardrails_means_no_guardrail_text_in_prompt(
     orchestrator: ConversationOrchestrator,
+    mock_good_intent: object,
 ) -> None:
     """Backward-compatibility: agents without persona_constraints receive a
     prompt with zero guardrail boilerplate — protects every existing config."""

--- a/backend/tests/test_gemini_client.py
+++ b/backend/tests/test_gemini_client.py
@@ -147,6 +147,34 @@ async def test_generic_api_error_maps_to_llm_api_error(
             await client.generate("sys", [Message(role=MessageRole.USER, content="hi")], llm_config)
 
 
+@pytest.mark.asyncio
+async def test_unknown_api_response_error_maps_to_llm_api_error(
+    client: GeminiClient, llm_config: LLMConfig
+) -> None:
+    """UnknownApiResponseError inherits from ValueError (not APIError), so it
+    slips past `except genai_errors.APIError`. Fires when the SDK cannot parse
+    the API response into its known schema (protocol drift, unexpected shape,
+    malformed JSON boundary). Regression guard for the parity extension of
+    Vineesh's #197 review to Gemini."""
+    unknown_exc = genai_errors.UnknownApiResponseError("could not parse response")
+    mock_metrics = MagicMock()
+
+    with patch("taskorbit.integrations.llm.gemini_client.get_metrics", return_value=mock_metrics):
+        with patch.object(
+            client._client.aio.models,
+            "generate_content",
+            new=AsyncMock(side_effect=unknown_exc),
+        ):
+            with pytest.raises(LLMAPIError, match="unparseable"):
+                await client.generate(
+                    "sys", [Message(role=MessageRole.USER, content="hi")], llm_config
+                )
+
+    mock_metrics.llm_requests_total.labels.assert_any_call(
+        provider="google", model=llm_config.model, status="unknown_response"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Empty response handling
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_intent_router.py
+++ b/backend/tests/test_intent_router.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
+from taskorbit.integrations.llm.errors import LLMRateLimitError
 from taskorbit.intent import (
     _KNOWN_INTENTS,
     CONFIDENCE_THRESHOLD,
@@ -57,6 +58,15 @@ async def test_invalid_json_falls_back_to_keyword_detector(router: IntentRouter)
     result = await router.detect("I have a complaint", [], llm_fn, Mock())
     assert result.confidence == 0.5
     assert result.name == "customer_dissatisfaction_inquiry"
+
+
+async def test_provider_error_propagates_not_swallowed(router: IntentRouter) -> None:
+    """A provider failure (quota/auth/timeout/API) must PROPAGATE so the
+    orchestration surfaces a clear error, not be masked as a low-confidence
+    clarification (which hid real outages like an exhausted OpenAI quota, #197)."""
+    llm_fn = AsyncMock(side_effect=LLMRateLimitError("OpenAI rate-limited: 429 insufficient_quota"))
+    with pytest.raises(LLMRateLimitError):
+        await router.detect("What are your opening hours?", [], llm_fn, Mock())
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_livekit_agent.py
+++ b/backend/tests/test_livekit_agent.py
@@ -522,3 +522,122 @@ def test_sync_workflow_state_clears_empty_selected_agent() -> None:
     agent._current_routed_agent = "agent-a"
     agent.sync_workflow_state(selected_agent="   ")
     assert agent._current_routed_agent is None
+
+
+# ---------------------------------------------------------------------------
+# #197: voice-path LLMError response handling
+# ---------------------------------------------------------------------------
+
+
+def _make_streaming_agent(
+    chunks: list[str],
+    final_response: ConversationResponse,
+) -> tuple[OrchestratorAgent, MagicMock]:
+    """Variant of _make_agent that streams `chunks` as str items before yielding
+    the final ConversationResponse. Used to reproduce the mid-stream LLMError
+    voice-worker scenario."""
+    orchestrator = MagicMock()
+
+    async def _process_message_stream(request: Any, db: Any = None, user_id: Any = None):
+        for c in chunks:
+            yield c
+        yield final_response
+
+    orchestrator.process_message_stream = _process_message_stream
+    agent = OrchestratorAgent(
+        orchestrator=orchestrator,
+        agent_config=AgentConfig(
+            id="agent-1",
+            name="TestBot",
+            persona="A test bot.",
+            greeting="Hi!",
+        ),
+        conversation_id="test-conv",
+    )
+    return agent, orchestrator
+
+
+@pytest.mark.asyncio
+async def test_llm_node_speaks_polite_reply_on_mid_stream_error() -> None:
+    """#197 regression: when the orchestrator streams partial chunks and then
+    yields an error ConversationResponse (mid-stream provider failure), the
+    voice worker must speak the polite reply AFTER the partial chunks so the
+    user does not hear a half-sentence trail off into silence.
+    """
+    error_response = ConversationResponse(
+        conversation_id="test-conv",
+        reply=Message(
+            role=MessageRole.ASSISTANT,
+            content=(
+                "I'm having trouble reaching my language model provider right now. "
+                "Please try again in a moment."
+            ),
+        ),
+        status="error",
+        error="OpenAI rate-limited: 429 quota exceeded",
+    )
+    agent, _ = _make_streaming_agent(chunks=["Hello ", "there"], final_response=error_response)
+    chat_ctx = _make_chat_ctx([("user", "Hi")])
+
+    agent.request_reply()
+    out = [c async for c in agent.llm_node(chat_ctx, [], MagicMock())]
+
+    # The partial chunks flow first (TTS is already speaking them), then the
+    # polite fallback is appended so the reply concludes gracefully.
+    assert out[:2] == ["Hello ", "there"]
+    assert "language model provider" in out[-1]
+
+
+@pytest.mark.asyncio
+async def test_llm_node_speaks_polite_reply_on_early_error() -> None:
+    """When the orchestrator yields an error response with NO chunks (auth
+    failure at the intent-detection step, for example), the voice worker
+    speaks the polite reply as the only TTS output for that turn."""
+    error_response = ConversationResponse(
+        conversation_id="test-conv",
+        reply=Message(
+            role=MessageRole.ASSISTANT,
+            content=(
+                "I'm having trouble reaching my language model provider right now. "
+                "Please try again in a moment."
+            ),
+        ),
+        status="error",
+        error="OpenAI authentication failed: 401",
+    )
+    agent, _ = _make_streaming_agent(chunks=[], final_response=error_response)
+    chat_ctx = _make_chat_ctx([("user", "Hi")])
+
+    agent.request_reply()
+    out = [c async for c in agent.llm_node(chat_ctx, [], MagicMock())]
+
+    assert len(out) == 1
+    assert "language model provider" in out[0]
+
+
+@pytest.mark.asyncio
+async def test_llm_node_preserves_workflow_state_on_error_response() -> None:
+    """#197: an error ConversationResponse must not clobber the voice worker's
+    locked intent, completed workflow steps, or routed agent. The orchestrator
+    emits a bare response on error paths, so overwriting stateful fields with
+    its defaults would strand the session mid-workflow."""
+    agent, _ = _make_streaming_agent(
+        chunks=[],
+        final_response=ConversationResponse(
+            conversation_id="test-conv",
+            reply=Message(role=MessageRole.ASSISTANT, content="polite fallback."),
+            status="error",
+            error="OpenAI request timed out",
+        ),
+    )
+    # Session is mid-workflow with intent locked + one step done + routed agent set.
+    agent._locked_intent_name = "book_appointment"
+    agent._completed_workflow_steps = ["collect_email"]
+    agent._current_routed_agent = "booking_agent"
+
+    agent.request_reply()
+    [_ async for _ in agent.llm_node(_make_chat_ctx([("user", "yes")]), [], MagicMock())]
+
+    assert agent._locked_intent_name == "book_appointment"
+    assert agent._completed_workflow_steps == ["collect_email"]
+    assert agent._current_routed_agent == "booking_agent"

--- a/backend/tests/test_ollama_client.py
+++ b/backend/tests/test_ollama_client.py
@@ -156,6 +156,26 @@ async def test_verify_model_available_maps_api_error() -> None:
         await client.verify_model_available()
 
 
+@pytest.mark.asyncio
+async def test_verify_model_available_maps_json_decode_error_to_llm_api_error() -> None:
+    """response.json() raises json.JSONDecodeError (a ValueError) when Ollama
+    returns malformed JSON (e.g. a reverse-proxy HTML error page fronting the
+    endpoint). The three-tier httpx catch does not cover ValueError, so this
+    would previously escape to the orchestrator's generic runtime_error bucket.
+    Regression guard for the parity extension of Vineesh's #197 review."""
+    client = OllamaClient(llm_config=_make_llm_config(), settings=_make_settings())
+    client._http = AsyncMock()
+    bad_resp = MagicMock(spec=httpx.Response)
+    bad_resp.raise_for_status = MagicMock()
+    bad_resp.json = MagicMock(
+        side_effect=json.JSONDecodeError("Expecting value", "<html>...</html>", 0)
+    )
+    client._http.get = AsyncMock(return_value=bad_resp)
+
+    with pytest.raises(LLMAPIError, match="malformed JSON"):
+        await client.verify_model_available()
+
+
 # ---------------------------------------------------------------------------
 # generate() — happy path
 # ---------------------------------------------------------------------------
@@ -283,6 +303,34 @@ async def test_generate_raises_llm_api_error_on_empty_content() -> None:
 
     with pytest.raises(LLMAPIError, match="empty response"):
         await client.generate("sys", [], _make_llm_config())
+
+
+@pytest.mark.asyncio
+async def test_generate_maps_json_decode_error_to_llm_api_error() -> None:
+    """response.json() raises json.JSONDecodeError (a ValueError) on a malformed
+    Ollama response, e.g. a truncated body on a socket close that still parses
+    as HTTP 200, or an HTML error page from a reverse proxy. The three-tier
+    httpx catch (TimeoutException, HTTPStatusError, HTTPError) does not cover
+    ValueError, so without an explicit catch this would escape to the
+    orchestrator's generic runtime_error bucket instead of the
+    llm_provider_error label. Regression guard for the #197 parity extension."""
+    client = OllamaClient(llm_config=_make_llm_config(), settings=_make_settings())
+    client._http = AsyncMock()
+    bad_resp = MagicMock(spec=httpx.Response)
+    bad_resp.raise_for_status = MagicMock()
+    bad_resp.json = MagicMock(
+        side_effect=json.JSONDecodeError("Expecting value", "<html>...</html>", 0)
+    )
+    client._http.post = AsyncMock(return_value=bad_resp)
+    mock_metrics = MagicMock()
+
+    with patch("taskorbit.integrations.llm.ollama_client.get_metrics", return_value=mock_metrics):
+        with pytest.raises(LLMAPIError, match="malformed JSON"):
+            await client.generate("sys", [], _make_llm_config())
+
+    mock_metrics.llm_requests_total.labels.assert_any_call(
+        provider="ollama", model="gemma4:26b", status="decode_error"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_openai_client.py
+++ b/backend/tests/test_openai_client.py
@@ -135,6 +135,55 @@ async def test_generic_api_error_maps_to_llm_api_error(
             await client.generate("sys", [Message(role=MessageRole.USER, content="hi")], llm_config)
 
 
+@pytest.mark.asyncio
+async def test_content_filter_finish_reason_maps_to_llm_api_error(
+    client: OpenAIClient, llm_config: LLMConfig
+) -> None:
+    """ContentFilterFinishReasonError inherits OpenAIError but NOT APIError, so
+    without the OpenAIError catch it would escape openai_client and land in the
+    orchestrator's generic runtime_error bucket instead of llm_provider_error.
+    Regression guard for the Vineesh review follow-up on #197."""
+    content_filter_exc = openai.ContentFilterFinishReasonError()
+    mock_metrics = MagicMock()
+
+    with patch("taskorbit.integrations.llm.openai_client.get_metrics", return_value=mock_metrics):
+        with patch.object(
+            client._client.chat.completions, "create", new=AsyncMock(side_effect=content_filter_exc)
+        ):
+            with pytest.raises(LLMAPIError, match="SDK error"):
+                await client.generate(
+                    "sys", [Message(role=MessageRole.USER, content="hi")], llm_config
+                )
+
+    mock_metrics.llm_requests_total.labels.assert_any_call(
+        provider="openai", model="gpt-4o-mini", status="api"
+    )
+
+
+@pytest.mark.asyncio
+async def test_length_finish_reason_maps_to_llm_api_error(
+    client: OpenAIClient, llm_config: LLMConfig
+) -> None:
+    """LengthFinishReasonError inherits OpenAIError but NOT APIError, so it also
+    needs the explicit OpenAIError catch. Regression guard for the Vineesh review
+    follow-up on #197."""
+    length_exc = openai.LengthFinishReasonError(completion=MagicMock())
+    mock_metrics = MagicMock()
+
+    with patch("taskorbit.integrations.llm.openai_client.get_metrics", return_value=mock_metrics):
+        with patch.object(
+            client._client.chat.completions, "create", new=AsyncMock(side_effect=length_exc)
+        ):
+            with pytest.raises(LLMAPIError, match="SDK error"):
+                await client.generate(
+                    "sys", [Message(role=MessageRole.USER, content="hi")], llm_config
+                )
+
+    mock_metrics.llm_requests_total.labels.assert_any_call(
+        provider="openai", model="gpt-4o-mini", status="api"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Empty response handling
 # ---------------------------------------------------------------------------
@@ -344,6 +393,39 @@ async def test_generate_stream_timeout_raises_llm_timeout_error(
         new=AsyncMock(side_effect=openai.APITimeoutError(request=MagicMock())),
     ):
         with pytest.raises(LLMTimeoutError):
+            async for _ in client.generate_stream(
+                "sys", [Message(role=MessageRole.USER, content="hi")], llm_config
+            ):
+                pass
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_content_filter_finish_reason_maps_to_llm_api_error(
+    client: OpenAIClient, llm_config: LLMConfig
+) -> None:
+    """Stream-path parity for the ContentFilterFinishReasonError guard, so voice
+    and SSE consumers see the polite reply instead of the generic bucket."""
+    content_filter_exc = openai.ContentFilterFinishReasonError()
+    with patch.object(
+        client._client.chat.completions, "create", new=AsyncMock(side_effect=content_filter_exc)
+    ):
+        with pytest.raises(LLMAPIError, match="SDK error"):
+            async for _ in client.generate_stream(
+                "sys", [Message(role=MessageRole.USER, content="hi")], llm_config
+            ):
+                pass
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_length_finish_reason_maps_to_llm_api_error(
+    client: OpenAIClient, llm_config: LLMConfig
+) -> None:
+    """Stream-path parity for the LengthFinishReasonError guard."""
+    length_exc = openai.LengthFinishReasonError(completion=MagicMock())
+    with patch.object(
+        client._client.chat.completions, "create", new=AsyncMock(side_effect=length_exc)
+    ):
+        with pytest.raises(LLMAPIError, match="SDK error"):
             async for _ in client.generate_stream(
                 "sys", [Message(role=MessageRole.USER, content="hi")], llm_config
             ):

--- a/backend/tests/test_openrouter_client.py
+++ b/backend/tests/test_openrouter_client.py
@@ -328,6 +328,41 @@ async def test_openrouter_client_generate_raises_llm_timeout_error(
 
 
 @pytest.mark.asyncio
+async def test_openrouter_client_no_response_error_maps_to_llm_timeout_error(
+    openrouter_settings: None,
+) -> None:
+    """NoResponseError is the only openrouter SDK class that does NOT inherit
+    from OpenRouterError, so both the specific-subclass catches and the broad
+    OpenRouterError backstop would miss it. Fires on transport-layer failures
+    (TCP reset, DNS failure, TLS handshake, upstream close-before-headers).
+    Regression guard for the parity extension of Vineesh's #197 review to
+    the remaining providers."""
+    from openrouter.errors import NoResponseError
+
+    settings = get_settings()
+    llm_config = _make_llm_config()
+    mock_metrics = MagicMock()
+
+    with patch(
+        "taskorbit.integrations.llm.openrouter_client.get_metrics", return_value=mock_metrics
+    ):
+        with patch("taskorbit.integrations.llm.openrouter_client.OpenRouter") as mock_cls:
+            mock_sdk = MagicMock()
+            mock_sdk.chat.send_async = AsyncMock(
+                side_effect=NoResponseError("connection reset by peer")
+            )
+            mock_cls.return_value = mock_sdk
+
+            client = OpenRouterClient(llm_config=llm_config, settings=settings)
+            with pytest.raises(LLMTimeoutError, match="no response"):
+                await client.generate("You are helpful.", [], llm_config)
+
+    mock_metrics.llm_requests_total.labels.assert_any_call(
+        provider="openrouter", model=llm_config.model, status="no_response"
+    )
+
+
+@pytest.mark.asyncio
 async def test_openrouter_client_generate_raises_llm_api_error_on_openrouter_error(
     openrouter_settings: None,
 ) -> None:

--- a/backend/tests/test_openrouter_client.py
+++ b/backend/tests/test_openrouter_client.py
@@ -20,6 +20,7 @@ from taskorbit.integrations.llm.errors import (
     LLMAPIError,
     LLMAuthError,
     LLMConfigError,
+    LLMRateLimitError,
     LLMTimeoutError,
 )
 from taskorbit.integrations.llm.factory import _guard_provider_model_match, get_llm_client
@@ -109,6 +110,80 @@ async def test_openrouter_client_generate_raises_llm_auth_error(openrouter_setti
 
         client = OpenRouterClient(llm_config=llm_config, settings=settings)
         with pytest.raises(LLMAuthError):
+            await client.generate("You are helpful.", [], llm_config)
+
+
+@pytest.mark.asyncio
+async def test_openrouter_client_generate_raises_llm_auth_error_on_unauthorized_response(
+    openrouter_settings: None,
+) -> None:
+    """Invalid or revoked API keys surface as UnauthorizedResponseError from
+    the SDK and must map to LLMAuthError so the orchestrator returns the
+    auth-specific user message (#197)."""
+    from openrouter.errors import UnauthorizedResponseError
+
+    settings = get_settings()
+    llm_config = _make_llm_config()
+
+    with patch("taskorbit.integrations.llm.openrouter_client.OpenRouter") as mock_cls:
+        mock_sdk = MagicMock()
+        mock_sdk.chat.send_async = AsyncMock(
+            side_effect=UnauthorizedResponseError(MagicMock(), MagicMock())
+        )
+        mock_cls.return_value = mock_sdk
+
+        client = OpenRouterClient(llm_config=llm_config, settings=settings)
+        with pytest.raises(LLMAuthError):
+            await client.generate("You are helpful.", [], llm_config)
+
+
+@pytest.mark.asyncio
+async def test_openrouter_client_generate_raises_llm_rate_limit_error_on_too_many_requests(
+    openrouter_settings: None,
+) -> None:
+    """OpenRouter's own 429 throttling surfaces as TooManyRequestsResponseError
+    and must map to LLMRateLimitError so the orchestrator returns the
+    rate-limit-specific user message (#197)."""
+    from openrouter.errors import TooManyRequestsResponseError
+
+    settings = get_settings()
+    llm_config = _make_llm_config()
+
+    with patch("taskorbit.integrations.llm.openrouter_client.OpenRouter") as mock_cls:
+        mock_sdk = MagicMock()
+        mock_sdk.chat.send_async = AsyncMock(
+            side_effect=TooManyRequestsResponseError(MagicMock(), MagicMock())
+        )
+        mock_cls.return_value = mock_sdk
+
+        client = OpenRouterClient(llm_config=llm_config, settings=settings)
+        with pytest.raises(LLMRateLimitError):
+            await client.generate("You are helpful.", [], llm_config)
+
+
+@pytest.mark.asyncio
+async def test_openrouter_client_generate_raises_llm_rate_limit_error_on_provider_overloaded(
+    openrouter_settings: None,
+) -> None:
+    """Upstream provider throttling on :free-tier models surfaces as
+    ProviderOverloadedResponseError. The body carries the actual reason
+    (str(exc) is a generic "Provider returned error"), so the client copies
+    exc.body into the raised LLMRateLimitError message for diagnosability (#197)."""
+    from openrouter.errors import ProviderOverloadedResponseError
+
+    settings = get_settings()
+    llm_config = _make_llm_config()
+
+    overloaded_exc = ProviderOverloadedResponseError(MagicMock(), MagicMock())
+    overloaded_exc.body = "upstream provider is currently overloaded, please retry"
+
+    with patch("taskorbit.integrations.llm.openrouter_client.OpenRouter") as mock_cls:
+        mock_sdk = MagicMock()
+        mock_sdk.chat.send_async = AsyncMock(side_effect=overloaded_exc)
+        mock_cls.return_value = mock_sdk
+
+        client = OpenRouterClient(llm_config=llm_config, settings=settings)
+        with pytest.raises(LLMRateLimitError, match="overloaded"):
             await client.generate("You are helpful.", [], llm_config)
 
 

--- a/backend/tests/test_openrouter_client.py
+++ b/backend/tests/test_openrouter_client.py
@@ -162,6 +162,124 @@ async def test_openrouter_client_generate_raises_llm_rate_limit_error_on_too_man
 
 
 @pytest.mark.asyncio
+async def test_openrouter_client_unauthorized_response_increments_auth_metric(
+    openrouter_settings: None,
+) -> None:
+    """UnauthorizedResponseError must increment llm_requests_total with status='auth'
+    so Grafana / alerting can distinguish key-invalid from other auth failures (#197)."""
+    from openrouter.errors import UnauthorizedResponseError
+
+    settings = get_settings()
+    llm_config = _make_llm_config()
+    mock_metrics = MagicMock()
+
+    with patch(
+        "taskorbit.integrations.llm.openrouter_client.get_metrics", return_value=mock_metrics
+    ):
+        with patch("taskorbit.integrations.llm.openrouter_client.OpenRouter") as mock_cls:
+            mock_sdk = MagicMock()
+            mock_sdk.chat.send_async = AsyncMock(
+                side_effect=UnauthorizedResponseError(MagicMock(), MagicMock())
+            )
+            mock_cls.return_value = mock_sdk
+
+            client = OpenRouterClient(llm_config=llm_config, settings=settings)
+            with pytest.raises(LLMAuthError):
+                await client.generate("You are helpful.", [], llm_config)
+
+    mock_metrics.llm_requests_total.labels.assert_any_call(
+        provider="openrouter", model=llm_config.model, status="auth"
+    )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_client_too_many_requests_uses_body_and_increments_rate_limit_metric(
+    openrouter_settings: None,
+) -> None:
+    """TooManyRequestsResponseError.body carries the actual reason; the client must
+    copy it into the raised LLMRateLimitError (#197) and emit status='rate_limit'."""
+    from openrouter.errors import TooManyRequestsResponseError
+
+    settings = get_settings()
+    llm_config = _make_llm_config()
+    mock_metrics = MagicMock()
+
+    tm_exc = TooManyRequestsResponseError(MagicMock(), MagicMock())
+    tm_exc.body = "rate limit exceeded, retry after 30s"
+
+    with patch(
+        "taskorbit.integrations.llm.openrouter_client.get_metrics", return_value=mock_metrics
+    ):
+        with patch("taskorbit.integrations.llm.openrouter_client.OpenRouter") as mock_cls:
+            mock_sdk = MagicMock()
+            mock_sdk.chat.send_async = AsyncMock(side_effect=tm_exc)
+            mock_cls.return_value = mock_sdk
+
+            client = OpenRouterClient(llm_config=llm_config, settings=settings)
+            with pytest.raises(LLMRateLimitError, match="rate limit exceeded"):
+                await client.generate("You are helpful.", [], llm_config)
+
+    mock_metrics.llm_requests_total.labels.assert_any_call(
+        provider="openrouter", model=llm_config.model, status="rate_limit"
+    )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_client_openrouter_error_uses_body_when_available(
+    openrouter_settings: None,
+) -> None:
+    """Generic OpenRouterError.body must be used in the raised LLMAPIError message
+    when populated, so the operator sees the real upstream reason rather than the
+    SDK's generic 'Provider returned error'."""
+    from openrouter.errors import OpenRouterError
+
+    settings = get_settings()
+    llm_config = _make_llm_config()
+
+    api_exc = OpenRouterError("api error", MagicMock())
+    api_exc.body = "upstream returned 502 bad gateway from anthropic"
+
+    with patch("taskorbit.integrations.llm.openrouter_client.OpenRouter") as mock_cls:
+        mock_sdk = MagicMock()
+        mock_sdk.chat.send_async = AsyncMock(side_effect=api_exc)
+        mock_cls.return_value = mock_sdk
+
+        client = OpenRouterClient(llm_config=llm_config, settings=settings)
+        with pytest.raises(LLMAPIError, match="upstream returned 502 bad gateway"):
+            await client.generate("You are helpful.", [], llm_config)
+
+
+@pytest.mark.asyncio
+async def test_openrouter_client_bounded_detail_truncates_large_bodies(
+    openrouter_settings: None,
+) -> None:
+    """_bounded_detail must cap exc.body at 500 chars so an oversized upstream
+    response body cannot bloat logs or the user-visible LLMError message."""
+    from openrouter.errors import OpenRouterError
+
+    settings = get_settings()
+    llm_config = _make_llm_config()
+
+    huge_body = "x" * 2000
+    api_exc = OpenRouterError("api error", MagicMock())
+    api_exc.body = huge_body
+
+    with patch("taskorbit.integrations.llm.openrouter_client.OpenRouter") as mock_cls:
+        mock_sdk = MagicMock()
+        mock_sdk.chat.send_async = AsyncMock(side_effect=api_exc)
+        mock_cls.return_value = mock_sdk
+
+        client = OpenRouterClient(llm_config=llm_config, settings=settings)
+        with pytest.raises(LLMAPIError) as excinfo:
+            await client.generate("You are helpful.", [], llm_config)
+
+    raised_msg = str(excinfo.value)
+    assert "[truncated]" in raised_msg
+    # Bound: 500 chars of body + a prefix and the truncation marker; nowhere near 2000.
+    assert len(raised_msg) < 800, f"expected truncation, got {len(raised_msg)} char message"
+
+
+@pytest.mark.asyncio
 async def test_openrouter_client_generate_raises_llm_rate_limit_error_on_provider_overloaded(
     openrouter_settings: None,
 ) -> None:

--- a/backend/tests/test_orchestration.py
+++ b/backend/tests/test_orchestration.py
@@ -794,31 +794,43 @@ async def test_process_message_stream_confirmation_required_does_not_dispatch_to
 async def test_process_message_stream_mid_stream_error_yields_error_response(
     mock_good_intent: Any,
 ) -> None:
-    """A provider that raises mid-stream produces an error ConversationResponse."""
+    """A provider that raises mid-stream produces an error ConversationResponse
+    with the #197 polite reply, the llm_provider_error metric label, and the
+    original SDK message in the .error field for on-call debugging."""
     from taskorbit.integrations.llm.errors import LLMAPIError
 
     orch = ConversationOrchestrator()
+    mock_metrics = MagicMock()
 
     async def _failing_stream(*args: Any, **kwargs: Any):
         yield "Hello "
         raise LLMAPIError("provider blew up")
 
-    with patch.object(
-        ConversationOrchestrator, "_call_llm", new_callable=AsyncMock, return_value="{}"
-    ):
+    with patch("taskorbit.orchestration.get_metrics", return_value=mock_metrics):
         with patch.object(
-            ConversationOrchestrator, "_call_llm_stream", return_value=_failing_stream()
+            ConversationOrchestrator, "_call_llm", new_callable=AsyncMock, return_value="{}"
         ):
-            events = []
-            async for event in orch.process_message_stream(_make_request("hi")):
-                events.append(event)
+            with patch.object(
+                ConversationOrchestrator, "_call_llm_stream", return_value=_failing_stream()
+            ):
+                events = []
+                async for event in orch.process_message_stream(_make_request("hi")):
+                    events.append(event)
 
     # The partial "Hello " chunk may or may not have been yielded before the
-    # error; what must always be true is that the final event is an error response.
+    # error; what must always be true is that the final event is an error response
+    # and it carries the polite reply + metric label required by #197.
     assert len(events) >= 1
     final = events[-1]
     assert not isinstance(final, str)
     assert final.status == "error"
+    assert final.reply is not None
+    assert "language model provider" in final.reply.content
+    assert final.error is not None
+    assert "provider blew up" in final.error
+    mock_metrics.conversation_errors_total.labels(
+        error_type="llm_provider_error"
+    ).inc.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -1587,3 +1599,77 @@ async def test_slot_extraction_reraises_provider_errors() -> None:
                 [{"name": "email", "type": "email", "required": True}],
                 request.agent_config.llm,
             )
+
+
+@pytest.mark.asyncio
+async def test_llm_timeout_error_in_stream_maps_to_timeout_handler(
+    mock_good_intent: Any,
+) -> None:
+    """The process_message_stream path must map LLMTimeoutError to the
+    dedicated llm_timeout bucket and the connectivity-focused user message,
+    not to the generic llm_provider_error bucket (#197). Mirrors the text-path
+    test above."""
+    from taskorbit.integrations.llm.errors import LLMTimeoutError
+
+    orch = ConversationOrchestrator()
+    mock_metrics = MagicMock()
+
+    with patch("taskorbit.orchestration.get_metrics", return_value=mock_metrics):
+        with patch.object(
+            ConversationOrchestrator,
+            "_call_llm_json",
+            new_callable=AsyncMock,
+            side_effect=LLMTimeoutError("OpenAI request timed out"),
+        ):
+            events = []
+            async for event in orch.process_message_stream(_make_request()):
+                events.append(event)
+
+    responses = [e for e in events if isinstance(e, ConversationResponse)]
+    assert len(responses) == 1
+    assert responses[0].status == "error"
+    assert "trouble connecting to my brain" in responses[0].reply.content
+    mock_metrics.conversation_errors_total.labels(error_type="llm_timeout").inc.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_handler_ordering_llm_config_still_routes_to_llm_config_bucket(
+    mock_good_intent: Any,
+) -> None:
+    """Regression guard for the #197 handler-order contract: LLMConfigError
+    inherits from LLMError, so it MUST be caught by the LLMConfigError handler
+    (label='llm_config'), not by the LLMError base handler (label='llm_provider_error').
+    A future refactor that swaps the handler order would silently downgrade
+    config errors, hiding onboarding problems ('did you set the API key?')
+    behind the generic provider-error label."""
+    from taskorbit.integrations.llm.errors import LLMConfigError
+
+    orch = ConversationOrchestrator()
+    mock_metrics = MagicMock()
+
+    with patch("taskorbit.orchestration.get_metrics", return_value=mock_metrics):
+        with patch.object(
+            ConversationOrchestrator,
+            "_call_llm_json",
+            new_callable=AsyncMock,
+            side_effect=LLMConfigError("OPENAI_API_KEY not set"),
+        ):
+            events = []
+            async for event in orch.process_message_stream(_make_request()):
+                events.append(event)
+
+    responses = [e for e in events if isinstance(e, ConversationResponse)]
+    assert len(responses) == 1
+    assert responses[0].status == "error"
+    assert "not properly configured" in responses[0].reply.content
+    mock_metrics.conversation_errors_total.labels(error_type="llm_config").inc.assert_called_once()
+    # And crucially, NOT the generic provider_error bucket.
+    provider_error_calls = [
+        c
+        for c in mock_metrics.conversation_errors_total.labels.call_args_list
+        if c.kwargs.get("error_type") == "llm_provider_error"
+    ]
+    assert not provider_error_calls, (
+        "LLMConfigError leaked into the llm_provider_error bucket — check handler ordering "
+        "in orchestration/__init__.py: LLMConfigError must be caught BEFORE LLMError base."
+    )

--- a/backend/tests/test_orchestration.py
+++ b/backend/tests/test_orchestration.py
@@ -1458,3 +1458,132 @@ async def test_get_agent_config_by_id_cross_user_returns_none() -> None:
     # The mock returns None (simulating that user B's record is excluded).
     result = await get_agent_configuration_by_id(mock_db, "some-uuid", user_id=user_a_id)
     assert result is None, "User A must not receive user B's agent configuration"
+
+
+# ---------------------------------------------------------------------------
+# LLM provider failures surface clearly (#197)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_provider_error_during_intent_detection_returns_clear_message() -> None:
+    """A provider failure in the intent router must yield a provider-error
+    response, not the generic clarification reply that masked outages (#197)."""
+    from taskorbit.integrations.llm.errors import LLMRateLimitError
+
+    orch = ConversationOrchestrator()
+    mock_metrics = MagicMock()
+
+    with patch("taskorbit.orchestration.get_metrics", return_value=mock_metrics):
+        with patch.object(
+            ConversationOrchestrator,
+            "_call_llm_json",
+            new_callable=AsyncMock,
+            side_effect=LLMRateLimitError("OpenAI rate-limited: 429 insufficient_quota"),
+        ):
+            response = await orch.process_message(_make_request())
+
+    assert response.status == "error"
+    assert "language model provider" in response.reply.content
+    assert "insufficient_quota" in response.error
+    mock_metrics.conversation_errors_total.labels(
+        error_type="llm_provider_error"
+    ).inc.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_provider_error_during_reply_generation_returns_clear_message(
+    mock_good_intent: Any,
+) -> None:
+    from taskorbit.integrations.llm.errors import LLMAPIError
+
+    orch = ConversationOrchestrator()
+    mock_metrics = MagicMock()
+
+    with patch("taskorbit.orchestration.get_metrics", return_value=mock_metrics):
+        with patch.object(
+            ConversationOrchestrator,
+            "_call_llm",
+            new_callable=AsyncMock,
+            side_effect=LLMAPIError("OpenAI API error: 500 server_error"),
+        ):
+            response = await orch.process_message(_make_request())
+
+    assert response.status == "error"
+    assert "language model provider" in response.reply.content
+    mock_metrics.conversation_errors_total.labels(
+        error_type="llm_provider_error"
+    ).inc.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_llm_timeout_error_maps_to_timeout_handler(mock_good_intent: Any) -> None:
+    """LLMTimeoutError (provider-side timeout) must land in the llm_timeout
+    bucket like the builtin TimeoutError, not in the generic runtime_error one."""
+    from taskorbit.integrations.llm.errors import LLMTimeoutError
+
+    orch = ConversationOrchestrator()
+    mock_metrics = MagicMock()
+
+    with patch("taskorbit.orchestration.get_metrics", return_value=mock_metrics):
+        with patch.object(
+            ConversationOrchestrator,
+            "_call_llm",
+            new_callable=AsyncMock,
+            side_effect=LLMTimeoutError("OpenAI request timed out"),
+        ):
+            response = await orch.process_message(_make_request())
+
+    assert response.status == "error"
+    assert "trouble connecting to my brain" in response.reply.content
+    mock_metrics.conversation_errors_total.labels(error_type="llm_timeout").inc.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_provider_error_in_stream_yields_error_response() -> None:
+    from taskorbit.integrations.llm.errors import LLMAuthError
+
+    orch = ConversationOrchestrator()
+    mock_metrics = MagicMock()
+
+    with patch("taskorbit.orchestration.get_metrics", return_value=mock_metrics):
+        with patch.object(
+            ConversationOrchestrator,
+            "_call_llm_json",
+            new_callable=AsyncMock,
+            side_effect=LLMAuthError("OpenAI authentication failed: 401"),
+        ):
+            events = []
+            async for event in orch.process_message_stream(_make_request()):
+                events.append(event)
+
+    responses = [e for e in events if isinstance(e, ConversationResponse)]
+    assert len(responses) == 1
+    assert responses[0].status == "error"
+    assert "language model provider" in responses[0].reply.content
+    mock_metrics.conversation_errors_total.labels(
+        error_type="llm_provider_error"
+    ).inc.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_slot_extraction_reraises_provider_errors() -> None:
+    """_extract_slots must not convert a provider outage into 'all slots
+    missing' — that would make the agent re-ask for data the user already gave."""
+    from taskorbit.integrations.llm.errors import LLMRateLimitError
+
+    orch = ConversationOrchestrator()
+    request = _make_request("My email is user@example.com")
+
+    with patch.object(
+        ConversationOrchestrator,
+        "_call_llm_json",
+        new_callable=AsyncMock,
+        side_effect=LLMRateLimitError("OpenAI rate-limited: 429"),
+    ):
+        with pytest.raises(LLMRateLimitError):
+            await orch._extract_slots(
+                request.messages,
+                [{"name": "email", "type": "email", "required": True}],
+                request.agent_config.llm,
+            )

--- a/backend/tests/test_stream_route.py
+++ b/backend/tests/test_stream_route.py
@@ -188,6 +188,86 @@ def test_stream_conversation_emits_error_event_on_orchestrator_error() -> None:
     app.dependency_overrides = {}
 
 
+async def _stream_error_response_with_polite_reply() -> None:
+    """Async generator that yields an error ConversationResponse WITH the
+    #197 polite reply set. Represents post-#197 orchestrator behaviour on
+    LLMError paths."""
+    yield ConversationResponse(
+        conversation_id="conv-1",
+        reply=Message(
+            role=MessageRole.ASSISTANT,
+            content=(
+                "I'm having trouble reaching my language model provider right now. "
+                "Please try again in a moment."
+            ),
+        ),
+        status="error",
+        error="OpenAI authentication failed: 401 invalid api key",
+    )
+
+
+def test_stream_conversation_forwards_reply_field_in_error_event() -> None:
+    """#197: on error events the SSE payload must include the polite reply
+    alongside the technical error message. Without this the FE only receives
+    the raw SDK error string and the whole polite-fallback contract of #197
+    is bypassed on the streaming path."""
+    mock_orchestrator = MagicMock()
+    mock_orchestrator.process_message_stream = MagicMock(
+        return_value=_stream_error_response_with_polite_reply()
+    )
+    app = create_app()
+    app.dependency_overrides[get_orchestrator] = lambda: mock_orchestrator
+    app.dependency_overrides[get_session] = _mock_db
+
+    with patch(
+        "taskorbit.api.routes.conversations.create_conversation_message",
+        new_callable=AsyncMock,
+        return_value=MagicMock(),
+    ):
+        with TestClient(app) as client:
+            response = client.post("/v1/conversations/stream", json=_VALID_PAYLOAD)
+
+    events = _parse_sse_events(response.text)
+    error_events = [e for e in events if e["type"] == "error"]
+
+    assert len(error_events) == 1
+    err = error_events[0]
+    assert "language model provider" in err["reply"]
+    # The technical error still lands in `message` for on-call diagnostics.
+    assert "OpenAI authentication failed" in err["message"]
+    app.dependency_overrides = {}
+
+
+def test_stream_conversation_persists_assistant_reply_on_error() -> None:
+    """#197: the polite assistant reply on an error turn must be written to
+    the DB so history stays symmetric with the /process endpoint (which
+    always persists both user + assistant rows)."""
+    mock_orchestrator = MagicMock()
+    mock_orchestrator.process_message_stream = MagicMock(
+        return_value=_stream_error_response_with_polite_reply()
+    )
+    app = create_app()
+    app.dependency_overrides[get_orchestrator] = lambda: mock_orchestrator
+    app.dependency_overrides[get_session] = _mock_db
+
+    with patch(
+        "taskorbit.api.routes.conversations.create_conversation_message",
+        new_callable=AsyncMock,
+        return_value=MagicMock(),
+    ) as mock_persist:
+        with TestClient(app) as client:
+            client.post("/v1/conversations/stream", json=_VALID_PAYLOAD)
+
+    # Two persists expected: user (upfront) + assistant (on error).
+    assert mock_persist.call_count == 2
+    assistant_calls = [
+        c for c in mock_persist.call_args_list if c.kwargs.get("role") == "assistant"
+    ]
+    assert len(assistant_calls) == 1
+    assert "language model provider" in assistant_calls[0].kwargs["content"]
+    app.dependency_overrides = {}
+
+
 def test_stream_conversation_rejects_invalid_payload() -> None:
     app = create_app()
     app.dependency_overrides[get_current_user_id] = lambda: 1

--- a/frontend/src/components/ConversationalChat.tsx
+++ b/frontend/src/components/ConversationalChat.tsx
@@ -502,7 +502,17 @@ export function ConversationalChat() {
                 }
               }
             } else if (event.type === "error") {
-              call.upsertTurnById(assistantTurnId, "assistant", `[Error: ${event.message}]`, true);
+              // Prefer the polite reply from #197 for the assistant bubble.
+              // Fall back to the technical message only for legacy backend
+              // paths that predate the reply-on-error contract.
+              const politeReply = event.reply?.trim();
+              const errorBubble = politeReply || `[Error: ${event.message}]`;
+              call.upsertTurnById(assistantTurnId, "assistant", errorBubble, true);
+              // Route the polite reply through TTS as well so voice users hear
+              // it. `replyText` is what the speaker branch below reads.
+              if (politeReply) {
+                replyText = politeReply;
+              }
             }
           }
 

--- a/frontend/src/lib/conversationApi.ts
+++ b/frontend/src/lib/conversationApi.ts
@@ -134,7 +134,15 @@ export type StreamEvent =
       /** Full assistant reply when no stream chunks were sent (e.g. workflow confirmation). */
       reply?: string | null;
     }
-  | { type: "error"; message: string };
+  | {
+      type: "error";
+      /** Technical error string from the LLM SDK. For on-call / debug UI only. */
+      message: string;
+      /** Polite user-facing reply from ConversationResponse.reply (#197). Render this
+       * in the assistant bubble instead of `message`. Nullable for legacy error
+       * paths that predate the polite-reply pattern (never on LLMError paths). */
+      reply?: string | null;
+    };
 
 type ConversationsResponse = {
   conversations: Array<{


### PR DESCRIPTION
Closes #197.

## Summary

Before this PR, an OpenAI provider failure (rate limit, auth, generic API error) returned "An unexpected error occurred" to the user because the orchestrator's `except` chain only caught `LLMConfigError` and Python's built-in `TimeoutError`. The intent router additionally swallowed provider failures as low-confidence clarifications, hiding the real cause.

This PR closes the loop end-to-end so every provider failure surfaces a category-specific polite reply on every entry point (POST `/v1/conversations/process`, POST `/v1/conversations/stream` SSE, and the LiveKit voice worker), with the technical detail preserved in the `error` field and a specific Prometheus label.

## What changed

**Backend, provider layer**

- `integrations/llm/openrouter_client.py`: maps `UnauthorizedResponseError`, `TooManyRequestsResponseError`, `ProviderOverloadedResponseError` to the shared `LLMError` taxonomy. New `_bounded_detail` helper caps `exc.body` at 500 chars so oversized upstream bodies cannot bloat logs or the user-visible error.
- `intent/__init__.py`: re-raises `LLMError` instead of masking it as a keyword-matching clarification, so intent-detection failures reach the orchestrator handlers.

**Backend, orchestrator + observability**

- `orchestration/__init__.py`: both text and stream paths catch `LLMConfigError`, `TimeoutError`/`LLMTimeoutError`, `LLMError`, `UnicodeEncodeError`, `ValueError`, `Exception` in that order with distinct metric labels and user messages. An inline note above the chain defends the ordering contract (subclass handlers must precede the `LLMError` base).
- `observability/metrics.py`: pre-registers `llm_provider_error` and `unhandled` in the allow-list so Prometheus exposes them from the first scrape.

**Backend, entry points**

- `api/routes/conversations.py::_sse_generator`: on error events, forwards the polite `reply` alongside the technical `message`, and persists the assistant reply so history stays symmetric with `/process`.
- `livekit_agent/llm.py`: speaks the polite reply through TTS on early-exit AND mid-stream errors (previous behaviour trailed off into silence after partial chunks). Preserves `_locked_intent_name` and `_completed_workflow_steps` on error responses so a transient blip does not strand the session mid-workflow.

**Frontend**

- `lib/conversationApi.ts`: extends the SSE error variant with a nullable `reply` field.
- `components/ConversationalChat.tsx`: renders `event.reply` in the assistant bubble on error, routes it through ElevenLabs TTS for text-chat-with-audio users.

**Tests**

Backend test suite grew across `test_orchestration.py` (stream `LLMTimeoutError`, handler-ordering regression, strengthened mid-stream assertions), `test_openrouter_client.py` (SDK mapping + metric increments + `_bounded_detail` truncation), `test_livekit_agent.py` (voice-worker mid-stream, early-error, workflow-state preservation), `test_stream_route.py` (SSE reply-forwarding + assistant persistence on error), `test_intent_router.py` (`LLMError` re-raise), and an autouse fixture in `conftest.py` that keeps orchestrator LLM JSON calls off the network by default.

**Docs**

New `Documentation/llm-providers.md` covering the error taxonomy, per-provider mapping matrix, orchestrator behaviour, seven Prometheus labels, and how to add a new provider. Linked from root `README.md`.

## Pre-PR review findings addressed

A multi-dimensional pre-PR review (AC compliance, DoD, correctness, security, test coverage, docs quality, regression risk, design, observability, contract surface) plus a completeness critic surfaced the following items. Every one is closed on the branch.

**High**

- SSE forwards the polite `reply` field on error events.
- SSE persists the assistant reply on error so history stays symmetric with `/process`.
- FE `conversationApi.ts` error variant extended with `reply?: string | null`.
- FE `ConversationalChat.tsx` renders the polite reply on error and routes it through TTS.

**Medium**

- Voice worker speaks the polite reply on mid-stream errors, not only on early exit.
- Voice worker preserves `_locked_intent_name` and `_completed_workflow_steps` on error responses.
- Handler-order inline defense comment added above the `except` chain in both text and stream paths.
- Handler-ordering regression test asserts `LLMConfigError` still routes to the `llm_config` bucket.
- Stream `LLMTimeoutError` branch has a dedicated test.
- Mid-stream error test strengthened to assert the metric label, the polite reply, and the `error` field.
- Three LiveKit voice-path tests: mid-stream polite-reply speaking, early-error speaking, workflow-state preservation.
- Two SSE route tests: reply-field forwarding on error, assistant persistence on error.
- Documented orchestrator handler chain expanded from a 4-step summary to the actual 6-step chain.
- Documented Ollama auth mapping corrected to reflect that only 401 is handled today (403 falls through to `LLMAPIError`).

**Low**

- `_bounded_detail` helper caps `exc.body` at 500 characters, with a truncation test.
- Both `llm_timeout` handlers bind the caught exception and log `error=str(exc)`.
- `"unhandled"` metric label pre-registered in the allow-list so Prometheus exposes it from the first scrape.
- OpenRouter metric-increment tests added for `status="auth"` and `status="rate_limit"`.
- OpenRouter body-detail extraction covered for `TooManyRequestsResponseError` and generic `OpenRouterError` (in addition to `ProviderOverloadedResponseError`).
- Documented 8s timeout replaced with the per-provider values (OpenAI 8s, Gemini 10s, Ollama 300s).
- Documented "Adding a new provider" reworded to reflect that `LLMClient` is a `typing.Protocol`, not a subclass base.
- Documented that OpenRouter's `generate_stream` delegates to `generate`, so the SDK-error mapping applies to both entry points on that provider.
- Documented metric-labels table expanded from three rows to all seven `conversation_errors_total` label values.
- Root `README.md` now links to `Documentation/llm-providers.md`, closing the discoverability gap.

## Acceptance criteria

- [x] With OpenAI selected the agent no longer returns "An unexpected error occurred" on provider failures; the user sees a category-specific polite reply on `/process`, on the `/stream` SSE endpoint, and on the LiveKit voice worker.
- [x] Metric label emitted matches the failure category (`llm_timeout` for timeouts, `llm_provider_error` for auth / rate limit / other API errors, `llm_config` for missing config, `invalid_input` for `ValueError`, `unhandled` at the app boundary).

