### PR TITLE
Fix/212 agent handoff resolution

### DIFF
--- a/Documentation/custom-agent-routing.md
+++ b/Documentation/custom-agent-routing.md
@@ -156,6 +156,17 @@ manual path.
 
 ## Frontend UX — agent handoff flow
 
+### Manual transfer (voice path, #212)
+
+During a voice call the @route pick is published to the worker over the
+LiveKit data channel (`taskorbit.manual_transfer`, handled in `worker.py`).
+The worker stores it on the agent bridge and attaches it as a one-shot
+`manual_transfer` to the NEXT voice turn's ConversationRequest, so the
+orchestrator's step-0a short-circuit performs the same hard transfer as the
+text path. After a successful transfer the worker publishes the standard
+`agent_handoff` swap so the frontend card and transcript marker update.
+Clearing the pick publishes a clear so a stale selection can never fire.
+
 ### Manual transfer (text path)
 
 1. User opens the route dropdown (`@` button in `InCallControls`) and picks

--- a/Documentation/custom-agent-routing.md
+++ b/Documentation/custom-agent-routing.md
@@ -60,25 +60,39 @@ After the target config is loaded the orchestrator clears
 re-enters the full pipeline (steps 1–6) under the new agent's persona
 with the full conversation history preserved (AC3).
 
-### Step 5 — Auto transfer via `agent_transfer` tool
+### Step 5 — Auto transfer via `agent_transfer` tool (reworked in #212)
 
-When the LLM includes an `agent_transfer` tool call in its reply,
-`_dispatch_tool` constructs `AgentTransferTool(db=db, user_id=user_id)` and
-calls `execute(context)`. The tool:
+**Selection.** `_select_active_tool` picks the transfer tool when intent
+routing points AWAY from the current agent and one of the tool's configured
+targets resolves to that destination. An explicit `active_tool_id` pin
+(confirmation round-trips) still wins, configs without a transfer tool keep
+the first-tool behaviour, and the current agent is normalised through the
+built-in resolver first so a completed handoff (reported back as a template
+slug by the voice worker) never re-fires the transfer. Without this rule,
+multi-tool custom agents could never reach their transfer tool, because
+neither the frontend nor the voice worker round-trips `next_active_tool_id`.
 
-1. Reads `targets[0]` from `context["parameters"]`.
-2. Calls `_is_valid_target(target_id)`:
-   - Checks built-in agent names first (no DB required).
-   - Falls back to `get_agent_configuration_by_id(db, target_id, user_id=user_id)`
-     when a DB session is available.
-3. Returns `{"selected_agent": target_id}` on success or
-   `{"error": "Unknown agent"}` on failure.
+**Target resolution.** `resolve_transfer_target()` in
+`tools/agent_transfer.py` resolves the configured target string in
+deterministic-first order:
 
-**UUID normalization:** target IDs that look like custom-agent UUIDs
-(matching `/^[0-9a-f]{8}-…-[0-9a-f]{12}$/i`) are passed through untouched.
-Only built-in slugs (e.g. `technical-support-agent`) are slug-normalized to
-their registry key (`technical_support`). This prevents hyphen corruption of
-custom agent UUIDs.
+1. Exact built-in registry name (`general_inquiry`), no DB required.
+2. Saved `AgentConfiguration` by primary key (UUID hex or slug), user-scoped.
+3. Built-in `DefaultAgentTemplate` by slug id (`general-inquiry-agent`).
+4. Saved `AgentConfiguration` by exact display name, user-scoped.
+5. Registry keyword mapping as the fuzzy last resort
+   (`inquiry-agent` resolves to `general_inquiry`).
+
+The orchestrator dispatch and `AgentTransferTool.execute()` share this
+resolver; on failure the tool returns the `Unknown agent '<target>'` error
+and the dispatch logs `agent_transfer_target_unresolved`. On success the
+tool returns `{"transferred_to": <canonical>, "requested_target": <raw>,
+"target_kind": builtin|config|template, ...}` and the response's
+`tool_invoked` carries a copy of the tool whose `parameters.targets` hold
+the CANONICAL id, so the voice worker publish and the frontend swap never
+see the raw config string. A sync subset,
+`resolve_builtin_transfer_target()`, backs tool selection (steps 1 and 5
+only, since intent destinations are always built-ins).
 
 ---
 
@@ -203,7 +217,7 @@ changes needed.
 | Orchestration pipeline + step 0a | `backend/src/taskorbit/orchestration/__init__.py` |
 | Manual transfer resolution | `orchestration/__init__.py` → `_handle_manual_transfer` |
 | Auto-tool dispatch wiring | `orchestration/__init__.py` → `_dispatch_tool` |
-| `AgentTransferTool` + `_is_valid_target` | `backend/src/taskorbit/tools/agent_transfer.py` |
+| `AgentTransferTool` + `resolve_transfer_target` | `backend/src/taskorbit/tools/agent_transfer.py` |
 | `AgentRegistry` + `CustomAgent` | `backend/src/taskorbit/agents/` |
 | DB lookups with user scoping | `backend/src/taskorbit/database/crud.py` |
 | Voice path agent + `user_id` threading | `backend/src/taskorbit/livekit_agent/llm.py` |
@@ -222,6 +236,6 @@ changes needed.
 |---|---|
 | `tests/test_orchestration.py` | End-to-end `process_message` with mock DB — auto-transfer to custom agent succeeds through `_dispatch_tool` wiring |
 | `tests/test_orchestration.py` | Cross-user `get_agent_configuration_by_id` regression — user A cannot load user B's config |
-| `tests/test_agent_transfer.py` | `AgentTransferTool._is_valid_target` with and without DB session |
+| `tests/test_agent_transfer.py` | `resolve_transfer_target` matrix + `AgentTransferTool.execute` with and without DB session |
 | `tests/test_custom_agent_routing.py` | Manual transfer short-circuit, recursion guard, name vs. ID precedence |
 | `tests/test_crud.py` | `get_agent_configuration_by_id` and `get_agent_configuration_by_name` user scoping |

--- a/backend/src/taskorbit/livekit_agent/llm.py
+++ b/backend/src/taskorbit/livekit_agent/llm.py
@@ -420,14 +420,6 @@ class OrchestratorAgent(Agent):
         # once, on this turn; the orchestrator's step-0a short-circuit swaps
         # the conversation to the picked agent.
         manual_transfer = self._consume_pending_manual_transfer()
-        if manual_transfer is not None:
-            # Surface the card swap at request time: the pick came from the
-            # live agent list, and deferring the publish until the reply
-            # completed made the swap hang- and cancel-fragile. The error
-            # branch below withdraws it on the rare lookup failure.
-            self._pending_handoff_target = (
-                manual_transfer.target_agent_id or manual_transfer.target_agent_name
-            )
 
         request = ConversationRequest(
             conversation_id=self._conversation_id,
@@ -581,6 +573,10 @@ class OrchestratorAgent(Agent):
         if (
             response.tool_invoked is not None
             and response.tool_invoked.type == _ToolType.AGENT_TRANSFER
+            # Publish only COMPLETED transfers: tool_invoked is also set on
+            # confirmation_required (the ask turn) and rejected responses,
+            # which must not swap the card or reroute the worker (#212).
+            and response.status == "success"
         ):
             targets = response.tool_invoked.parameters.get("targets") or []
             if targets:
@@ -596,14 +592,12 @@ class OrchestratorAgent(Agent):
                     conversation_id=self._conversation_id,
                 )
 
-        # Manual voice transfer (#212): the pending swap was surfaced at
-        # request time; withdraw it if the orchestrator could not resolve the
-        # picked agent, otherwise just record the outcome.
+        # Manual voice transfer (#212): surface the swap only once the
+        # orchestrator confirms the transfer completed, so a cancelled or
+        # failed turn can never swap the card away from the real agent.
         if manual_transfer is not None:
             expected = manual_transfer.target_agent_id or manual_transfer.target_agent_name
             if response.status == "error":
-                if self._pending_handoff_target == expected:
-                    self._pending_handoff_target = None
                 log.warning(
                     "voice_manual_transfer_failed",
                     target=expected,
@@ -611,6 +605,7 @@ class OrchestratorAgent(Agent):
                     conversation_id=self._conversation_id,
                 )
             else:
+                self._pending_handoff_target = expected
                 log.info(
                     "voice_manual_transfer_applied",
                     target=expected,

--- a/backend/src/taskorbit/livekit_agent/llm.py
+++ b/backend/src/taskorbit/livekit_agent/llm.py
@@ -420,6 +420,14 @@ class OrchestratorAgent(Agent):
         # once, on this turn; the orchestrator's step-0a short-circuit swaps
         # the conversation to the picked agent.
         manual_transfer = self._consume_pending_manual_transfer()
+        if manual_transfer is not None:
+            # Surface the card swap at request time: the pick came from the
+            # live agent list, and deferring the publish until the reply
+            # completed made the swap hang- and cancel-fragile. The error
+            # branch below withdraws it on the rare lookup failure.
+            self._pending_handoff_target = (
+                manual_transfer.target_agent_id or manual_transfer.target_agent_name
+            )
 
         request = ConversationRequest(
             conversation_id=self._conversation_id,
@@ -588,19 +596,27 @@ class OrchestratorAgent(Agent):
                     conversation_id=self._conversation_id,
                 )
 
-        # Manual voice transfer (#212): the pick arrived over the data channel
-        # and step-0a applied it above; surface the swap to the frontend
-        # through the same handoff publish as auto transfers.
-        if manual_transfer is not None and response.status != "error":
-            self._pending_handoff_target = (
-                manual_transfer.target_agent_id or manual_transfer.target_agent_name
-            )
-            log.info(
-                "voice_manual_transfer_applied",
-                target=self._pending_handoff_target,
-                selected_agent=response.selected_agent,
-                conversation_id=self._conversation_id,
-            )
+        # Manual voice transfer (#212): the pending swap was surfaced at
+        # request time; withdraw it if the orchestrator could not resolve the
+        # picked agent, otherwise just record the outcome.
+        if manual_transfer is not None:
+            expected = manual_transfer.target_agent_id or manual_transfer.target_agent_name
+            if response.status == "error":
+                if self._pending_handoff_target == expected:
+                    self._pending_handoff_target = None
+                log.warning(
+                    "voice_manual_transfer_failed",
+                    target=expected,
+                    error=response.error,
+                    conversation_id=self._conversation_id,
+                )
+            else:
+                log.info(
+                    "voice_manual_transfer_applied",
+                    target=expected,
+                    selected_agent=response.selected_agent,
+                    conversation_id=self._conversation_id,
+                )
 
         if self._t_commit is not None:
             elapsed = time.perf_counter() - self._t_commit

--- a/backend/src/taskorbit/livekit_agent/llm.py
+++ b/backend/src/taskorbit/livekit_agent/llm.py
@@ -38,6 +38,7 @@ from taskorbit.types import (
     AgentConfig,
     ConversationRequest,
     LLMConfig,
+    ManualTransferRequest,
     Message,
     MessageRole,
     PersonaConstraints,
@@ -239,9 +240,35 @@ class OrchestratorAgent(Agent):
         # handler can read this to notify the client that the active agent
         # changed mid-call without dropping the room.
         self._pending_handoff_target: str | None = None
+        # UI-picked manual transfer waiting for the next voice turn (#212).
+        self._pending_manual_transfer: ManualTransferRequest | None = None
         # #71: Workflow state for voice path
         self._completed_workflow_steps: list[str] = []
         self._pending_confirmation_id: str | None = None
+
+    def set_manual_transfer(
+        self, target_agent_id: str | None, target_agent_name: str | None
+    ) -> None:
+        """Store a UI-picked agent transfer to apply on the next voice turn (#212).
+
+        The @route menu has no typed message to carry ``manual_transfer``
+        during a voice call, so the frontend publishes the pick over the data
+        channel and the next turn attaches it to the ConversationRequest.
+        Passing (None, None) clears a pending pick (user deselected the menu).
+        """
+        if target_agent_id is None and target_agent_name is None:
+            self._pending_manual_transfer = None
+            return
+        self._pending_manual_transfer = ManualTransferRequest(
+            target_agent_id=target_agent_id,
+            target_agent_name=target_agent_name,
+        )
+
+    def _consume_pending_manual_transfer(self) -> ManualTransferRequest | None:
+        """One-shot: return and clear the pending manual transfer, if any."""
+        pending = self._pending_manual_transfer
+        self._pending_manual_transfer = None
+        return pending
 
     def sync_workflow_state(
         self,
@@ -389,6 +416,11 @@ class OrchestratorAgent(Agent):
         if self._pending_confirmation_id and last_user:
             decision = _voice_confirmation_decision(last_user.content)
 
+        # #212: a manual transfer picked from the @route menu applies exactly
+        # once, on this turn; the orchestrator's step-0a short-circuit swaps
+        # the conversation to the picked agent.
+        manual_transfer = self._consume_pending_manual_transfer()
+
         request = ConversationRequest(
             conversation_id=self._conversation_id,
             agent_config=self._agent_config,
@@ -398,6 +430,7 @@ class OrchestratorAgent(Agent):
             completed_workflow_steps=self._completed_workflow_steps,
             confirmation_id=self._pending_confirmation_id if decision else None,
             decision=decision,
+            manual_transfer=manual_transfer,
         )
         from taskorbit.types import ToolType as _ToolType
 
@@ -554,6 +587,20 @@ class OrchestratorAgent(Agent):
                     selected_agent=response.selected_agent,
                     conversation_id=self._conversation_id,
                 )
+
+        # Manual voice transfer (#212): the pick arrived over the data channel
+        # and step-0a applied it above; surface the swap to the frontend
+        # through the same handoff publish as auto transfers.
+        if manual_transfer is not None and response.status != "error":
+            self._pending_handoff_target = (
+                manual_transfer.target_agent_id or manual_transfer.target_agent_name
+            )
+            log.info(
+                "voice_manual_transfer_applied",
+                target=self._pending_handoff_target,
+                selected_agent=response.selected_agent,
+                conversation_id=self._conversation_id,
+            )
 
         if self._t_commit is not None:
             elapsed = time.perf_counter() - self._t_commit

--- a/backend/src/taskorbit/livekit_agent/llm.py
+++ b/backend/src/taskorbit/livekit_agent/llm.py
@@ -544,6 +544,10 @@ class OrchestratorAgent(Agent):
             targets = response.tool_invoked.parameters.get("targets") or []
             if targets:
                 self._pending_handoff_target = str(targets[0])
+                # The conversation is now routed to the target: without this,
+                # selected_agent stays on the entry agent and the transfer
+                # re-fires (and re-publishes) on every subsequent turn (#212).
+                self._current_routed_agent = self._pending_handoff_target
                 log.info(
                     "voice_agent_handoff_pending",
                     target=self._pending_handoff_target,

--- a/backend/src/taskorbit/orchestration/__init__.py
+++ b/backend/src/taskorbit/orchestration/__init__.py
@@ -1723,9 +1723,20 @@ class ConversationOrchestrator:
             if match:
                 return match
 
-        if intent is not None and intent.agent_name and intent.agent_name != current_agent:
+        if intent is not None and intent.agent_name:
             from taskorbit.tools.agent_transfer import resolve_builtin_transfer_target
 
+            # current_agent can arrive as a template slug after a completed voice
+            # handoff ("technical-support-agent"), while intent.agent_name is a
+            # registry name ("technical_support"). Normalise before comparing so
+            # a finished handoff never re-fires the transfer (#212).
+            effective_current = (
+                resolve_builtin_transfer_target(current_agent) or current_agent
+                if current_agent
+                else current_agent
+            )
+            if intent.agent_name == effective_current:
+                return tools[0]
             for tool in tools:
                 if tool.type != ToolType.AGENT_TRANSFER:
                     continue

--- a/backend/src/taskorbit/orchestration/__init__.py
+++ b/backend/src/taskorbit/orchestration/__init__.py
@@ -171,6 +171,10 @@ class _DispatchResult:
     response_status: ConversationStatus
     llm_text_override: str | None
     tool_call_elapsed: float | None = None
+    # #212: on a successful agent_transfer, a copy of the tool whose targets
+    # hold the RESOLVED canonical id, so the voice publish and the FE swap
+    # never see the raw config string.
+    tool_invoked_override: ToolDefinition | None = None
 
 
 class ConversationOrchestrator:
@@ -687,7 +691,7 @@ class ConversationOrchestrator:
                 status=response_status,
                 extracted_slots=slot_result.to_dict(),
                 missing_slots=slot_result.missing,
-                tool_invoked=active_tool if tool_data else None,
+                tool_invoked=(dispatch.tool_invoked_override or active_tool) if tool_data else None,
                 locked_intent_name=intent.name,
                 next_active_tool_id=next_active_tool_id,
                 completed_workflow_steps=updated_completed_steps,
@@ -1292,7 +1296,7 @@ class ConversationOrchestrator:
                 status=response_status,
                 extracted_slots=slot_result.to_dict(),
                 missing_slots=slot_result.missing,
-                tool_invoked=active_tool if tool_data else None,
+                tool_invoked=(dispatch.tool_invoked_override or active_tool) if tool_data else None,
                 locked_intent_name=intent.name,
                 next_active_tool_id=next_active_tool_id,
                 completed_workflow_steps=updated_completed_steps,
@@ -1799,6 +1803,7 @@ class ConversationOrchestrator:
         response_status = ConversationStatus.SUCCESS
         llm_text_override: str | None = None
         tool_call_elapsed: float | None = None
+        tool_invoked_override: ToolDefinition | None = None
 
         no_slots_tool_ready = active_tool is not None and active_tool.type in (
             ToolType.END_CALL,
@@ -1911,6 +1916,20 @@ class ConversationOrchestrator:
                 if active_tool.type == ToolType.END_CALL:
                     response_status = ConversationStatus.ENDED
                 elif active_tool.type == ToolType.AGENT_TRANSFER:
+                    resolved_id = tool_data.get("transferred_to")
+                    if resolved_id:
+                        # Hand consumers the canonical target: the voice worker
+                        # publishes tool_invoked.parameters.targets[0] and the
+                        # FE swap matches on it, so the raw config string must
+                        # not leak past this point (#212).
+                        tool_invoked_override = active_tool.model_copy(
+                            update={
+                                "parameters": {
+                                    **active_tool.parameters,
+                                    "targets": [resolved_id],
+                                }
+                            }
+                        )
                     logger.info(
                         "agent_handoff",
                         from_agent=request.agent_config.name,
@@ -1924,6 +1943,7 @@ class ConversationOrchestrator:
             response_status=response_status,
             llm_text_override=llm_text_override,
             tool_call_elapsed=tool_call_elapsed,
+            tool_invoked_override=tool_invoked_override,
         )
 
     async def _dispatch_tool(

--- a/backend/src/taskorbit/orchestration/__init__.py
+++ b/backend/src/taskorbit/orchestration/__init__.py
@@ -553,7 +553,11 @@ class ConversationOrchestrator:
 
             # 3. Select active tool
             active_tool = self._select_active_tool(
-                request.messages, agent, active_tool_id=request.active_tool_id
+                request.messages,
+                agent,
+                active_tool_id=request.active_tool_id,
+                intent=intent,
+                current_agent=request.selected_agent or request.agent_config.id,
             )
 
             # 3b. Extract slots from conversation history.
@@ -1143,7 +1147,11 @@ class ConversationOrchestrator:
 
             # 3. Select active tool.
             active_tool = self._select_active_tool(
-                request.messages, agent, active_tool_id=request.active_tool_id
+                request.messages,
+                agent,
+                active_tool_id=request.active_tool_id,
+                intent=intent,
+                current_agent=request.selected_agent or request.agent_config.id,
             )
 
             # Pre-extraction scope short-circuit (parity with the text path, #168):
@@ -1691,8 +1699,18 @@ class ConversationOrchestrator:
         messages: list[Message],
         agent: BaseAgent,
         active_tool_id: str | None = None,
+        intent: IntentResult | None = None,
+        current_agent: str | None = None,
     ) -> ToolDefinition | None:
-        """Decide which tool should be in scope for this turn, if any."""
+        """Decide which tool should be in scope for this turn, if any.
+
+        Order: an explicit active_tool_id pin (confirmation round-trips) wins;
+        then, when intent routing points AWAY from the current agent and the
+        config carries an agent_transfer tool for that destination, the
+        transfer owns the turn (#212 — multi-tool configs otherwise never
+        reach tools[1:], because neither client round-trips
+        next_active_tool_id); otherwise the first configured tool.
+        """
         tools = agent.get_task_definitions()
         if not tools:
             return None
@@ -1700,6 +1718,24 @@ class ConversationOrchestrator:
             match = next((t for t in tools if t.id == active_tool_id), None)
             if match:
                 return match
+
+        if intent is not None and intent.agent_name and intent.agent_name != current_agent:
+            from taskorbit.tools.agent_transfer import resolve_builtin_transfer_target
+
+            for tool in tools:
+                if tool.type != ToolType.AGENT_TRANSFER:
+                    continue
+                targets = tool.parameters.get("targets") or []
+                for raw in targets:
+                    if resolve_builtin_transfer_target(str(raw)) == intent.agent_name:
+                        logger.info(
+                            "agent_transfer_tool_selected",
+                            destination=intent.agent_name,
+                            requested_target=str(raw),
+                            tool_id=tool.id,
+                        )
+                        return tool
+
         return tools[0]
 
     async def _call_llm(
@@ -1825,11 +1861,24 @@ class ConversationOrchestrator:
             else:
                 dispatch_context: dict[str, Any] = dict(slot_result.to_dict())
                 if active_tool.type == ToolType.AGENT_TRANSFER:
-                    from taskorbit.tools.agent_transfer import resolve_transfer_target
+                    from taskorbit.tools.agent_transfer import (
+                        resolve_builtin_transfer_target,
+                        resolve_transfer_target,
+                    )
 
                     targets = active_tool.parameters.get("targets") or []
                     if targets:
                         raw = str(targets[0])
+                        # Multi-target tools: prefer the target matching the
+                        # routed intent so selection and dispatch agree (#212).
+                        if intent is not None and len(targets) > 1:
+                            for candidate in targets:
+                                if (
+                                    resolve_builtin_transfer_target(str(candidate))
+                                    == intent.agent_name
+                                ):
+                                    raw = str(candidate)
+                                    break
                         resolved_target = await resolve_transfer_target(raw, db=db, user_id=user_id)
                         if resolved_target is not None:
                             dispatch_context["target_agent_id"] = resolved_target.canonical_id

--- a/backend/src/taskorbit/orchestration/__init__.py
+++ b/backend/src/taskorbit/orchestration/__init__.py
@@ -21,7 +21,6 @@ Flow per message:
 from __future__ import annotations
 
 import asyncio
-import re
 import time
 from dataclasses import dataclass
 from dataclasses import replace as dataclass_replace
@@ -1826,18 +1825,23 @@ class ConversationOrchestrator:
             else:
                 dispatch_context: dict[str, Any] = dict(slot_result.to_dict())
                 if active_tool.type == ToolType.AGENT_TRANSFER:
+                    from taskorbit.tools.agent_transfer import resolve_transfer_target
+
                     targets = active_tool.parameters.get("targets") or []
                     if targets:
                         raw = str(targets[0])
-                        if re.match(
-                            r"^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$",
-                            raw,
-                            re.IGNORECASE,
-                        ):
-                            normalized = raw
+                        resolved_target = await resolve_transfer_target(raw, db=db, user_id=user_id)
+                        if resolved_target is not None:
+                            dispatch_context["target_agent_id"] = resolved_target.canonical_id
                         else:
-                            normalized = raw.removesuffix("-agent").replace("-", "_")
-                        dispatch_context["target_agent_id"] = normalized
+                            # Pass the raw value through; the tool re-resolves and
+                            # owns the user-facing "Unknown agent" error (#212).
+                            logger.warning(
+                                "agent_transfer_target_unresolved",
+                                raw_target=raw,
+                                conversation_id=request.conversation_id,
+                            )
+                            dispatch_context["target_agent_id"] = raw
                     dispatch_context["conversation_history"] = [
                         {"role": m.role.value, "content": m.content} for m in request.messages
                     ]

--- a/backend/src/taskorbit/orchestration/__init__.py
+++ b/backend/src/taskorbit/orchestration/__init__.py
@@ -559,7 +559,10 @@ class ConversationOrchestrator:
             active_tool = self._select_active_tool(
                 request.messages,
                 agent,
-                active_tool_id=request.active_tool_id,
+                # confirmation_id IS the pending tool's id: pinning on it keeps
+                # a decision turn on the tool being confirmed even when the
+                # client does not round-trip active_tool_id (#212).
+                active_tool_id=request.active_tool_id or request.confirmation_id,
                 intent=intent,
                 current_agent=request.selected_agent or request.agent_config.id,
             )
@@ -1153,7 +1156,10 @@ class ConversationOrchestrator:
             active_tool = self._select_active_tool(
                 request.messages,
                 agent,
-                active_tool_id=request.active_tool_id,
+                # confirmation_id IS the pending tool's id: pinning on it keeps
+                # a decision turn on the tool being confirmed even when the
+                # client does not round-trip active_tool_id (#212).
+                active_tool_id=request.active_tool_id or request.confirmation_id,
                 intent=intent,
                 current_agent=request.selected_agent or request.agent_config.id,
             )

--- a/backend/src/taskorbit/tools/agent_transfer.py
+++ b/backend/src/taskorbit/tools/agent_transfer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from taskorbit.tools import BaseTool, ToolResult
@@ -17,6 +18,85 @@ def _get_known_agent_names() -> frozenset[str]:
     return AgentRegistry.known_agent_names()
 
 
+@dataclass(frozen=True)
+class ResolvedTransferTarget:
+    """Outcome of resolving a configured transfer target to a real agent.
+
+    ``canonical_id`` is the identifier every downstream consumer should use:
+    the registry agent_name for built-ins (e.g. "general_inquiry"), or the DB
+    row id for saved configs and templates (UUID hex / template slug). The
+    frontend handoff swap matches on exactly these forms (useAgentHandoff).
+    """
+
+    canonical_id: str
+    kind: str  # "builtin" | "config" | "template"
+    display_name: str | None = None
+
+
+async def resolve_transfer_target(
+    target: str,
+    db: AsyncSession | None = None,
+    user_id: int | None = None,
+) -> ResolvedTransferTarget | None:
+    """Resolve a configured transfer target to a canonical agent identifier.
+
+    Transfer targets are free text in the config UI today (#203 adds a
+    dropdown), so real configs contain UUID hex ids, template slugs
+    ("general-inquiry-agent"), registry names ("general_inquiry"), display
+    names ("General Inquiry Agent"), or near-misses ("inquiry-agent", the
+    #212 prod value). Deterministic matches run first; the registry keyword
+    map runs last so an exact match can never be shadowed by a fuzzy hit.
+    Returns None when nothing matches; callers own the error reporting.
+    """
+    raw = (target or "").strip()
+    if not raw:
+        return None
+
+    # 1. Exact built-in registry name, no DB needed.
+    if raw in _get_known_agent_names():
+        return ResolvedTransferTarget(canonical_id=raw, kind="builtin")
+
+    if db is not None:
+        from taskorbit.database.crud import (
+            get_agent_configuration_by_id,
+            get_agent_configuration_by_name,
+            get_default_agent_template,
+        )
+
+        # 2. Saved config by primary key (UUID hex, or slug id on old rows).
+        #    A PK hit means record.id == raw, so raw IS the canonical id.
+        record = await get_agent_configuration_by_id(db, raw, user_id=user_id)
+        if record is not None:
+            return ResolvedTransferTarget(canonical_id=raw, kind="config", display_name=record.name)
+
+        # 3. Un-customized built-in template by slug id ("general-inquiry-agent").
+        #    The manual-transfer path checks this table too; the tool must match it.
+        template = await get_default_agent_template(db, raw)
+        if template is not None:
+            return ResolvedTransferTarget(
+                canonical_id=raw, kind="template", display_name=template.name
+            )
+
+        # 4. Saved config by exact display name, user-scoped (fails closed
+        #    without a user, same contract as the manual-transfer path).
+        record = await get_agent_configuration_by_name(db, raw, user_id=user_id)
+        if record is not None:
+            return ResolvedTransferTarget(
+                canonical_id=record.id, kind="config", display_name=record.name
+            )
+
+    # 5. Registry keyword mapping, fuzzy last resort ("inquiry-agent" ->
+    #    general_inquiry). get_agent_name_for_id echoes its input when nothing
+    #    matches, so only accept results that are real registry names.
+    from taskorbit.agents import AgentRegistry
+
+    mapped = AgentRegistry.get_agent_name_for_id(raw)
+    if mapped in _get_known_agent_names():
+        return ResolvedTransferTarget(canonical_id=mapped, kind="builtin")
+
+    return None
+
+
 class AgentTransferTool(BaseTool):
     tool_type = ToolType.AGENT_TRANSFER
 
@@ -24,25 +104,13 @@ class AgentTransferTool(BaseTool):
         self._db = db
         self._user_id = user_id
 
-    async def _is_valid_target(self, target_agent_id: str) -> bool:
-        """Return True when target_agent_id is a built-in agent name or a saved custom agent."""
-        if target_agent_id in _get_known_agent_names():
-            return True
-        if self._db is not None:
-            from taskorbit.database.crud import get_agent_configuration_by_id
-
-            record = await get_agent_configuration_by_id(
-                self._db, target_agent_id, user_id=self._user_id
-            )
-            return record is not None
-        return False
-
     async def execute(self, parameters: dict[str, Any]) -> ToolResult:
         """Transfer the conversation to another agent, preserving full history.
 
         Expected parameters:
-            target_agent_id (str): built-in agent_name (e.g. "technical_support")
-                or the UUID hex ID of a saved custom AgentConfiguration.
+            target_agent_id (str): built-in agent_name (e.g. "technical_support"),
+                the UUID hex ID or template slug of a saved agent, its display
+                name, or a keyword near-miss; resolved via resolve_transfer_target.
             conversation_history (list[dict]): full message list — passed through
                 so the new agent has full context.
         """
@@ -50,7 +118,10 @@ class AgentTransferTool(BaseTool):
         if not target_agent_id:
             return ToolResult(success=False, error="target_agent_id is required")
 
-        if not await self._is_valid_target(target_agent_id):
+        resolved = await resolve_transfer_target(
+            target_agent_id, db=self._db, user_id=self._user_id
+        )
+        if resolved is None:
             known = sorted(_get_known_agent_names())
             return ToolResult(
                 success=False,
@@ -62,7 +133,9 @@ class AgentTransferTool(BaseTool):
         return ToolResult(
             success=True,
             data={
-                "transferred_to": target_agent_id,
+                "transferred_to": resolved.canonical_id,
+                "target_kind": resolved.kind,
+                "requested_target": target_agent_id,
                 "history_preserved": True,
                 "message_count": len(conversation_history),
             },

--- a/backend/src/taskorbit/tools/agent_transfer.py
+++ b/backend/src/taskorbit/tools/agent_transfer.py
@@ -33,6 +33,29 @@ class ResolvedTransferTarget:
     display_name: str | None = None
 
 
+def resolve_builtin_transfer_target(target: str) -> str | None:
+    """Resolve a configured target to a built-in agent_name, without DB access.
+
+    Sync subset of resolve_transfer_target for callers that only need the
+    built-in destination (tool selection compares against intent.agent_name,
+    which is always a registry agent). Kept separate from the async resolver
+    so its keyword fallback cannot jump ahead of the deterministic DB matches
+    there (#212).
+    """
+    raw = (target or "").strip()
+    if not raw:
+        return None
+    if raw in _get_known_agent_names():
+        return raw
+
+    from taskorbit.agents import AgentRegistry
+
+    mapped = AgentRegistry.get_agent_name_for_id(raw)
+    if mapped in _get_known_agent_names():
+        return mapped
+    return None
+
+
 async def resolve_transfer_target(
     target: str,
     db: AsyncSession | None = None,

--- a/backend/src/taskorbit/worker.py
+++ b/backend/src/taskorbit/worker.py
@@ -204,12 +204,41 @@ async def entrypoint(ctx: JobContext) -> None:
     # Holds the most-recent pending reply task so it can be cancelled on
     # interruption before the orchestrator finishes processing.
     reply_task: asyncio.Task[None] | None = None
+    # Strong references for detached flush tasks: the event loop only keeps
+    # weak refs, so an unreferenced fire-and-forget task can be garbage
+    # collected before it runs (#212).
+    background_tasks: set[asyncio.Task[None]] = set()
+
+    async def _flush_pending_handoff() -> None:
+        """Publish the pending agent handoff exactly once (#212).
+
+        Reads AND clears the pending target before awaiting, so concurrent
+        callers (the normal post-playout path and the cancellation path) can
+        never double-publish, and a barge-in can never orphan a transfer that
+        the orchestrator already applied.
+        """
+        pending = agent._pending_handoff_target
+        if not pending:
+            return
+        agent._pending_handoff_target = None
+        try:
+            payload = json.dumps({"type": "agent_handoff", "target": pending})
+            await ctx.room.local_participant.publish_data(
+                payload, reliable=True, topic=_HANDOFF_TOPIC
+            )
+            logger.info("worker_handoff_published", target=pending, topic=_HANDOFF_TOPIC)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("worker_handoff_publish_failed", error=str(exc))
 
     async def _commit_and_reply(turn_start: float) -> None:
         # Small delay so Deepgram can flush its final transcription segment
         # into the ChatContext before generate_reply() reads it. Without this,
         # the last word(s) of the utterance may be missing from the reply.
         try:
+            # Publish any swap left over from a cancelled or hung prior turn
+            # BEFORE this turn's request can overwrite it (#212). Determinism
+            # backstop for the detached cancel-path flush.
+            await _flush_pending_handoff()
             await asyncio.sleep(_DEEPGRAM_FLUSH_DELAY_S)
             # generate_reply() returns a SpeechHandle synchronously; the actual
             # llm_node + orchestrator work happens in the background. We must
@@ -261,21 +290,20 @@ async def entrypoint(ctx: JobContext) -> None:
                     agent._call_ended = False
 
             # AC7: now that the orchestrator has finished (wait_for_playout
-            # above), the pending target is set if an agent_transfer dispatched
-            # this turn. Publish on the FE-subscribed topic so the client
-            # swaps the active agent card without dropping the LiveKit room.
-            pending = agent._pending_handoff_target
-            if pending:
-                try:
-                    payload = json.dumps({"type": "agent_handoff", "target": pending})
-                    await ctx.room.local_participant.publish_data(
-                        payload, reliable=True, topic=_HANDOFF_TOPIC
-                    )
-                    logger.info("worker_handoff_published", target=pending, topic=_HANDOFF_TOPIC)
-                except Exception as exc:  # noqa: BLE001
-                    logger.warning("worker_handoff_publish_failed", error=str(exc))
-                finally:
-                    agent._pending_handoff_target = None
+            # above), the pending target is set if a transfer dispatched this
+            # turn. Publish on the FE-subscribed topic so the client swaps the
+            # active agent card without dropping the LiveKit room.
+            await _flush_pending_handoff()
+        except asyncio.CancelledError:
+            # Barge-in cancelled this reply mid-generation or mid-playout. The
+            # orchestrator may ALREADY have applied a transfer, so the card
+            # swap must not be lost (#212): flush it from a detached task,
+            # since awaiting inside a cancelled task would re-raise. Keep a
+            # strong reference or the task can be GC'd before it runs.
+            flush_task = asyncio.create_task(_flush_pending_handoff())
+            background_tasks.add(flush_task)
+            flush_task.add_done_callback(background_tasks.discard)
+            raise
         except Exception as exc:  # noqa: BLE001
             logger.warning("worker_generate_reply_failed", error=str(exc))
 

--- a/backend/src/taskorbit/worker.py
+++ b/backend/src/taskorbit/worker.py
@@ -48,7 +48,7 @@ _DEEPGRAM_FLUSH_DELAY_S: float = 0.3
 # Explicit allowlist of data-channel message types this worker handles.
 # Packets with any other `type` value are silently discarded.
 _RECOGNISED_MSG_TYPES: frozenset[str] = frozenset(
-    {"commit_turn", "interrupt_playback", "workflow_state"}
+    {"commit_turn", "interrupt_playback", "workflow_state", "manual_transfer"}
 )
 
 # Topic the FE subscribes to via useAgentHandoff to swap the active agent
@@ -312,6 +312,24 @@ async def entrypoint(ctx: JobContext) -> None:
                 logger.info("worker_interrupt_requested")
             except Exception as exc:  # noqa: BLE001
                 logger.warning("worker_interrupt_failed", error=str(exc))
+        elif msg_type == "manual_transfer":
+            # #212: @route menu pick during a voice call; stored on the agent
+            # and applied as a hard manual_transfer on the next voice turn.
+            if msg.get("clear"):
+                agent.set_manual_transfer(None, None)
+                logger.info("worker_manual_transfer_cleared")
+            else:
+                target_id = msg.get("target_agent_id")
+                target_name = msg.get("target_agent_name")
+                agent.set_manual_transfer(
+                    target_id if isinstance(target_id, str) else None,
+                    target_name if isinstance(target_name, str) else None,
+                )
+                logger.info(
+                    "worker_manual_transfer_received",
+                    target_id=target_id,
+                    target_name=target_name,
+                )
         elif msg_type == "workflow_state":
             selected = msg.get("selected_agent")
             completed = msg.get("completed_workflow_steps")

--- a/backend/src/taskorbit/worker.py
+++ b/backend/src/taskorbit/worker.py
@@ -228,6 +228,10 @@ async def entrypoint(ctx: JobContext) -> None:
             )
             logger.info("worker_handoff_published", target=pending, topic=_HANDOFF_TOPIC)
         except Exception as exc:  # noqa: BLE001
+            # Restore so a later flush retries instead of losing the swap,
+            # unless a newer target has already been stashed meanwhile (#212).
+            if agent._pending_handoff_target is None:
+                agent._pending_handoff_target = pending
             logger.warning("worker_handoff_publish_failed", error=str(exc))
 
     async def _commit_and_reply(turn_start: float) -> None:
@@ -306,6 +310,17 @@ async def entrypoint(ctx: JobContext) -> None:
             raise
         except Exception as exc:  # noqa: BLE001
             logger.warning("worker_generate_reply_failed", error=str(exc))
+
+    # Catch-all handoff flush (#212): some generations are driven by the
+    # framework's own end-of-turn (not _commit_and_reply), so their stashed
+    # handoff would otherwise wait for the next commit. Whenever the agent
+    # finishes speaking, drain any pending swap.
+    @session.on("agent_state_changed")
+    def _flush_on_state(ev: AgentEvent) -> None:
+        if getattr(ev, "new_state", None) in ("listening", "idle"):
+            flush_task = asyncio.create_task(_flush_pending_handoff())
+            background_tasks.add(flush_task)
+            flush_task.add_done_callback(background_tasks.discard)
 
     # When the frontend Send button is clicked, useMicRecorder.sendUtterance()
     # publishes {"type": "commit_turn"} over the data channel. Handling it here

--- a/backend/tests/test_agent_transfer.py
+++ b/backend/tests/test_agent_transfer.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
-from taskorbit.tools.agent_transfer import AgentTransferTool
+from taskorbit.tools.agent_transfer import AgentTransferTool, resolve_transfer_target
 
 
 @pytest.fixture
@@ -138,10 +138,23 @@ async def test_transfer_to_unknown_custom_agent_fails_with_db() -> None:
 
     mock_db = AsyncMock()
 
-    with patch(
-        "taskorbit.database.crud.get_agent_configuration_by_id",
-        new_callable=AsyncMock,
-        return_value=None,
+    # The resolver consults all three lookups (#212); none may match here.
+    with (
+        patch(
+            "taskorbit.database.crud.get_agent_configuration_by_id",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "taskorbit.database.crud.get_default_agent_template",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "taskorbit.database.crud.get_agent_configuration_by_name",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
     ):
         tool = AgentTransferTool(db=mock_db)
         result = await tool.execute({"target_agent_id": "nonexistent_custom_id"})
@@ -174,3 +187,177 @@ async def test_custom_agent_history_preserved_with_db() -> None:
         result = await tool.execute({"target_agent_id": "abc123", "conversation_history": history})
 
     assert result.data["message_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# resolve_transfer_target() — the #212 resolution matrix
+# ---------------------------------------------------------------------------
+
+
+async def test_resolve_exact_builtin_name_without_db() -> None:
+    resolved = await resolve_transfer_target("general_inquiry")
+    assert resolved is not None
+    assert resolved.canonical_id == "general_inquiry"
+    assert resolved.kind == "builtin"
+
+
+async def test_resolve_kebab_near_miss_via_keywords() -> None:
+    # The exact prod value that broke #212: "inquiry-agent" is neither a
+    # registry name nor a DB id, but the keyword map lands it on general_inquiry.
+    resolved = await resolve_transfer_target("inquiry-agent")
+    assert resolved is not None
+    assert resolved.canonical_id == "general_inquiry"
+    assert resolved.kind == "builtin"
+
+
+async def test_resolve_display_name_with_spaces_and_case() -> None:
+    resolved = await resolve_transfer_target("General Inquiry Agent")
+    assert resolved is not None
+    assert resolved.canonical_id == "general_inquiry"
+
+
+async def test_resolve_capitalised_agent_suffix() -> None:
+    # removesuffix("-agent") in the old normalisation was case-sensitive;
+    # the keyword map is not.
+    resolved = await resolve_transfer_target("General-Inquiry-Agent")
+    assert resolved is not None
+    assert resolved.canonical_id == "general_inquiry"
+
+
+async def test_resolve_template_slug_with_db() -> None:
+    from unittest.mock import AsyncMock, MagicMock
+
+    mock_db = AsyncMock()
+    fake_template = MagicMock()
+    fake_template.name = "General Inquiry Agent"
+
+    with (
+        patch(
+            "taskorbit.database.crud.get_agent_configuration_by_id",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "taskorbit.database.crud.get_default_agent_template",
+            new_callable=AsyncMock,
+            return_value=fake_template,
+        ),
+    ):
+        resolved = await resolve_transfer_target("general-inquiry-agent", db=mock_db)
+
+    assert resolved is not None
+    assert resolved.canonical_id == "general-inquiry-agent"
+    assert resolved.kind == "template"
+    assert resolved.display_name == "General Inquiry Agent"
+
+
+async def test_resolve_custom_agent_by_uuid_with_db() -> None:
+    from unittest.mock import AsyncMock, MagicMock
+
+    from taskorbit.database.models import AgentConfiguration
+
+    mock_db = AsyncMock()
+    fake_record = MagicMock(spec=AgentConfiguration)
+    fake_record.name = "John Max"
+
+    with patch(
+        "taskorbit.database.crud.get_agent_configuration_by_id",
+        new_callable=AsyncMock,
+        return_value=fake_record,
+    ):
+        resolved = await resolve_transfer_target(
+            "33834dd8d88d4c73ab899a188f949a99", db=mock_db, user_id=1
+        )
+
+    assert resolved is not None
+    assert resolved.canonical_id == "33834dd8d88d4c73ab899a188f949a99"
+    assert resolved.kind == "config"
+
+
+async def test_resolve_custom_agent_by_display_name_with_db() -> None:
+    from unittest.mock import AsyncMock, MagicMock
+
+    from taskorbit.database.models import AgentConfiguration
+
+    mock_db = AsyncMock()
+    fake_record = MagicMock(spec=AgentConfiguration)
+    fake_record.id = "row99"
+    fake_record.name = "Max-Agent-Pizza"
+
+    with (
+        patch(
+            "taskorbit.database.crud.get_agent_configuration_by_id",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "taskorbit.database.crud.get_default_agent_template",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "taskorbit.database.crud.get_agent_configuration_by_name",
+            new_callable=AsyncMock,
+            return_value=fake_record,
+        ),
+    ):
+        resolved = await resolve_transfer_target("Max-Agent-Pizza", db=mock_db, user_id=1)
+
+    assert resolved is not None
+    assert resolved.canonical_id == "row99"
+    assert resolved.kind == "config"
+
+
+async def test_resolve_name_match_beats_keyword_fuzz() -> None:
+    # A saved agent whose NAME contains a registry keyword ("tech") must
+    # resolve to that saved agent, never fuzz-map to technical_support.
+    from unittest.mock import AsyncMock, MagicMock
+
+    from taskorbit.database.models import AgentConfiguration
+
+    mock_db = AsyncMock()
+    fake_record = MagicMock(spec=AgentConfiguration)
+    fake_record.id = "row42"
+    fake_record.name = "Tech Billing"
+
+    with (
+        patch(
+            "taskorbit.database.crud.get_agent_configuration_by_id",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "taskorbit.database.crud.get_default_agent_template",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "taskorbit.database.crud.get_agent_configuration_by_name",
+            new_callable=AsyncMock,
+            return_value=fake_record,
+        ),
+    ):
+        resolved = await resolve_transfer_target("Tech Billing", db=mock_db, user_id=1)
+
+    assert resolved is not None
+    assert resolved.canonical_id == "row42"
+    assert resolved.kind == "config"
+
+
+async def test_resolve_unknown_returns_none() -> None:
+    assert await resolve_transfer_target("emergency-line-xyz") is None
+
+
+async def test_resolve_empty_returns_none() -> None:
+    assert await resolve_transfer_target("") is None
+    assert await resolve_transfer_target("   ") is None
+
+
+async def test_execute_resolves_inquiry_agent_to_general_inquiry() -> None:
+    # End-to-end through the tool: the #212 prod config value now transfers.
+    tool = AgentTransferTool()
+    result = await tool.execute({"target_agent_id": "inquiry-agent"})
+    assert result.success is True
+    assert result.data["transferred_to"] == "general_inquiry"
+    assert result.data["requested_target"] == "inquiry-agent"
+    assert result.data["target_kind"] == "builtin"

--- a/backend/tests/test_agent_transfer.py
+++ b/backend/tests/test_agent_transfer.py
@@ -6,7 +6,11 @@ from unittest.mock import patch
 
 import pytest
 
-from taskorbit.tools.agent_transfer import AgentTransferTool, resolve_transfer_target
+from taskorbit.tools.agent_transfer import (
+    AgentTransferTool,
+    resolve_builtin_transfer_target,
+    resolve_transfer_target,
+)
 
 
 @pytest.fixture
@@ -361,3 +365,25 @@ async def test_execute_resolves_inquiry_agent_to_general_inquiry() -> None:
     assert result.data["transferred_to"] == "general_inquiry"
     assert result.data["requested_target"] == "inquiry-agent"
     assert result.data["target_kind"] == "builtin"
+
+
+# ---------------------------------------------------------------------------
+# resolve_builtin_transfer_target() — sync subset used by tool selection (#212)
+# ---------------------------------------------------------------------------
+
+
+def test_builtin_resolver_exact_name() -> None:
+    assert resolve_builtin_transfer_target("general_inquiry") == "general_inquiry"
+
+
+def test_builtin_resolver_keyword_near_miss() -> None:
+    assert resolve_builtin_transfer_target("inquiry-agent") == "general_inquiry"
+
+
+def test_builtin_resolver_display_name() -> None:
+    assert resolve_builtin_transfer_target("General Inquiry Agent") == "general_inquiry"
+
+
+def test_builtin_resolver_unknown_returns_none() -> None:
+    assert resolve_builtin_transfer_target("emergency-line-xyz") is None
+    assert resolve_builtin_transfer_target("") is None

--- a/backend/tests/test_livekit_agent.py
+++ b/backend/tests/test_livekit_agent.py
@@ -696,3 +696,56 @@ async def test_llm_node_preserves_workflow_state_on_error_response() -> None:
     assert agent._locked_intent_name == "book_appointment"
     assert agent._completed_workflow_steps == ["collect_email"]
     assert agent._current_routed_agent == "booking_agent"
+
+
+# ---------------------------------------------------------------------------
+# Manual voice transfer (#212) — @route menu picks over the data channel
+# ---------------------------------------------------------------------------
+
+
+def _manual_transfer_agent() -> OrchestratorAgent:
+    from unittest.mock import MagicMock
+
+    return OrchestratorAgent(
+        orchestrator=MagicMock(),
+        agent_config=AgentConfig(
+            id="agent-1",
+            name="TestBot",
+            persona="A test bot.",
+            greeting="Hi!",
+        ),
+        conversation_id="test-conv",
+    )
+
+
+def test_set_manual_transfer_stores_pending() -> None:
+    agent = _manual_transfer_agent()
+    agent.set_manual_transfer("sales-agent", "Sales Agent")
+    pending = agent._consume_pending_manual_transfer()
+    assert pending is not None
+    assert pending.target_agent_id == "sales-agent"
+    assert pending.target_agent_name == "Sales Agent"
+
+
+def test_consume_pending_manual_transfer_is_one_shot() -> None:
+    agent = _manual_transfer_agent()
+    agent.set_manual_transfer("sales-agent", "Sales Agent")
+    assert agent._consume_pending_manual_transfer() is not None
+    # Second turn must NOT re-apply the transfer.
+    assert agent._consume_pending_manual_transfer() is None
+
+
+def test_set_manual_transfer_none_clears_pending() -> None:
+    agent = _manual_transfer_agent()
+    agent.set_manual_transfer("sales-agent", "Sales Agent")
+    agent.set_manual_transfer(None, None)
+    assert agent._consume_pending_manual_transfer() is None
+
+
+def test_manual_transfer_last_pick_wins() -> None:
+    agent = _manual_transfer_agent()
+    agent.set_manual_transfer("sales-agent", "Sales Agent")
+    agent.set_manual_transfer("general-inquiry-agent", "General Inquiry Agent")
+    pending = agent._consume_pending_manual_transfer()
+    assert pending is not None
+    assert pending.target_agent_id == "general-inquiry-agent"

--- a/backend/tests/test_orchestration.py
+++ b/backend/tests/test_orchestration.py
@@ -1823,3 +1823,68 @@ def test_select_no_tools_returns_none_still() -> None:
         )
         is None
     )
+
+
+# ---------------------------------------------------------------------------
+# tool_invoked carries the RESOLVED transfer target (#212)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_transfer_tool_invoked_carries_canonical_target() -> None:
+    """The response's tool_invoked must expose the canonical target, not the
+    raw config string: the voice worker publishes parameters.targets[0] and
+    the FE swap matches on it."""
+    from unittest.mock import AsyncMock, patch
+
+    from taskorbit.slots.models import SlotExtractionResult, SlotValue
+    from taskorbit.types import ConfirmationConfig, ToolDefinition, ToolType
+
+    orch = ConversationOrchestrator()
+    intent = _intent_result(
+        required_inputs=[{"name": "caller_name", "type": "string", "required": True}]
+    )
+    transfer_tool = ToolDefinition(
+        id="transfer_to_inquiry_agent",
+        name="transfer_to_inquiry_agent",
+        type=ToolType.AGENT_TRANSFER,
+        description="hand off",
+        confirmation=ConfirmationConfig(required=False, prompt=""),
+        parameters={"targets": ["inquiry-agent"]},
+    )
+    slot_result = SlotExtractionResult(
+        filled={"caller_name": SlotValue(name="caller_name", value="Asad", slot_type="string")},
+        missing=[],
+    )
+
+    with (
+        patch.object(orch._intent_router, "detect", new_callable=AsyncMock, return_value=intent),
+        patch.object(ConversationOrchestrator, "_select_active_tool", return_value=transfer_tool),
+        patch.object(
+            ConversationOrchestrator,
+            "_extract_slots",
+            new_callable=AsyncMock,
+            return_value=slot_result,
+        ),
+        patch.object(
+            ConversationOrchestrator,
+            "_dispatch_tool",
+            new_callable=AsyncMock,
+            return_value=(
+                {
+                    "transferred_to": "general_inquiry",
+                    "requested_target": "inquiry-agent",
+                    "history_preserved": True,
+                },
+                0.0,
+            ),
+        ),
+        patch.object(
+            ConversationOrchestrator, "_call_llm", new_callable=AsyncMock, return_value="ok"
+        ),
+    ):
+        response = await orch.process_message(_make_request("transfer me"))
+
+    assert response.tool_invoked is not None
+    assert response.tool_invoked.type == ToolType.AGENT_TRANSFER
+    assert response.tool_invoked.parameters["targets"] == ["general_inquiry"]

--- a/backend/tests/test_orchestration.py
+++ b/backend/tests/test_orchestration.py
@@ -1888,3 +1888,17 @@ async def test_transfer_tool_invoked_carries_canonical_target() -> None:
     assert response.tool_invoked is not None
     assert response.tool_invoked.type == ToolType.AGENT_TRANSFER
     assert response.tool_invoked.parameters["targets"] == ["general_inquiry"]
+
+
+def test_select_no_refire_when_current_agent_is_template_slug() -> None:
+    """After a completed voice handoff the worker reports the canonical
+    template slug as the current agent; the transfer must NOT re-fire (#212)."""
+    orch = ConversationOrchestrator()
+    tool = orch._select_active_tool(
+        [],
+        _FakeAgent(_john_max_tools()),
+        intent=_intent_for("general_inquiry"),
+        current_agent="general-inquiry-agent",
+    )
+    assert tool is not None
+    assert tool.id == "collect_user_info"

--- a/backend/tests/test_orchestration.py
+++ b/backend/tests/test_orchestration.py
@@ -1688,3 +1688,138 @@ async def test_handler_ordering_llm_config_still_routes_to_llm_config_bucket(
         "LLMConfigError leaked into the llm_provider_error bucket — check handler ordering "
         "in orchestration/__init__.py: LLMConfigError must be caught BEFORE LLMError base."
     )
+
+
+# ---------------------------------------------------------------------------
+# _select_active_tool — intent-driven transfer selection (#212)
+# ---------------------------------------------------------------------------
+
+
+class _FakeAgent:
+    """Minimal stand-in exposing get_task_definitions like BaseAgent."""
+
+    def __init__(self, tools):
+        self._tools = tools
+
+    def get_task_definitions(self):
+        return self._tools
+
+
+def _john_max_tools():
+    from taskorbit.types import ConfirmationConfig, ToolDefinition, ToolType
+
+    confirm = ConfirmationConfig(required=False, prompt="")
+    return [
+        ToolDefinition(
+            id="collect_user_info",
+            name="collect_user_info",
+            type=ToolType.DATA_EXTRACTION,
+            description="collect",
+            confirmation=confirm,
+            parameters={"params": []},
+        ),
+        ToolDefinition(
+            id="end_call",
+            name="end_call",
+            type=ToolType.END_CALL,
+            description="end",
+            confirmation=confirm,
+            parameters={},
+        ),
+        ToolDefinition(
+            id="transfer_to_inquiry_agent",
+            name="transfer_to_inquiry_agent",
+            type=ToolType.AGENT_TRANSFER,
+            description="hand off",
+            confirmation=confirm,
+            parameters={"targets": ["inquiry-agent"]},
+        ),
+    ]
+
+
+def _intent_for(agent_name: str):
+    from taskorbit.intent import IntentResult
+
+    return IntentResult(name=agent_name or "unknown", description="", agent_name=agent_name)
+
+
+def test_select_transfer_when_intent_routes_away() -> None:
+    """#212: intent routing away + matching transfer tool selects the transfer,
+    not tools[0], even though the target is the sloppy prod value."""
+    orch = ConversationOrchestrator()
+    tool = orch._select_active_tool(
+        [],
+        _FakeAgent(_john_max_tools()),
+        intent=_intent_for("general_inquiry"),
+        current_agent="demoday",
+    )
+    assert tool is not None
+    assert tool.id == "transfer_to_inquiry_agent"
+
+
+def test_select_pin_wins_over_transfer_rule() -> None:
+    """A confirmation round-trip pin must still take precedence."""
+    orch = ConversationOrchestrator()
+    tool = orch._select_active_tool(
+        [],
+        _FakeAgent(_john_max_tools()),
+        active_tool_id="collect_user_info",
+        intent=_intent_for("general_inquiry"),
+        current_agent="demoday",
+    )
+    assert tool is not None
+    assert tool.id == "collect_user_info"
+
+
+def test_select_stays_on_first_tool_when_intent_matches_current_agent() -> None:
+    orch = ConversationOrchestrator()
+    tool = orch._select_active_tool(
+        [],
+        _FakeAgent(_john_max_tools()),
+        intent=_intent_for("general_inquiry"),
+        current_agent="general_inquiry",
+    )
+    assert tool is not None
+    assert tool.id == "collect_user_info"
+
+
+def test_select_stays_on_first_tool_when_no_target_matches_destination() -> None:
+    orch = ConversationOrchestrator()
+    tool = orch._select_active_tool(
+        [],
+        _FakeAgent(_john_max_tools()),
+        intent=_intent_for("sales"),
+        current_agent="demoday",
+    )
+    assert tool is not None
+    assert tool.id == "collect_user_info"
+
+
+def test_select_stays_on_first_tool_for_unknown_intent() -> None:
+    orch = ConversationOrchestrator()
+    tool = orch._select_active_tool(
+        [],
+        _FakeAgent(_john_max_tools()),
+        intent=_intent_for(""),
+        current_agent="demoday",
+    )
+    assert tool is not None
+    assert tool.id == "collect_user_info"
+
+
+def test_select_unchanged_without_intent_argument() -> None:
+    """Callers that never pass intent keep the legacy tools[0] behaviour."""
+    orch = ConversationOrchestrator()
+    tool = orch._select_active_tool([], _FakeAgent(_john_max_tools()))
+    assert tool is not None
+    assert tool.id == "collect_user_info"
+
+
+def test_select_no_tools_returns_none_still() -> None:
+    orch = ConversationOrchestrator()
+    assert (
+        orch._select_active_tool(
+            [], _FakeAgent([]), intent=_intent_for("general_inquiry"), current_agent="x"
+        )
+        is None
+    )

--- a/frontend/src/components/ConversationalChat.tsx
+++ b/frontend/src/components/ConversationalChat.tsx
@@ -21,6 +21,8 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 import { useVoiceCall } from "@/hooks/useVoiceCall";
 import {
+  ManualTransferVoiceBridge,
+  type ManualTransferVoiceSyncFn,
   WorkflowVoiceSyncBridge,
   type WorkflowVoiceSyncFn,
   type WorkflowVoiceState,
@@ -157,6 +159,13 @@ export function ConversationalChat() {
   const registerWorkflowVoiceSync = useCallback((sync: WorkflowVoiceSyncFn | null) => {
     workflowVoiceSyncRef.current = sync;
   }, []);
+  const manualTransferVoiceRef = useRef<ManualTransferVoiceSyncFn | null>(null);
+  const registerManualTransferVoiceSync = useCallback(
+    (sync: ManualTransferVoiceSyncFn | null) => {
+      manualTransferVoiceRef.current = sync;
+    },
+    [],
+  );
   const syncWorkflowToVoice = useCallback(async (state: WorkflowVoiceState) => {
     try {
       await workflowVoiceSyncRef.current?.(state);
@@ -629,6 +638,13 @@ export function ConversationalChat() {
       if (!target) {
         manualRoutingLockRef.current = false;
         setRoutedAgent(null);
+        // #212: a cleared pick must also clear the worker's pending transfer,
+        // otherwise the next voice turn would still hard-transfer.
+        if (call.livekitCredentials !== null) {
+          manualTransferVoiceRef.current?.(null).catch((err) => {
+            console.warn("[ConversationalChat] manual transfer clear failed", err);
+          });
+        }
         return;
       }
       const badgeName = target.name.replace(/\s+[Aa]gent$/i, "").trim();
@@ -637,8 +653,20 @@ export function ConversationalChat() {
       const transferMsg = `Transferring you to ${target.name} upon your request.`;
       call.appendAssistantTurn(transferMsg);
       playSynthesizedSpeech(transferMsg, restTtsOptions(agent.tts)).catch(() => {});
+      // #212: during a live voice call there is no typed message to carry
+      // manual_transfer, so hand the pick to the worker over the data channel;
+      // it applies the hard transfer on the next voice turn and publishes the
+      // agent_handoff swap back to us.
+      if (call.livekitCredentials !== null) {
+        manualTransferVoiceRef.current?.({
+          target_agent_id: target.id,
+          target_agent_name: target.name,
+        }).catch((err) => {
+          console.warn("[ConversationalChat] manual transfer publish failed", err);
+        });
+      }
     },
-    [call],
+    [call, agent.tts],
   );
 
   const handleSendDecision = useCallback(
@@ -957,6 +985,7 @@ export function ConversationalChat() {
             onConnectionLost={call.reportConnectionLost}
           />
           <WorkflowVoiceSyncBridge onRegister={registerWorkflowVoiceSync} />
+          <ManualTransferVoiceBridge onRegister={registerManualTransferVoiceSync} />
           {body}
         </LiveKitRoom>
       ) : (

--- a/frontend/src/components/ConversationalChat.tsx
+++ b/frontend/src/components/ConversationalChat.tsx
@@ -160,12 +160,9 @@ export function ConversationalChat() {
     workflowVoiceSyncRef.current = sync;
   }, []);
   const manualTransferVoiceRef = useRef<ManualTransferVoiceSyncFn | null>(null);
-  const registerManualTransferVoiceSync = useCallback(
-    (sync: ManualTransferVoiceSyncFn | null) => {
-      manualTransferVoiceRef.current = sync;
-    },
-    [],
-  );
+  const registerManualTransferVoiceSync = useCallback((sync: ManualTransferVoiceSyncFn | null) => {
+    manualTransferVoiceRef.current = sync;
+  }, []);
   const syncWorkflowToVoice = useCallback(async (state: WorkflowVoiceState) => {
     try {
       await workflowVoiceSyncRef.current?.(state);
@@ -658,12 +655,14 @@ export function ConversationalChat() {
       // it applies the hard transfer on the next voice turn and publishes the
       // agent_handoff swap back to us.
       if (call.livekitCredentials !== null) {
-        manualTransferVoiceRef.current?.({
-          target_agent_id: target.id,
-          target_agent_name: target.name,
-        }).catch((err) => {
-          console.warn("[ConversationalChat] manual transfer publish failed", err);
-        });
+        manualTransferVoiceRef
+          .current?.({
+            target_agent_id: target.id,
+            target_agent_name: target.name,
+          })
+          .catch((err) => {
+            console.warn("[ConversationalChat] manual transfer publish failed", err);
+          });
       }
     },
     [call, agent.tts],

--- a/frontend/src/components/ConversationalChat.tsx
+++ b/frontend/src/components/ConversationalChat.tsx
@@ -518,9 +518,16 @@ export function ConversationalChat() {
                 if (targetId) {
                   try {
                     const entries = await fetchUserAgents(controller.signal);
-                    const match = entries.find(
-                      (e) => e.template_id === targetId || e.id === targetId,
-                    );
+                    // The backend sends the canonical target: a registry name
+                    // ("general_inquiry") for built-ins, or a row id for saved
+                    // agents. Bridge kebab template ids the same way as
+                    // useAgentHandoff so both paths match identically (#212).
+                    const match = entries.find((e) => {
+                      const uaId = e.template_id ?? e.id;
+                      if (uaId === targetId || e.id === targetId) return true;
+                      const normalized = uaId.replace(/-agent$/, "").replace(/-/g, "_");
+                      return normalized === targetId;
+                    });
                     if (match) {
                       const next = backendToFrontendAgent(match);
                       setActiveAgent(next, `ua:${match.template_id ?? match.id}`);

--- a/frontend/src/hooks/useAgentHandoff.ts
+++ b/frontend/src/hooks/useAgentHandoff.ts
@@ -65,6 +65,10 @@ export function useAgentHandoff(onTransferred?: (agentName: string) => void): vo
         // Fuzzy match: the backend normalizes "sales-agent" to "sales" (removes -agent, replaces - with _).
         // We check for exact matches first, then normalized matches to bridge this gap.
         const match = entries.find((e) => {
+          // Customised agents publish their row UUID as the target (#212);
+          // template_id would mask it, so check the row id explicitly, the
+          // same way the text-path matcher does.
+          if (e.id === parsed.target) return true;
           const uaId = e.template_id ?? e.id;
           if (uaId === parsed.target) return true;
 

--- a/frontend/src/hooks/useWorkflowVoiceSync.ts
+++ b/frontend/src/hooks/useWorkflowVoiceSync.ts
@@ -53,3 +53,63 @@ export function WorkflowVoiceSyncBridge({ onRegister }: Props): null {
 
   return null;
 }
+
+// ---------------------------------------------------------------------------
+// Manual transfer bridge (#212)
+// ---------------------------------------------------------------------------
+
+export const MANUAL_TRANSFER_TOPIC = "taskorbit.manual_transfer";
+
+/** Payload for a UI-picked agent transfer during a voice call; null clears. */
+export type ManualTransferVoiceMsg = {
+  target_agent_id: string;
+  target_agent_name: string;
+} | null;
+
+export type ManualTransferVoiceSyncFn = (msg: ManualTransferVoiceMsg) => Promise<void>;
+
+/**
+ * Publishes @route menu picks to the voice worker over the data channel.
+ * During a voice call there is no typed message to carry manual_transfer,
+ * so the worker stores the pick and applies it as a hard transfer on the
+ * next voice turn (#212). Mirrors WorkflowVoiceSyncBridge.
+ */
+export function ManualTransferVoiceBridge({
+  onRegister,
+}: {
+  onRegister: (sync: ManualTransferVoiceSyncFn | null) => void;
+}): null {
+  const room = useRoomContext();
+
+  useEffect(() => {
+    if (!room) {
+      onRegister(null);
+      return;
+    }
+
+    const sync: ManualTransferVoiceSyncFn = async (msg) => {
+      const payload = new TextEncoder().encode(
+        JSON.stringify(
+          msg === null
+            ? { type: "manual_transfer", clear: true }
+            : {
+                type: "manual_transfer",
+                target_agent_id: msg.target_agent_id,
+                target_agent_name: msg.target_agent_name,
+              },
+        ),
+      );
+      await room.localParticipant.publishData(payload, {
+        reliable: true,
+        topic: MANUAL_TRANSFER_TOPIC,
+      });
+    };
+
+    onRegister(sync);
+    return () => {
+      onRegister(null);
+    };
+  }, [room, onRegister]);
+
+  return null;
+}


### PR DESCRIPTION
Fixes #212. The agent handoff never fired in prod. Root cause analysis found the transfer broken at several independent layers; each is fixed and tested:

- ✅ **Transfer tool was unreachable.** Tool selection always returned the first configured tool and neither client round-trips `next_active_tool_id`, so a multi-tool agent could never reach its transfer tool. Selection now picks the transfer tool when intent routing points away from the current agent and one of its targets resolves to that destination. Confirmation pins keep precedence, the allowed_handoffs gate still runs first, agents without a transfer tool are unchanged, and a completed handoff never re-fires.
- ✅ **Target strings did not resolve.** The configured target ("inquiry-agent" in prod) was normalised by a fragile regex and failed validation. New `resolve_transfer_target()` resolves deterministic-first: built-in name, saved config by id, built-in template by slug (previously never checked), saved config by display name, registry keyword mapping last. Shared by dispatch and the tool.
- ✅ **The visual swap got the raw string.** The response's `tool_invoked` now carries the resolved canonical target, and the swap matchers on both paths bridge row UUIDs, template slugs, and registry names identically.
- ✅ **Manual @route transfers did nothing on voice.** The pick only announced; nothing reached the backend. The pick is now published to the worker over the data channel and applied as a one-shot `manual_transfer` on the next voice turn through the orchestrator's existing manual-transfer short-circuit, then surfaced through the standard handoff publish. Works for built-ins and custom agents (verified by UUID).
- ✅ **Card swaps could be lost or lie.** The handoff publish only ran after reply playout, so barge-ins cancelled it, hung turns stranded it, an unreferenced rescue task could be garbage collected, and unconfirmed or rejected transfers still published. The publish is now an exactly-once flush that runs post-playout, on cancellation via a strongly referenced task, as a leading flush on the next turn, and as a catch-all when the agent returns to listening; it fires only after the orchestrator confirms the transfer completed, and failed publishes are restored for retry.

**Verified:** 737 backend tests green (30 new: resolution matrix, selection rules, re-fire regression, canonical propagation, manual-transfer bridge), frontend build green, and manual voice E2E on a local stack: auto-transfer to General Inquiry / Technical Support / Customer Dissatisfaction (single marker each, no re-fires, no false fires on small talk), manual @route transfer to a built-in and to a custom agent by UUID, auto and manual transfers coexisting in one call, interruption and rapid re-pick torture tests, full log chain firing exactly once per handoff. A final adversarial multi-agent code review over the whole branch confirmed and fixed five additional defects (customized-agent card matching, confirmation-gated publishes, decision-turn tool pinning, cancellation-safe manual swaps, framework-turn flush coverage) before this PR was opened.