### PR TITLE
diag(voice): log every user_state_changed transition with held_ms

### DIFF
--- a/backend/src/taskorbit/worker.py
+++ b/backend/src/taskorbit/worker.py
@@ -177,8 +177,34 @@ async def entrypoint(ctx: JobContext) -> None:
                 audio_duration_ms=round(m.audio_duration * 1000, 1),
             )
 
+    # Timestamp (event-clock, from UserStateChangedEvent.created_at) of the
+    # last user_state_changed transition, so each new transition can log how
+    # long the PREVIOUS state actually held. Diagnostic for bug 2: VAD has
+    # been observed staying in "speaking" for 30-40s straight (no transition
+    # to "listening" at all) before force_commit ever fires, which this
+    # makes directly visible instead of inferring it from STT heartbeat gaps.
+    _last_user_state_change_at: float | None = None
+
     @session.on("user_state_changed")
     def _on_user_state(ev: AgentEvent) -> None:
+        nonlocal _last_user_state_change_at
+        old_state = getattr(ev, "old_state", None)
+        new_state = getattr(ev, "new_state", None)
+        created_at = getattr(ev, "created_at", None)
+        held_ms = (
+            round((created_at - _last_user_state_change_at) * 1000, 1)
+            if created_at is not None and _last_user_state_change_at is not None
+            else None
+        )
+        if created_at is not None:
+            _last_user_state_change_at = created_at
+        logger.info(
+            "user_state_changed",
+            old_state=old_state,
+            new_state=new_state,
+            held_ms=held_ms,
+        )
+
         # Server-side VAD end-of-speech backstop (#153). When Silero detects the
         # user has stopped (speaking -> listening), nudge the frontend to commit
         # the turn. The frontend's amplitude silence detection is the primary
@@ -186,7 +212,7 @@ async def entrypoint(ctx: JobContext) -> None:
         # analyser above its threshold so it never fires and the turn hangs. The
         # frontend ignores the nudge unless it is still recording, so a turn it
         # already committed is unaffected.
-        if getattr(ev, "new_state", None) != "listening":
+        if new_state != "listening":
             return
 
         async def _publish_force_commit() -> None:

--- a/backend/tests/test_worker.py
+++ b/backend/tests/test_worker.py
@@ -472,6 +472,58 @@ async def test_user_state_listening_publishes_force_commit(configured_settings: 
 
 
 @pytest.mark.asyncio
+async def test_user_state_changed_logs_every_transition_with_held_ms(
+    configured_settings: None,
+) -> None:
+    """Bug 2 diagnostic: every user_state_changed transition must be logged
+    (not just the "listening" one that triggers force_commit), with how long
+    the previous state held, computed from the event's own created_at clock.
+    Without this we can only infer a VAD stall indirectly from STT heartbeat
+    gaps; with it, a stuck "speaking" state is directly visible in the logs.
+    """
+    ctx, _ = _make_ctx()
+    ctx.room.local_participant.publish_data = AsyncMock()
+    mock_agent = MagicMock()
+    handler_ref: list = []
+
+    mock_session = AsyncMock()
+
+    def capture_on(event: str):
+        def decorator(fn):
+            if event == "user_state_changed":
+                handler_ref.append(fn)
+            return fn
+
+        return decorator
+
+    mock_session.on = MagicMock(side_effect=capture_on)
+
+    with (
+        patch("taskorbit.worker.build_agent_session", return_value=mock_session),
+        patch("taskorbit.worker.build_default_agent", return_value=mock_agent),
+        patch("taskorbit.worker.logger") as mock_logger,
+    ):
+        await entrypoint(ctx)
+
+        assert handler_ref, "_on_user_state not registered"
+        handler = handler_ref[0]
+
+        handler(MagicMock(old_state=None, new_state="speaking", created_at=100.0))
+        handler(MagicMock(old_state="speaking", new_state="listening", created_at=134.5))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    events = [
+        call.kwargs
+        for call in mock_logger.info.call_args_list
+        if call.args and call.args[0] == "user_state_changed"
+    ]
+    assert len(events) == 2
+    assert events[0] == {"old_state": None, "new_state": "speaking", "held_ms": None}
+    assert events[1] == {"old_state": "speaking", "new_state": "listening", "held_ms": 34500.0}
+
+
+@pytest.mark.asyncio
 async def test_local_participant_packet_ignored(configured_settings: None) -> None:
     """A packet whose sender identity matches the local participant must be ignored."""
     ctx, registered = _make_ctx()


### PR DESCRIPTION
## Summary
- Bug 2: live voice calls have shown ~30-40s dead-air stalls where `worker_force_commit_published` (the server-VAD end-of-speech backstop, #153) only fires after a long delay, with nothing but `stt_metrics_collected` heartbeats logged in between. `_on_user_state` previously only logged the `listening` transition that triggers `force_commit`, so a stuck `speaking` state (the suspected cause — background noise parking Silero's speech probability in the activation/deactivation hysteresis band) could only be inferred indirectly from gaps between heartbeat lines.
- Every `user_state_changed` transition is now logged with `old_state`, `new_state`, and `held_ms` (how long the previous state actually lasted, computed from the event's own `created_at` clock), so a stuck state is directly visible in the logs instead of inferred.
- Diagnostics only — no behavior change. This is step 1 of the mitigation plan for Bug 2; deciding between a hard-timeout fallback and further VAD threshold tuning depends on what this logging shows next time the stall reproduces.

## Test plan
- [x] `ruff check` — clean
- [x] New unit test `test_user_state_changed_logs_every_transition_with_held_ms` asserts both the field shape and the `held_ms` computation across two transitions
- [x] Full `test_worker.py` suite passes (25/25)
- [ ] Reviewer: watch `docker compose logs -f worker` for `user_state_changed` lines next time a voice call stalls, to confirm whether VAD is stuck in `speaking` or flapping