### PR TITLE
fix(db): merge divergent Alembic heads

### DIFF
--- a/backend/migrations/versions/bf94337a5ebc_merge_heads_duration_ms_and_slot_.py
+++ b/backend/migrations/versions/bf94337a5ebc_merge_heads_duration_ms_and_slot_.py
@@ -1,0 +1,25 @@
+"""merge heads: duration_ms and slot_extractions dedup
+
+Revision ID: bf94337a5ebc
+Revises: a1b2c3d4e5f6, f7a8b9c0d1e2
+Create Date: 2026-07-07 21:00:47.240144
+
+"""
+
+from collections.abc import Sequence
+
+# revision identifiers, used by Alembic.
+revision: str = "bf94337a5ebc"
+down_revision: str | Sequence[str] | None = ("a1b2c3d4e5f6", "f7a8b9c0d1e2")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass


### PR DESCRIPTION
Merge a1b2c3d4e5f6 (slot_extractions dedup) and
f7a8b9c0d1e2 (tool_executions duration_ms), which both branched from e5f6a7b8c9d0, resolving multiple migration heads and restoring `alembic upgrade head`.