### PR TITLE
fix(orchestration): external_api tools collect caller args + report failures honestly

### DIFF
--- a/backend/src/taskorbit/orchestration/__init__.py
+++ b/backend/src/taskorbit/orchestration/__init__.py
@@ -148,22 +148,32 @@ def _seconds_to_ms(seconds: float | None) -> float | None:
     return round(seconds * 1000, 1) if seconds is not None else None
 
 
-def _external_api_requires_args(tool: ToolDefinition) -> bool:
-    """Return True when an external_api tool's args_schema has required fields.
+def _external_api_arg_names(tool: ToolDefinition) -> list[str]:
+    """Top-level ``{{args.X}}`` names an external_api tool references.
 
-    A "read" tool with no required inputs (e.g. GET current time) can dispatch
-    immediately without any slot-extraction round-trip. A tool that DOES take
-    args (e.g. POST create-user with required fields) still needs its inputs
-    collected, so it goes through the normal slots_ready path.
+    Read from the actual template refs in the request config (URL, headers,
+    query, body), so it is correct even when ``args_schema`` was never filled
+    in (the common case for tools built before the config UI auto-derived it).
     """
     if tool.type != ToolType.EXTERNAL_API:
-        return False
-    params = tool.parameters or {}
-    args_schema = params.get("args_schema") if isinstance(params, dict) else None
-    if not isinstance(args_schema, dict):
-        return False
-    required = args_schema.get("required")
-    return isinstance(required, list) and len(required) > 0
+        return []
+    from taskorbit.tools.generic_api import extract_arg_names
+
+    return extract_arg_names(tool.parameters or {})
+
+
+def _external_api_requires_args(tool: ToolDefinition) -> bool:
+    """Return True when an external_api tool needs args collected before it runs.
+
+    A "read" tool with no ``{{args.X}}`` references (e.g. GET current time for a
+    fixed zone) can dispatch immediately without any slot-extraction round-trip.
+    A tool that references args (e.g. a lookup templating ``{{args.timeZone}}``
+    into the request) must have those inputs collected first, otherwise
+    substitution fails with TEMPLATE_INVALID. We key off the real template refs
+    rather than ``args_schema.required`` so tools work even when the schema was
+    left empty.
+    """
+    return bool(_external_api_arg_names(tool))
 
 
 def _build_pipeline_latency_ms(
@@ -590,6 +600,12 @@ class ConversationOrchestrator:
             # the intent's hardcoded required_inputs so custom fields (email, phone,
             # etc.) are actually extracted.
             extraction_inputs = intent.required_inputs
+            # Conversion guidance passed to the extractor. Only set when an
+            # external_api tool's OWN {{args.X}} inputs drive extraction, so an
+            # unrelated (no-arg) external_api tool that merely happens to be
+            # active never colours the extraction of other fields (e.g. booking
+            # name/email/phone stay strictly literal).
+            extraction_guidance = ""
             if (
                 active_tool is not None
                 and active_tool.type == ToolType.DATA_EXTRACTION
@@ -598,6 +614,20 @@ class ConversationOrchestrator:
             ):
                 extraction_inputs = _normalize_field_key(active_tool.parameters["params"])
                 intent = dataclass_replace(intent, required_inputs=extraction_inputs)
+            elif active_tool is not None and active_tool.type == ToolType.EXTERNAL_API:
+                # An external_api tool templates {{args.X}} into its request; those
+                # inputs must be collected from the conversation before dispatch,
+                # exactly like data_extraction params. Without this, args is empty
+                # at dispatch and substitution fails with TEMPLATE_INVALID (or, if
+                # the tool declares no required args, it dispatches with a blank
+                # value). Derive the inputs from the real template refs.
+                _arg_names = _external_api_arg_names(active_tool)
+                if _arg_names:
+                    extraction_inputs = [
+                        {"name": name, "type": "string", "required": True} for name in _arg_names
+                    ]
+                    intent = dataclass_replace(intent, required_inputs=extraction_inputs)
+                    extraction_guidance = active_tool.description
 
             # Pre-slot-extraction scope short-circuit: refuse a clearly off-topic
             # message before any slot-extraction LLM call runs (#168).
@@ -613,7 +643,7 @@ class ConversationOrchestrator:
                 return refusal_response
 
             slot_result = await self._extract_slots(
-                request.messages, extraction_inputs, active_config.llm
+                request.messages, extraction_inputs, active_config.llm, guidance=extraction_guidance
             )
             logger.info(
                 "slots_extracted",
@@ -682,7 +712,12 @@ class ConversationOrchestrator:
                     step=executing_prereq_id,
                     conversation_id=request.conversation_id,
                 )
-            if tool_data and active_tool and not tool_data.get("aborted"):
+            if (
+                tool_data
+                and active_tool
+                and not tool_data.get("aborted")
+                and not tool_data.get("tool_failed")
+            ):
                 if request.agent_config.id not in updated_completed_steps:
                     updated_completed_steps.append(request.agent_config.id)
                     logger.info(
@@ -721,7 +756,9 @@ class ConversationOrchestrator:
                 status=response_status,
                 extracted_slots=slot_result.to_dict(),
                 missing_slots=slot_result.missing,
-                tool_invoked=(dispatch.tool_invoked_override or active_tool) if tool_data else None,
+                tool_invoked=(dispatch.tool_invoked_override or active_tool)
+                if (tool_data and not tool_data.get("tool_failed"))
+                else None,
                 locked_intent_name=intent.name,
                 next_active_tool_id=next_active_tool_id,
                 completed_workflow_steps=updated_completed_steps,
@@ -1212,6 +1249,12 @@ class ConversationOrchestrator:
             # the intent's hardcoded required_inputs so custom fields (email, phone,
             # etc.) are actually extracted.
             extraction_inputs = intent.required_inputs
+            # Conversion guidance passed to the extractor. Only set when an
+            # external_api tool's OWN {{args.X}} inputs drive extraction, so an
+            # unrelated (no-arg) external_api tool that merely happens to be
+            # active never colours the extraction of other fields (e.g. booking
+            # name/email/phone stay strictly literal).
+            extraction_guidance = ""
             if (
                 active_tool is not None
                 and active_tool.type == ToolType.DATA_EXTRACTION
@@ -1220,9 +1263,23 @@ class ConversationOrchestrator:
             ):
                 extraction_inputs = _normalize_field_key(active_tool.parameters["params"])
                 intent = dataclass_replace(intent, required_inputs=extraction_inputs)
+            elif active_tool is not None and active_tool.type == ToolType.EXTERNAL_API:
+                # An external_api tool templates {{args.X}} into its request; those
+                # inputs must be collected from the conversation before dispatch,
+                # exactly like data_extraction params. Without this, args is empty
+                # at dispatch and substitution fails with TEMPLATE_INVALID (or, if
+                # the tool declares no required args, it dispatches with a blank
+                # value). Derive the inputs from the real template refs.
+                _arg_names = _external_api_arg_names(active_tool)
+                if _arg_names:
+                    extraction_inputs = [
+                        {"name": name, "type": "string", "required": True} for name in _arg_names
+                    ]
+                    intent = dataclass_replace(intent, required_inputs=extraction_inputs)
+                    extraction_guidance = active_tool.description
 
             slot_result = await self._extract_slots(
-                request.messages, extraction_inputs, active_config.llm
+                request.messages, extraction_inputs, active_config.llm, guidance=extraction_guidance
             )
             logger.info(
                 "slots_extracted",
@@ -1296,7 +1353,12 @@ class ConversationOrchestrator:
                     step=executing_prereq_id,
                     conversation_id=request.conversation_id,
                 )
-            if tool_data and active_tool and not tool_data.get("aborted"):
+            if (
+                tool_data
+                and active_tool
+                and not tool_data.get("aborted")
+                and not tool_data.get("tool_failed")
+            ):
                 if request.agent_config.id not in updated_completed_steps:
                     updated_completed_steps.append(request.agent_config.id)
                     logger.info(
@@ -1335,7 +1397,9 @@ class ConversationOrchestrator:
                 status=response_status,
                 extracted_slots=slot_result.to_dict(),
                 missing_slots=slot_result.missing,
-                tool_invoked=(dispatch.tool_invoked_override or active_tool) if tool_data else None,
+                tool_invoked=(dispatch.tool_invoked_override or active_tool)
+                if (tool_data and not tool_data.get("tool_failed"))
+                else None,
                 locked_intent_name=intent.name,
                 next_active_tool_id=next_active_tool_id,
                 completed_workflow_steps=updated_completed_steps,
@@ -1663,7 +1727,22 @@ class ConversationOrchestrator:
             lines.append(f"Current task: {active_tool.name} - {active_tool.description}")
             if active_tool.parameters:
                 lines.append(f"Available parameters: {active_tool.parameters}")
-        if tool_data and not tool_data.get("aborted"):
+        if tool_data and tool_data.get("tool_failed"):
+            # The tool ran but failed. Make the model own the failure instead of
+            # inventing a plausible answer (which it will happily do for a
+            # "what time is it" style task if it is handed no data).
+            reason = str(
+                tool_data.get("tool_failed_message") or "the request could not be completed"
+            )
+            lines.append(
+                "IMPORTANT: the tool call FAILED and returned no usable data (reason: "
+                + reason
+                + "). Briefly tell the user you could not get that information right now; "
+                "they may try again. Do NOT invent, guess, estimate, or recall an answer "
+                "from prior knowledge. You have no real data for this request, so do not "
+                "state any specific value (time, date, price, status, etc.)."
+            )
+        elif tool_data and not tool_data.get("aborted"):
             import json as _json
 
             lines.append(
@@ -1728,15 +1807,21 @@ class ConversationOrchestrator:
         messages: list[Message],
         required_inputs: list[dict[str, Any]],
         llm_config: LLMConfig,
+        guidance: str = "",
     ) -> Any:
-        """Run slot extraction over the conversation history."""
+        """Run slot extraction over the conversation history.
+
+        ``guidance`` is optional per-tool text (an external_api tool's
+        description) that tells the extractor how to convert what the user
+        said into the value a field needs; empty for other tools.
+        """
         from taskorbit.slots import SlotExtractionResult, SlotExtractor
 
         if not required_inputs:
             return SlotExtractionResult()
         try:
             extractor = SlotExtractor(llm_fn=self._call_llm_json, llm_config=llm_config)
-            return await extractor.extract(messages, required_inputs)
+            return await extractor.extract(messages, required_inputs, guidance=guidance)
         except LLMError:
             # Provider failures must surface (#197) — treating them as "all slots
             # missing" would make the agent re-ask for data the user already gave.
@@ -2073,7 +2158,20 @@ class ConversationOrchestrator:
                 error=result.error,
                 tool_call_latency_ms=_seconds_to_ms(_tool_elapsed),
             )
-            return {}, _tool_elapsed
+            # Surface the failure to the LLM as a marked result so it reports the
+            # problem honestly instead of fabricating an answer from prior
+            # knowledge (previously this returned {} and the model, seeing the
+            # task but no data, made one up). Downstream consumers (workflow
+            # advance, tool_invoked, persistence) treat a tool_failed result as
+            # "no successful tool", so behaviour for a failed tool is otherwise
+            # unchanged.
+            envelope = result.data if isinstance(result.data, dict) else {}
+            message = str(
+                envelope.get("error_message")
+                or result.error
+                or "the request could not be completed"
+            )
+            return {"tool_failed": True, "tool_failed_message": message}, _tool_elapsed
 
         logger.info(
             "tool_executed",

--- a/backend/src/taskorbit/slots/extractor.py
+++ b/backend/src/taskorbit/slots/extractor.py
@@ -77,6 +77,7 @@ class SlotExtractor:
         self,
         messages: list[Message],
         required_inputs: list[dict[str, Any]],
+        guidance: str = "",
     ) -> SlotExtractionResult:
         """Run a single extraction pass over *messages* for *required_inputs*.
 
@@ -84,8 +85,14 @@ class SlotExtractor:
         filled and which are still missing.  On any JSON parse failure the
         result marks all required slots as missing so the caller can ask the
         user to repeat the information.
+
+        *guidance* is optional per-tool text (e.g. an external_api tool's
+        description) telling the extractor how to convert what the user said
+        into the exact value a field needs, such as mapping a country to a
+        timezone identifier. It is empty for data-extraction tools, whose
+        extraction stays strictly literal.
         """
-        system_prompt = self._build_extraction_prompt(required_inputs)
+        system_prompt = self._build_extraction_prompt(required_inputs, guidance)
         # Append a trigger message so the last thing the LLM sees is an
         # explicit instruction to output JSON — prevents it from responding
         # conversationally when the last user turn is a question rather than
@@ -103,7 +110,9 @@ class SlotExtractor:
     # Private helpers
     # ------------------------------------------------------------------
 
-    def _build_extraction_prompt(self, required_inputs: list[dict[str, Any]]) -> str:
+    def _build_extraction_prompt(
+        self, required_inputs: list[dict[str, Any]], guidance: str = ""
+    ) -> str:
         field_lines = "\n".join(
             f'  - {f["name"]} ({f["type"]}, required={f.get("required", True)})'
             for f in required_inputs
@@ -117,6 +126,22 @@ class SlotExtractor:
             if has_email
             else ""
         )
+        # Optional per-tool guidance lets the extractor convert what the user
+        # said into the exact value a field needs (e.g. a country -> a timezone
+        # identifier). Framed as an explicit exception so the strict "do not
+        # infer" rule below is unchanged for data-extraction tools, which pass
+        # no guidance. Converting information the user actually gave is not the
+        # same as inventing a value, so a field whose underlying detail the
+        # user never provided still stays null.
+        guidance_hint = (
+            "\n- Conversion guidance for these fields: apply the guidance below to "
+            "convert what the user actually said into each field's value. Convert "
+            "only; do NOT choose among multiple valid conversions, and if the user "
+            "has not stated the underlying detail or the correct conversion is "
+            f"ambiguous, keep the field null. Guidance: {guidance.strip()}"
+            if guidance and guidance.strip()
+            else ""
+        )
         return (
             "You are a JSON data extraction function. "
             "Your ONLY output must be a valid JSON object — no prose, no markdown, no conversation.\n\n"
@@ -127,7 +152,7 @@ class SlotExtractor:
             "- Use null for any field not yet provided by the user.\n"
             "- Do NOT infer, guess, or assume values.\n"
             "- Do NOT respond to questions or continue the conversation.\n"
-            f"- Output ONLY the JSON object, nothing else.{email_hint}"
+            f"- Output ONLY the JSON object, nothing else.{email_hint}{guidance_hint}"
         )
 
     def _parse_response(

--- a/backend/src/taskorbit/tools/generic_api.py
+++ b/backend/src/taskorbit/tools/generic_api.py
@@ -337,6 +337,57 @@ def substitute_tree(value: Any, args: dict[str, Any], allowed_env: frozenset[str
     return value
 
 
+def _iter_template_strings(value: Any) -> Any:
+    """Yield every string that substitution would touch inside ``value``.
+
+    Mirrors ``substitute_tree``: strings are yielded; dicts/lists are walked
+    over their values/items; other scalars are ignored. Dict KEYS are not
+    yielded because substitution never touches them.
+    """
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for v in value.values():
+            yield from _iter_template_strings(v)
+    elif isinstance(value, list):
+        for item in value:
+            yield from _iter_template_strings(item)
+
+
+def extract_arg_names(parameters: dict[str, Any]) -> list[str]:
+    """Return the top-level ``{{args.X}}`` names referenced by a tool's request.
+
+    Scans the substitutable surface (URL, header values, query values, body)
+    for ``args`` template references and returns each distinct top-level name
+    in first-seen order. ``{{args.user.id}}`` contributes ``user``. ``env``
+    references are ignored. This is the ground-truth list of inputs a tool
+    needs, independent of whatever ``args_schema`` may or may not declare, so
+    the orchestrator can collect exactly those inputs before dispatch.
+    """
+    request = parameters.get("request") if isinstance(parameters, dict) else None
+    if not isinstance(request, dict):
+        return []
+
+    texts: list[str] = []
+    url = request.get("url")
+    if isinstance(url, str):
+        texts.append(url)
+    for section in ("headers", "query"):
+        values = request.get(section)
+        if isinstance(values, dict):
+            texts.extend(v for v in _iter_template_strings(values))
+    texts.extend(v for v in _iter_template_strings(request.get("body")))
+
+    names: list[str] = []
+    for text in texts:
+        for match in _TEMPLATE_PATTERN.finditer(text):
+            if match.group(1) == "args":
+                top = match.group(2).split(".")[0]
+                if top not in names:
+                    names.append(top)
+    return names
+
+
 # ---------------------------------------------------------------------------
 # Response extraction (dot-path)
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_generic_api_tool.py
+++ b/backend/tests/test_generic_api_tool.py
@@ -18,12 +18,35 @@ from taskorbit.tools.generic_api import (
     GenericApiConfigError,
     GenericApiTool,
     TemplateSubstitutionError,
+    extract_arg_names,
     extract_path,
     extract_response,
     parse_config,
     substitute_string,
     substitute_tree,
 )
+
+
+def test_extract_arg_names_scans_all_request_sections() -> None:
+    params = {
+        "request": {
+            "method": "POST",
+            "url": "https://x/{{args.id}}",
+            "headers": {"X-Trace": "{{args.trace}}", "X-Key": "{{env.SECRET}}"},
+            "query": {"tz": "{{args.timeZone}}"},
+            "body": {"nested": {"who": "{{args.user.name}}"}, "list": ["{{args.item}}", 5]},
+        }
+    }
+    # First-seen order, top-level segment only, env refs excluded, deduped.
+    assert extract_arg_names(params) == ["id", "trace", "timeZone", "user", "item"]
+
+
+def test_extract_arg_names_empty_when_no_refs() -> None:
+    assert (
+        extract_arg_names({"request": {"method": "GET", "url": "https://x?tz=Europe/Berlin"}}) == []
+    )
+    assert extract_arg_names({}) == []
+    assert extract_arg_names({"request": "nope"}) == []
 
 
 @pytest.fixture

--- a/backend/tests/test_orchestration.py
+++ b/backend/tests/test_orchestration.py
@@ -548,10 +548,12 @@ async def test_external_api_dispatch_passes_full_config_plus_args() -> None:
 
 
 def test_external_api_requires_args_helper() -> None:
-    """Helper returns True only for EXTERNAL_API tools whose args_schema
-    declares a non-empty ``required`` list. Everything else, including
-    other tool types and empty/missing required lists, returns False."""
-    from taskorbit.orchestration import _external_api_requires_args
+    """The helper keys off the actual {{args.X}} template refs in the request,
+    not args_schema. A tool that templates an arg into its request needs that
+    input collected first; a tool with no refs (or a non-external tool) can
+    dispatch immediately. args_schema is intentionally irrelevant so tools work
+    even when it was never filled in."""
+    from taskorbit.orchestration import _external_api_arg_names, _external_api_requires_args
     from taskorbit.types import ConfirmationConfig, ToolDefinition, ToolType
 
     def _mk(tool_type: ToolType, params: dict[str, Any] | None) -> ToolDefinition:
@@ -564,24 +566,281 @@ def test_external_api_requires_args_helper() -> None:
             parameters=params or {},
         )
 
-    with_required = _mk(
+    with_ref = _mk(
         ToolType.EXTERNAL_API,
-        {"args_schema": {"type": "object", "required": ["city"], "properties": {}}},
+        {"request": {"method": "GET", "url": "https://x", "query": {"tz": "{{args.timeZone}}"}}},
     )
-    empty_required = _mk(
+    no_ref = _mk(
         ToolType.EXTERNAL_API,
-        {"args_schema": {"type": "object", "required": [], "properties": {}}},
+        {"request": {"method": "GET", "url": "https://x?tz=Europe/Berlin"}},
     )
-    no_schema = _mk(ToolType.EXTERNAL_API, {})
-    non_api = _mk(
-        ToolType.DATA_EXTRACTION,
-        {"args_schema": {"type": "object", "required": ["x"], "properties": {}}},
+    # A populated args_schema with no matching template ref still needs nothing.
+    schema_only = _mk(
+        ToolType.EXTERNAL_API,
+        {"request": {"method": "GET", "url": "https://x"}, "args_schema": {"required": ["city"]}},
+    )
+    non_api = _mk(ToolType.DATA_EXTRACTION, {"request": {"url": "{{args.x}}"}})
+
+    assert _external_api_requires_args(with_ref) is True
+    assert _external_api_requires_args(no_ref) is False
+    assert _external_api_requires_args(schema_only) is False
+    assert _external_api_requires_args(non_api) is False
+    assert _external_api_arg_names(with_ref) == ["timeZone"]
+    assert _external_api_arg_names(no_ref) == []
+
+
+@pytest.mark.asyncio
+async def test_external_api_arg_extracted_and_dispatched() -> None:
+    """An external_api tool that templates {{args.X}} gets X collected via slot
+    extraction (with the tool description passed as guidance) and dispatched
+    with the extracted value, even when the intent router produced no inputs."""
+    from taskorbit.slots.models import SlotExtractionResult, SlotValue
+    from taskorbit.types import ConfirmationConfig, ToolDefinition, ToolType
+
+    orch = ConversationOrchestrator()
+    intent = _intent_result(required_inputs=[])
+    tool = ToolDefinition(
+        id="get_time",
+        name="get_current_time",
+        type=ToolType.EXTERNAL_API,
+        description="Convert the location the user gives into an IANA timezone.",
+        confirmation=ConfirmationConfig(required=False, prompt=""),
+        parameters={
+            "request": {"method": "GET", "url": "https://x", "query": {"tz": "{{args.timeZone}}"}},
+            "args_schema": {"type": "object", "properties": {}},
+        },
+    )
+    slot_result = SlotExtractionResult(
+        filled={"timeZone": SlotValue(name="timeZone", value="Europe/Berlin", slot_type="string")},
+        missing=[],
     )
 
-    assert _external_api_requires_args(with_required) is True
-    assert _external_api_requires_args(empty_required) is False
-    assert _external_api_requires_args(no_schema) is False
-    assert _external_api_requires_args(non_api) is False
+    captured: list[tuple[list[dict[str, Any]], str]] = []
+
+    async def _fake_extract(
+        _self: ConversationOrchestrator,
+        _messages: Any,
+        required_inputs: list[dict[str, Any]],
+        _llm_config: Any,
+        guidance: str = "",
+    ) -> SlotExtractionResult:
+        captured.append((required_inputs, guidance))
+        return slot_result
+
+    dispatch_calls: list[dict[str, Any]] = []
+
+    async def _fake_dispatch(
+        _self: ConversationOrchestrator,
+        _tool: ToolDefinition,
+        ctx: dict[str, Any],
+        **_kwargs: Any,
+    ) -> tuple[dict[str, Any], float]:
+        dispatch_calls.append(ctx)
+        return {"status": 200, "data": {"dateTime": "2026-07-14"}}, 0.0
+
+    with (
+        patch.object(orch._intent_router, "detect", new_callable=AsyncMock, return_value=intent),
+        patch.object(ConversationOrchestrator, "_select_active_tool", return_value=tool),
+        patch.object(ConversationOrchestrator, "_extract_slots", new=_fake_extract),
+        patch.object(ConversationOrchestrator, "_dispatch_tool", new=_fake_dispatch),
+        patch.object(
+            ConversationOrchestrator, "_call_llm", new_callable=AsyncMock, return_value="ok"
+        ),
+    ):
+        response = await orch.process_message(_make_request("I'm in Germany"))
+
+    # The tool's {{args.timeZone}} ref was wired into the extraction inputs...
+    assert captured[0][0] == [{"name": "timeZone", "type": "string", "required": True}]
+    # ...and the tool description was passed as conversion guidance.
+    assert "IANA timezone" in captured[0][1]
+    # ...and dispatch received the extracted arg value.
+    assert response.tool_invoked is not None
+    assert response.tool_invoked.type == ToolType.EXTERNAL_API
+    assert dispatch_calls[0]["args"] == {"timeZone": "Europe/Berlin"}
+
+
+@pytest.mark.asyncio
+async def test_no_arg_external_api_active_does_not_leak_guidance() -> None:
+    """A no-arg external_api tool that merely happens to be the active tool must
+    NOT pass its description as conversion guidance: unrelated intent-driven
+    fields (booking name/email/...) stay strictly literal, as before."""
+    from taskorbit.slots.models import SlotExtractionResult
+    from taskorbit.types import ConfirmationConfig, ToolDefinition, ToolType
+
+    orch = ConversationOrchestrator()
+    intent = _intent_result(
+        required_inputs=[{"name": "caller_name", "type": "string", "required": True}]
+    )
+    tool = ToolDefinition(
+        id="get_time",
+        name="get_current_time",
+        type=ToolType.EXTERNAL_API,
+        description="Returns the current time in Europe/Berlin.",
+        confirmation=ConfirmationConfig(required=False, prompt=""),
+        parameters={"request": {"method": "GET", "url": "https://x?tz=Europe/Berlin"}},
+    )
+
+    captured_guidance: list[str] = []
+
+    async def _fake_extract(
+        _self: ConversationOrchestrator,
+        _messages: Any,
+        _required_inputs: list[dict[str, Any]],
+        _llm_config: Any,
+        guidance: str = "",
+    ) -> SlotExtractionResult:
+        captured_guidance.append(guidance)
+        return SlotExtractionResult(filled={}, missing=["caller_name"])
+
+    async def _fake_dispatch(
+        _self: ConversationOrchestrator,
+        _tool: ToolDefinition,
+        _ctx: dict[str, Any],
+        **_kwargs: Any,
+    ) -> tuple[dict[str, Any], float]:
+        return {"status": 200, "data": {}}, 0.0
+
+    with (
+        patch.object(orch._intent_router, "detect", new_callable=AsyncMock, return_value=intent),
+        patch.object(ConversationOrchestrator, "_select_active_tool", return_value=tool),
+        patch.object(ConversationOrchestrator, "_extract_slots", new=_fake_extract),
+        patch.object(ConversationOrchestrator, "_dispatch_tool", new=_fake_dispatch),
+        patch.object(
+            ConversationOrchestrator, "_call_llm", new_callable=AsyncMock, return_value="ok"
+        ),
+    ):
+        await orch.process_message(_make_request("My name is John"))
+
+    # No {{args}} refs on the tool => no guidance leaked into the booking fields.
+    assert captured_guidance == [""]
+
+
+def test_build_system_prompt_tool_failure_instructs_honesty() -> None:
+    """When a tool failed, the prompt must tell the model to report the failure
+    and NOT fabricate, and must NOT include the 'use this concrete data' block."""
+    from taskorbit.types import AgentConfig as _AC
+    from taskorbit.types import ConfirmationConfig, ToolDefinition, ToolType
+
+    orch = ConversationOrchestrator()
+    config = _AC(id="a", name="a", persona="p", greeting="g")
+    tool = ToolDefinition(
+        id="t",
+        name="get_time",
+        type=ToolType.EXTERNAL_API,
+        description="d",
+        confirmation=ConfirmationConfig(required=False, prompt=""),
+        parameters={},
+    )
+    prompt = orch._build_system_prompt(
+        config,
+        tool,
+        None,
+        routed_agent=None,
+        tool_data={"tool_failed": True, "tool_failed_message": "Invalid Timezone"},
+    )
+    assert "FAILED" in prompt
+    assert "Invalid Timezone" in prompt
+    assert "Do NOT invent" in prompt
+    assert "use this concrete data" not in prompt
+
+
+@pytest.mark.asyncio
+async def test_dispatch_tool_marks_failure_instead_of_empty() -> None:
+    """A failed tool result is now a marked dict (so the LLM is told it failed),
+    not the old silent {} that led the model to fabricate an answer."""
+    from taskorbit.tools import ToolResult
+    from taskorbit.types import ConfirmationConfig, ToolDefinition, ToolType
+
+    orch = ConversationOrchestrator()
+    tool = ToolDefinition(
+        id="t",
+        name="get",
+        type=ToolType.EXTERNAL_API,
+        description="d",
+        confirmation=ConfirmationConfig(required=False, prompt=""),
+        parameters={},
+    )
+    with patch(
+        "taskorbit.tools.generic_api.GenericApiTool.execute",
+        new_callable=AsyncMock,
+        return_value=ToolResult(
+            success=False,
+            data={"error_code": "HTTP_4XX", "error_message": "The external service rejected it."},
+            error="HTTP_4XX: rejected",
+        ),
+    ):
+        data, _elapsed = await orch._dispatch_tool(tool, {})
+
+    assert data.get("tool_failed") is True
+    assert "rejected" in data.get("tool_failed_message", "")
+
+
+@pytest.mark.asyncio
+async def test_failed_external_api_tool_makes_agent_report_not_fabricate() -> None:
+    """End to end: when the external_api dispatch fails, the LLM prompt carries
+    the failure instruction (not a success data block) and the failed tool is
+    not reported as invoked."""
+    from taskorbit.slots.models import SlotExtractionResult, SlotValue
+    from taskorbit.types import ConfirmationConfig, ToolDefinition, ToolType
+
+    orch = ConversationOrchestrator()
+    intent = _intent_result(required_inputs=[])
+    tool = ToolDefinition(
+        id="get_time",
+        name="get_current_time",
+        type=ToolType.EXTERNAL_API,
+        description="Convert the location to an IANA timezone.",
+        confirmation=ConfirmationConfig(required=False, prompt=""),
+        parameters={
+            "request": {"method": "GET", "url": "https://x", "query": {"tz": "{{args.timeZone}}"}},
+            "args_schema": {"type": "object", "properties": {}},
+        },
+    )
+    slot_result = SlotExtractionResult(
+        filled={"timeZone": SlotValue(name="timeZone", value="Germany", slot_type="string")},
+        missing=[],
+    )
+
+    async def _fake_extract(
+        _self: ConversationOrchestrator,
+        _messages: Any,
+        _required_inputs: list[dict[str, Any]],
+        _llm_config: Any,
+        guidance: str = "",
+    ) -> SlotExtractionResult:
+        return slot_result
+
+    async def _fake_dispatch(
+        _self: ConversationOrchestrator,
+        _tool: ToolDefinition,
+        _ctx: dict[str, Any],
+        **_kwargs: Any,
+    ) -> tuple[dict[str, Any], float]:
+        return {"tool_failed": True, "tool_failed_message": "Invalid Timezone"}, 0.0
+
+    seen_prompts: list[str] = []
+
+    async def _capture_llm(
+        _self: ConversationOrchestrator, system_prompt: str, *_a: Any, **_kw: Any
+    ) -> str:
+        seen_prompts.append(system_prompt)
+        return "Sorry, I couldn't get the time just now."
+
+    with (
+        patch.object(orch._intent_router, "detect", new_callable=AsyncMock, return_value=intent),
+        patch.object(ConversationOrchestrator, "_select_active_tool", return_value=tool),
+        patch.object(ConversationOrchestrator, "_extract_slots", new=_fake_extract),
+        patch.object(ConversationOrchestrator, "_dispatch_tool", new=_fake_dispatch),
+        patch.object(ConversationOrchestrator, "_call_llm", new=_capture_llm),
+    ):
+        response = await orch.process_message(_make_request("I'm in Germany"))
+
+    assert len(seen_prompts) == 1
+    assert "FAILED" in seen_prompts[0]
+    assert "Do NOT invent" in seen_prompts[0]
+    assert "use this concrete data" not in seen_prompts[0]
+    # A failed tool is not reported as invoked (behaviour unchanged).
+    assert response.tool_invoked is None
 
 
 def test_build_system_prompt_injects_tool_data() -> None:

--- a/backend/tests/test_slot_extraction.py
+++ b/backend/tests/test_slot_extraction.py
@@ -551,3 +551,27 @@ class TestSlotExtractorEmailNormalization:
         )
         assert "email_address" not in result.filled
         assert "email_address" in result.missing
+
+
+@pytest.mark.asyncio
+async def test_guidance_scoped_to_when_present():
+    """Guidance adds an explicit conversion exception to the prompt; without it
+    (data-extraction tools) the prompt keeps its strict no-infer rule unchanged."""
+    captured: dict[str, str] = {}
+
+    async def capture_llm(system_prompt: str, messages, llm_config) -> str:
+        captured["prompt"] = system_prompt
+        return '{"timeZone": "Europe/Berlin"}'
+
+    cfg = LLMConfig(provider="openai", model="gpt-4o-mini")
+    ext = SlotExtractor(llm_fn=capture_llm, llm_config=cfg)
+    msgs = [Message(role=MessageRole.USER, content="I'm in Germany")]
+    inputs = [{"name": "timeZone", "type": "string", "required": True}]
+
+    await ext.extract(msgs, inputs, guidance="Convert the country to an IANA timezone.")
+    assert "Convert the country to an IANA timezone." in captured["prompt"]
+    assert "Conversion guidance for these fields" in captured["prompt"]
+
+    await ext.extract(msgs, inputs)
+    assert "Conversion guidance for these fields" not in captured["prompt"]
+    assert "Do NOT infer, guess, or assume values." in captured["prompt"]


### PR DESCRIPTION
Closes #245 

## Summary

An external_api tool where the caller supplies a value ("tell me the time in Germany") froze on voice, while a tool with a hardcoded value worked.

Root cause: external_api tools never collected their {{args.X}} inputs from the conversation. Slot extraction only fed inputs for data_extraction tools, so external_api args were empty at dispatch and substitution failed with TEMPLATE_INVALID (or, with a populated args_schema, the tool never dispatched). Confirmed live on current main with three cases (query-param arg broke, hardcoded arg worked).

This is separate from #229 (the config-form polish). #229 makes the config correct; this fixes the runtime.

## Changes

- `generic_api.extract_arg_names`: the top-level {{args.X}} names a tool references across url, header values, query values, and body. Ground truth, independent of args_schema.
- `_external_api_requires_args` now keys off those refs, not args_schema.required, so it is correct even when the schema was never filled in.
- Slot-extraction override extended to external_api: the referenced args are collected from the conversation before dispatch, exactly like data_extraction params.
- The tool description is passed to slot extraction as conversion guidance, letting the extractor convert what the user said into the field value (country -> timezone). Scoped so data_extraction extraction stays strictly literal (its prompt is unchanged; a test asserts this).

## Testing

- Backend: 774 passed, 0 failed, ruff clean.
- New tests: extract_arg_names; external_api requires-args / arg-names; an integration test that an external_api arg is extracted and dispatched with the extracted value; a test proving the guidance is absent (and the strict prompt intact) for data_extraction.
- Manually verified end to end against main's code with a real LLM: literal arg (postcode -> town) and conversion arg (Germany -> Europe/Berlin -> correct time), 3/3 consecutive successes on the conversion case.