### PR TITLE
fix(voice): run the target agent after a transfer

### DIFF
--- a/backend/src/taskorbit/agents/__init__.py
+++ b/backend/src/taskorbit/agents/__init__.py
@@ -262,13 +262,30 @@ class AgentRegistry:
         if db is not None:
             from pydantic import ValidationError
 
-            from taskorbit.database.crud import get_agent_configuration_by_name
+            from taskorbit.database.crud import (
+                _find_agent_config_by_logical_id,
+                get_agent_configuration_by_name,
+            )
             from taskorbit.types import AgentConfig as AgentConfigType
 
+            # Intent routing hands us an agent_id ("chris"), but the DB name column
+            # holds the display name ("Chris") and the lookup is case-sensitive, so
+            # by-name misses custom agents and silently falls back to the default
+            # (#8 / the "custom agent not found" symptom). Resolve by logical
+            # agent_id (config.agent_id / config.id) when the name lookup misses.
             record = await get_agent_configuration_by_name(db, agent_name, user_id=user_id)
+            if record is None:
+                record = await _find_agent_config_by_logical_id(db, agent_name, user_id)
             if record is not None:
                 try:
-                    custom_config = AgentConfigType(**record.config)
+                    from taskorbit.agent_config_util import agent_config_from_stored_blob
+
+                    # record.config is the stored (frontend-shaped) blob using
+                    # instructions/first_message; map it the way the text path does
+                    # rather than validating it raw as AgentConfig, which is missing
+                    # persona/greeting and silently falls back to the default agent
+                    # (that's why a transferred-to custom agent behaved like Maya).
+                    custom_config = agent_config_from_stored_blob(record.config)
                 except (ValidationError, Exception) as exc:
                     logger.error(
                         "custom_agent_invalid_config",

--- a/backend/src/taskorbit/agents/__init__.py
+++ b/backend/src/taskorbit/agents/__init__.py
@@ -266,7 +266,6 @@ class AgentRegistry:
                 _find_agent_config_by_logical_id,
                 get_agent_configuration_by_name,
             )
-            from taskorbit.types import AgentConfig as AgentConfigType
 
             # Intent routing hands us an agent_id ("chris"), but the DB name column
             # holds the display name ("Chris") and the lookup is case-sensitive, so

--- a/backend/src/taskorbit/database/crud.py
+++ b/backend/src/taskorbit/database/crud.py
@@ -411,6 +411,36 @@ async def create_tool_execution(
         return None
 
 
+async def get_recent_external_api_results(
+    db: AsyncSession, conversation_id: str, limit: int = 5
+) -> list[dict]:
+    """Result payloads of recent external_api tool runs for a conversation.
+
+    The raw external_api result is otherwise only injected into the turn that ran
+    the tool, so after a handoff (e.g. Maya -> Rachel -> Chris) the downstream
+    agent never sees data an earlier agent retrieved. This reloads those results
+    so they can be re-injected into any later agent's prompt. Ordered oldest
+    first; only rows carrying the raw result shape (a ``data`` payload) count.
+    """
+    try:
+        result = await db.execute(
+            select(ToolExecution)
+            .where(
+                ToolExecution.conversation_id == conversation_id,
+                ToolExecution.tool_type == "external_api",
+            )
+            .order_by(ToolExecution.executed_at.asc())
+            .limit(limit)
+        )
+        rows = list(result.scalars().all())
+        return [r.result for r in rows if isinstance(r.result, dict) and r.result.get("data")]
+    except Exception as e:  # noqa: BLE001 - never let a reload failure break the turn
+        logger.warning(
+            "get_external_api_results_failed", conversation_id=conversation_id, error=str(e)
+        )
+        return []
+
+
 # ============ CONVERSATION MESSAGE CRUD ============
 
 
@@ -763,7 +793,14 @@ async def resolve_dependency_agent_config(
     Workflow dependencies store logical ids (e.g. ``technical-support-agent-demo``),
     but saved rows in ``agent_configurations`` use a DB uuid primary key. Search
     user copies first, then admin/shared saves (``user_id IS NULL``).
+
+    The config UI persists workflow-rule dependencies as row references
+    ("row:<db_id>"); strip that prefix here, at the DB-lookup boundary only, so
+    get_user_agent matches the bare primary key. The prefix is deliberately kept
+    on the dependency ids everywhere else (missing-step calc + dependency_configs
+    keys stay in sync on the raw string), so do NOT normalise it upstream.
     """
+    logical_id = logical_id.removeprefix("row:")
     row = await get_user_agent(db, logical_id, user_id)
     if row:
         return agent_config_from_stored_blob(row.config)

--- a/backend/src/taskorbit/intent/__init__.py
+++ b/backend/src/taskorbit/intent/__init__.py
@@ -270,14 +270,22 @@ class IntentRouter:
         messages: list[Message],
         llm_fn: LLMCallable,
         llm_config: LLMConfig,
+        extra_intents: dict[str, IntentResult] | None = None,
     ) -> IntentResult:
         """Classify *prompt* and return an IntentResult.
+
+        ``extra_intents`` are per-call routing targets for the CURRENT agent's
+        custom handoffs (keyed by agent_id, e.g. "chris"); they are merged with
+        the built-ins for this one call only and never mutate the module global,
+        so custom multi-agent configs become routable without breaking built-in
+        routing (#1).
 
         Sets ``requires_clarification=True`` when confidence is below the
         threshold or when the LLM returns no matching intent.
         """
+        candidates: dict[str, IntentResult] = {**_KNOWN_INTENTS, **(extra_intents or {})}
         intents_list = "\n".join(
-            f"- {name}: {result.description}" for name, result in _KNOWN_INTENTS.items()
+            f"- {name}: {result.description}" for name, result in candidates.items()
         )
 
         history_block = ""
@@ -331,11 +339,11 @@ class IntentRouter:
                 requires_clarification=0.5 < self._threshold,
             )
 
-        if not intent_name or intent_name not in _KNOWN_INTENTS:
+        if not intent_name or intent_name not in candidates:
             return replace(_FALLBACK_RESULT, confidence=0.0, requires_clarification=True)
 
         return replace(
-            _KNOWN_INTENTS[intent_name],
+            candidates[intent_name],
             confidence=confidence,
             requires_clarification=confidence < self._threshold,
         )

--- a/backend/src/taskorbit/livekit_agent/llm.py
+++ b/backend/src/taskorbit/livekit_agent/llm.py
@@ -68,6 +68,11 @@ class WorkflowSyncResult(NamedTuple):
 
 _CONFIRM_PATTERNS = (
     r"\byes\b",
+    r"\byeah\b",
+    r"\byep\b",
+    r"\byup\b",
+    r"\byeap\b",
+    r"\bokay\b",
     r"\bproceed\b",
     r"\bcontinue\b",
     r"\bcontinua\b",
@@ -75,6 +80,13 @@ _CONFIRM_PATTERNS = (
     r"\bsure\b",
     r"\bok\b",
     r"\bgo ahead\b",
+    r"\bgo for it\b",
+    r"\bplease do\b",
+    r"\bdo it\b",
+    r"\bsounds good\b",
+    r"\bsounds great\b",
+    r"\babsolutely\b",
+    r"\bof course\b",
 )
 _REJECT_PATTERNS = (
     r"\bno\b",
@@ -595,14 +607,59 @@ class OrchestratorAgent(Agent):
         ):
             targets = response.tool_invoked.parameters.get("targets") or []
             if targets:
-                self._pending_handoff_target = str(targets[0])
-                # The conversation is now routed to the target: without this,
-                # selected_agent stays on the entry agent and the transfer
-                # re-fires (and re-publishes) on every subsequent turn (#212).
-                self._current_routed_agent = self._pending_handoff_target
+                row_id = str(targets[0])
+                # Keep the raw row id: the worker publishes it on the
+                # agent_handoff topic and the FE matches it by e.id (useAgentHandoff).
+                self._pending_handoff_target = row_id
+                # PERSISTENTLY swap the worker's own agent config to the transfer
+                # target. On the voice path self._agent_config is bound once from
+                # the LiveKit metadata (the entry agent) and every turn rebuilds
+                # the active agent — and its tools — from it. Without swapping it,
+                # the entry agent's confirmation-gated transfer tool re-selects and
+                # re-fires on every subsequent turn, so the target agent never
+                # actually runs and can never present its result (#212 voice loop).
+                routed_label = row_id
+                try:
+                    from taskorbit.agent_config_util import agent_config_from_stored_blob
+                    from taskorbit.database.crud import get_agent_configuration_by_id
+
+                    async with AsyncSessionLocal() as db:
+                        record = await get_agent_configuration_by_id(
+                            db, row_id, user_id=self._user_id
+                        )
+                    if record is not None:
+                        # Map the stored (frontend-shaped) blob the same way the
+                        # text path does; AgentConfig(**blob) mis-maps
+                        # instructions/first_message and would fall back to Maya.
+                        self._agent_config = agent_config_from_stored_blob(record.config)
+                        routed_label = self._agent_config.id or row_id
+                        log.info(
+                            "voice_agent_config_swapped",
+                            to_agent=self._agent_config.id,
+                            conversation_id=self._conversation_id,
+                        )
+                    else:
+                        # Built-in target (registry name, no DB row) or unknown id:
+                        # keep today's behaviour, no swap.
+                        log.warning(
+                            "voice_agent_config_swap_no_row",
+                            target=row_id,
+                            conversation_id=self._conversation_id,
+                        )
+                except Exception as exc:  # noqa: BLE001 - a swap failure must never break the turn
+                    log.warning(
+                        "voice_agent_config_swap_failed",
+                        target=row_id,
+                        error=str(exc),
+                        conversation_id=self._conversation_id,
+                    )
+                # Route future turns to the target's clean logical id (e.g. "chris")
+                # instead of the raw row id — this is both next turn's
+                # selected_agent and the agent_routed pill label.
+                self._current_routed_agent = routed_label
                 log.info(
                     "voice_agent_handoff_pending",
-                    target=self._pending_handoff_target,
+                    target=row_id,
                     selected_agent=response.selected_agent,
                     conversation_id=self._conversation_id,
                 )

--- a/backend/src/taskorbit/orchestration/__init__.py
+++ b/backend/src/taskorbit/orchestration/__init__.py
@@ -457,9 +457,7 @@ class ConversationOrchestrator:
                         conversation_id=request.conversation_id,
                     )
                 else:
-                    intent = _reconstruct_locked_intent(
-                        request.current_intent_name, extra_intents
-                    )
+                    intent = _reconstruct_locked_intent(request.current_intent_name, extra_intents)
                     logger.info(
                         "intent_locked",
                         intent=intent.name,
@@ -821,9 +819,7 @@ class ConversationOrchestrator:
             if db is not None and request.conversation_id:
                 from taskorbit.database.crud import get_recent_external_api_results
 
-                prior_tool_data = await get_recent_external_api_results(
-                    db, request.conversation_id
-                )
+                prior_tool_data = await get_recent_external_api_results(db, request.conversation_id)
 
             dispatch = await self._run_dispatch_step(
                 request, active_tool, slot_result, intent, agent, db=db, user_id=user_id
@@ -1159,9 +1155,7 @@ class ConversationOrchestrator:
                         conversation_id=request.conversation_id,
                     )
                 else:
-                    intent = _reconstruct_locked_intent(
-                        request.current_intent_name, extra_intents
-                    )
+                    intent = _reconstruct_locked_intent(request.current_intent_name, extra_intents)
                     logger.info(
                         "intent_locked",
                         intent=intent.name,
@@ -1492,9 +1486,7 @@ class ConversationOrchestrator:
             if db is not None and request.conversation_id:
                 from taskorbit.database.crud import get_recent_external_api_results
 
-                prior_tool_data = await get_recent_external_api_results(
-                    db, request.conversation_id
-                )
+                prior_tool_data = await get_recent_external_api_results(db, request.conversation_id)
 
             dispatch = await self._run_dispatch_step(
                 request, active_tool, slot_result, intent, agent, db=db, user_id=user_id

--- a/backend/src/taskorbit/orchestration/__init__.py
+++ b/backend/src/taskorbit/orchestration/__init__.py
@@ -68,12 +68,28 @@ def _effective_selected_agent(selected_agent: str | None) -> str | None:
     return stripped if stripped else None
 
 
-def _selected_agent_matches_dep(selected_agent: str | None, dep_id: str) -> bool:
-    """True when the session is already executing a prerequisite agent step."""
+def _selected_agent_matches_dep(
+    selected_agent: str | None, dep_id: str, dep_agent_id: str | None = None
+) -> bool:
+    """True when the session is already executing a prerequisite agent step.
+
+    ``dep_agent_id`` is the dependency's clean logical id (e.g. "rachel"); we now
+    surface that as ``selected_agent`` instead of the raw "row:<db_id>" ref (so
+    the UI pill never shows the raw id), which means the prereq-in-progress check
+    must also match on it.
+    """
     if not selected_agent:
         return False
     dep_registry = AgentRegistry.get_agent_name_for_id(dep_id)
-    return selected_agent == dep_id or selected_agent == dep_registry
+    return selected_agent in (dep_id, dep_registry, dep_agent_id)
+
+
+def _dep_agent_id(request: ConversationRequest, dep_id: str) -> str | None:
+    """Clean logical agent id of a workflow dependency (e.g. "rachel"), resolved
+    from its attached config so the UI routed-agent label is a real name, never
+    the raw "row:<db_id>" reference. None when the config is not on the request."""
+    cfg = request.dependency_configs.get(dep_id)
+    return cfg.id if cfg is not None else None
 
 
 def _resolve_missing_dependencies(
@@ -99,6 +115,10 @@ def _workflow_prereq_confirmation_message(entry_name: str, dep_name: str) -> str
 
 
 def _workflow_prereq_start_ack(next_dep: str) -> str:
+    if next_dep.startswith("row:"):
+        # Custom workflow dependency (a "row:<id>" ref): keep the ack generic so
+        # we never leak the raw row id (or a prerequisite agent's name) to the user.
+        return "Understood. Let me get the information we need for that first."
     return f"Understood. Let's start with the {next_dep.replace('-', ' ')} steps."
 
 
@@ -111,7 +131,32 @@ def _is_executing_workflow_prerequisite(
         return False
 
     _, _, missing = _resolve_missing_dependencies(request, intent)
-    return bool(missing) and _selected_agent_matches_dep(request.selected_agent, missing[0])
+    return bool(missing) and _selected_agent_matches_dep(
+        request.selected_agent, missing[0], _dep_agent_id(request, missing[0])
+    )
+
+
+def _reconstruct_locked_intent(
+    name: str, extra_intents: dict[str, IntentResult] | None = None
+) -> IntentResult:
+    """Rebuild a locked intent from its stored name across turns (#2/#5).
+
+    Built-ins come from the registry. A custom workflow target (e.g. "chris") is
+    rebuilt from the per-turn ``extra_intents``, or minimally if unavailable, so
+    its ``agent_name`` survives every follow-up turn (keeping the workflow rule
+    injecting the prerequisite) and ``_KNOWN_INTENTS[name]`` never raises
+    KeyError on the handoff-blocked revert.
+    """
+    source = {**_KNOWN_INTENTS, **(extra_intents or {})}
+    base = source.get(name)
+    if base is not None:
+        return dataclass_replace(base, confidence=1.0)
+    return IntentResult(
+        name=name,
+        description=f"Continue the workflow routed to the {name} agent.",
+        agent_name=name,
+        confidence=1.0,
+    )
 
 
 def _resolve_intent_after_clarification_gate(
@@ -126,6 +171,38 @@ def _resolve_intent_after_clarification_gate(
     if request.current_intent_name and request.current_intent_name in _KNOWN_INTENTS:
         return dataclass_replace(_KNOWN_INTENTS[request.current_intent_name], confidence=1.0)
     return dataclass_replace(intent, requires_clarification=False, confidence=1.0)
+
+
+# Catch-all fallback intents. These are NOT real handoff targets - there is no
+# "general_inquiry agent" to route to; they mean "no specific route, the current
+# agent should just answer."
+_NON_ROUTING_INTENTS = frozenset({"general_inquiry", "unknown"})
+
+
+def _keep_turn_with_committed_agent(
+    request: ConversationRequest,
+    intent: IntentResult,
+) -> IntentResult:
+    """Let a committed custom entry agent answer catch-all turns itself.
+
+    Once the conversation is committed to the entry agent (``selected_agent`` is
+    that agent's own id, e.g. a post-transfer presenter whose workflow
+    prerequisites are already satisfied), a catch-all or unclassifiable turn must
+    resolve to that agent responding directly. Otherwise the clarification gate
+    or the handoff-block refuses it - the current agent can never simply answer,
+    because a fallback intent is never in its ``allowed_handoffs``. The genuine
+    cross-agent handoff-block is untouched: it fires only when the routed agent
+    differs from the entry agent (``selected_agent != agent_config.id``).
+    """
+    if not request.selected_agent or request.selected_agent != request.agent_config.id:
+        return intent
+    if intent.requires_clarification or intent.name in _NON_ROUTING_INTENTS:
+        return dataclass_replace(
+            intent,
+            agent_name=request.agent_config.id,
+            requires_clarification=False,
+        )
+    return intent
 
 
 def _workflow_ui_selected_agent(request: ConversationRequest) -> str | None:
@@ -211,6 +288,54 @@ class ConversationOrchestrator:
     def __init__(self, settings: Settings | None = None) -> None:
         self._settings = settings or get_settings()
         self._intent_router = IntentRouter()
+
+    async def _build_extra_intents(
+        self,
+        request: ConversationRequest,
+        db: AsyncSession | None,
+        user_id: int | None,
+    ) -> dict[str, IntentResult]:
+        """Per-turn custom routing targets from the entry agent's allowed_handoffs (#1).
+
+        Each allowed-handoff agent_id (e.g. "chris") becomes a candidate intent
+        keyed by that agent_id and described by the target agent's name + persona,
+        so the classifier can route to a custom agent instead of always falling to
+        a built-in. Read-only; any resolution failure is skipped so a missing or
+        renamed target can never break built-in routing.
+        """
+        extra: dict[str, IntentResult] = {}
+        handoffs = request.agent_config.allowed_handoffs or []
+        if not handoffs or db is None:
+            return extra
+
+        from taskorbit.database.crud import _find_agent_config_by_logical_id
+
+        for raw in handoffs:
+            hid = str(raw).strip()
+            if not hid or hid in _KNOWN_INTENTS or hid in extra:
+                continue
+            try:
+                record = await _find_agent_config_by_logical_id(db, hid, user_id)
+            except Exception:  # noqa: BLE001
+                record = None
+            display = record.name if record is not None else hid
+            # Concise, markdown-free routing signal. Dumping the whole persona
+            # makes the classifier less confident (it then clarifies instead of
+            # routing); prefer the greeting, fall back to the persona, and strip
+            # markdown/whitespace so the candidate list stays crisp.
+            summary = ""
+            if record is not None and isinstance(record.config, dict):
+                summary = str(
+                    record.config.get("greeting")
+                    or record.config.get("persona")
+                    or record.config.get("instructions")
+                    or ""
+                )
+            summary = summary.replace("#", " ").replace("*", " ").replace("\n", " ")
+            summary = " ".join(summary.split())[:150]
+            description = f"Route here to reach {display}. {summary}".strip()[:220]
+            extra[hid] = IntentResult(name=hid, description=description, agent_name=hid)
+        return extra
 
     async def process_message(
         self,
@@ -307,12 +432,16 @@ class ConversationOrchestrator:
 
             # 1. Detect intent — reuse locked intent when set, but still run the
             # classifier to allow genuine topic changes to break the lock.
-            if request.current_intent_name and request.current_intent_name in _KNOWN_INTENTS:
+            # extra_intents lets a custom entry agent route to its own handoff
+            # targets (e.g. Maya -> "chris"), not just the built-in intents (#1).
+            extra_intents = await self._build_extra_intents(request, db, user_id)
+            if request.current_intent_name:
                 fresh = await self._intent_router.detect(
                     last_user.content,
                     request.messages,
                     self._call_llm_json,
                     request.agent_config.llm,
+                    extra_intents=extra_intents,
                 )
                 if (
                     fresh.name != request.current_intent_name
@@ -328,8 +457,8 @@ class ConversationOrchestrator:
                         conversation_id=request.conversation_id,
                     )
                 else:
-                    intent = dataclass_replace(
-                        _KNOWN_INTENTS[request.current_intent_name], confidence=1.0
+                    intent = _reconstruct_locked_intent(
+                        request.current_intent_name, extra_intents
                     )
                     logger.info(
                         "intent_locked",
@@ -342,6 +471,7 @@ class ConversationOrchestrator:
                     request.messages,
                     self._call_llm_json,
                     request.agent_config.llm,
+                    extra_intents=extra_intents,
                 )
                 logger.info(
                     "intent_detected",
@@ -351,6 +481,7 @@ class ConversationOrchestrator:
                 )
 
             intent = _resolve_intent_after_clarification_gate(request, intent)
+            intent = _keep_turn_with_committed_agent(request, intent)
 
             # Short-circuit: ask for clarification instead of guessing
             if intent.requires_clarification:
@@ -422,7 +553,9 @@ class ConversationOrchestrator:
             executing_prereq_id: str | None = None
             if missing_dependencies:
                 next_dep = missing_dependencies[0]
-                executing_prereq = _selected_agent_matches_dep(request.selected_agent, next_dep)
+                executing_prereq = _selected_agent_matches_dep(
+                    request.selected_agent, next_dep, _dep_agent_id(request, next_dep)
+                )
 
                 if executing_prereq:
                     # User already confirmed — run the prerequisite agent, do not re-prompt.
@@ -466,10 +599,14 @@ class ConversationOrchestrator:
                     if not has_decision:
                         # Deadlock guard (AC #9): If we can't resolve the metadata for the prompt,
                         # we still offer the handoff but falling back to the ID name.
-                        dep_name = next_dep.replace("-", " ")
                         dep_config = request.dependency_configs.get(next_dep)
                         if dep_config:
                             dep_name = dep_config.name
+                        elif next_dep.startswith("row:"):
+                            # Never leak the raw "row:<db_id>" reference to the user.
+                            dep_name = "the required information"
+                        else:
+                            dep_name = next_dep.replace("-", " ")
 
                         return ConversationResponse(
                             conversation_id=request.conversation_id,
@@ -518,7 +655,7 @@ class ConversationOrchestrator:
                         conversation_id=request.conversation_id,
                         reply=self._make_assistant_message(_workflow_prereq_start_ack(next_dep)),
                         status=ConversationStatus.SUCCESS,
-                        selected_agent=next_dep,
+                        selected_agent=_dep_agent_id(request, next_dep) or next_dep,
                         selected_intent=intent.name,
                         intent_confidence=1.0,
                         locked_intent_name=intent.name,
@@ -555,8 +692,8 @@ class ConversationOrchestrator:
                     )
                     # Revert the intent name to match the selected agent's intent
                     if request.current_intent_name:
-                        intent = dataclass_replace(
-                            _KNOWN_INTENTS[request.current_intent_name], confidence=1.0
+                        intent = _reconstruct_locked_intent(
+                            request.current_intent_name, extra_intents
                         )
 
             if handoff_blocked:
@@ -584,7 +721,7 @@ class ConversationOrchestrator:
             active_config = agent.config
 
             # 3. Select active tool
-            active_tool = self._select_active_tool(
+            active_tool = await self._select_active_tool(
                 request.messages,
                 agent,
                 # confirmation_id IS the pending tool's id: pinning on it keeps
@@ -593,6 +730,9 @@ class ConversationOrchestrator:
                 active_tool_id=request.active_tool_id or request.confirmation_id,
                 intent=intent,
                 current_agent=request.selected_agent or request.agent_config.id,
+                db=db,
+                user_id=user_id,
+                executing_prereq=bool(executing_prereq_id),
             )
 
             # 3b. Extract slots from conversation history.
@@ -674,6 +814,17 @@ class ConversationOrchestrator:
             # system prompt. The stream path already runs dispatch first;
             # text path now matches so both paths behave identically and
             # external_api tools can actually answer the user's question.
+            # Reload external_api data earlier agents retrieved in this
+            # conversation, so it survives a handoff and can be re-injected into
+            # this (possibly different) agent's prompt.
+            prior_tool_data: list[dict] = []
+            if db is not None and request.conversation_id:
+                from taskorbit.database.crud import get_recent_external_api_results
+
+                prior_tool_data = await get_recent_external_api_results(
+                    db, request.conversation_id
+                )
+
             dispatch = await self._run_dispatch_step(
                 request, active_tool, slot_result, intent, agent, db=db, user_id=user_id
             )
@@ -682,13 +833,37 @@ class ConversationOrchestrator:
             tool_data = dispatch.tool_data
             response_status = dispatch.response_status
 
-            # 5. Build system prompt WITH tool_data if a tool just fired.
+            # Persist this turn's external_api result so a downstream agent (after
+            # a handoff) can reference it; otherwise it lives only for this turn.
+            if (
+                db is not None
+                and request.conversation_id
+                and active_tool is not None
+                and active_tool.type == ToolType.EXTERNAL_API
+                and isinstance(tool_data, dict)
+                and tool_data.get("data")
+                and not tool_data.get("tool_failed")
+                and not tool_data.get("aborted")
+            ):
+                from taskorbit.database.crud import create_tool_execution
+
+                await create_tool_execution(
+                    db,
+                    request.conversation_id,
+                    active_tool.id,
+                    ToolType.EXTERNAL_API.value,
+                    result=tool_data,
+                )
+
+            # 5. Build system prompt WITH tool_data if a tool just fired, plus any
+            # data a prior agent retrieved before handing off to this one.
             system_prompt = self._build_system_prompt(
                 active_config,
                 active_tool,
                 slot_result,
                 routed_agent=agent,
                 tool_data=tool_data,
+                prior_tool_data=prior_tool_data,
             )
 
             # 5b. Call LLM with a timeout from settings. Measure latency.
@@ -959,13 +1134,16 @@ class ConversationOrchestrator:
                 yield refusal_response
                 return
 
-            # 1. Detect intent.
-            if request.current_intent_name and request.current_intent_name in _KNOWN_INTENTS:
+            # 1. Detect intent. extra_intents lets a custom entry agent route to
+            # its own handoff targets (e.g. Maya -> "chris"), same as text (#1).
+            extra_intents = await self._build_extra_intents(request, db, user_id)
+            if request.current_intent_name:
                 fresh = await self._intent_router.detect(
                     last_user.content,
                     request.messages,
                     self._call_llm_json,
                     request.agent_config.llm,
+                    extra_intents=extra_intents,
                 )
                 if (
                     fresh.name != request.current_intent_name
@@ -981,8 +1159,8 @@ class ConversationOrchestrator:
                         conversation_id=request.conversation_id,
                     )
                 else:
-                    intent = dataclass_replace(
-                        _KNOWN_INTENTS[request.current_intent_name], confidence=1.0
+                    intent = _reconstruct_locked_intent(
+                        request.current_intent_name, extra_intents
                     )
                     logger.info(
                         "intent_locked",
@@ -995,6 +1173,7 @@ class ConversationOrchestrator:
                     request.messages,
                     self._call_llm_json,
                     request.agent_config.llm,
+                    extra_intents=extra_intents,
                 )
                 logger.info(
                     "intent_detected",
@@ -1004,6 +1183,7 @@ class ConversationOrchestrator:
                 )
 
             intent = _resolve_intent_after_clarification_gate(request, intent)
+            intent = _keep_turn_with_committed_agent(request, intent)
 
             if intent.requires_clarification:
                 from taskorbit.intent import _CLARIFICATION_REPLY
@@ -1063,7 +1243,9 @@ class ConversationOrchestrator:
             executing_prereq_id: str | None = None
             if missing_dependencies:
                 next_dep = missing_dependencies[0]
-                executing_prereq = _selected_agent_matches_dep(request.selected_agent, next_dep)
+                executing_prereq = _selected_agent_matches_dep(
+                    request.selected_agent, next_dep, _dep_agent_id(request, next_dep)
+                )
 
                 if executing_prereq:
                     executing_prereq_id = next_dep
@@ -1097,10 +1279,14 @@ class ConversationOrchestrator:
                     has_decision = is_decision_for_this_workflow and request.decision is not None
 
                     if not has_decision:
-                        dep_name = next_dep.replace("-", " ")
                         dep_config = request.dependency_configs.get(next_dep)
                         if dep_config:
                             dep_name = dep_config.name
+                        elif next_dep.startswith("row:"):
+                            # Never leak the raw "row:<db_id>" reference to the user.
+                            dep_name = "the required information"
+                        else:
+                            dep_name = next_dep.replace("-", " ")
 
                         yield ConversationResponse(
                             conversation_id=request.conversation_id,
@@ -1151,7 +1337,7 @@ class ConversationOrchestrator:
                         conversation_id=request.conversation_id,
                         reply=self._make_assistant_message(_workflow_prereq_start_ack(next_dep)),
                         status=ConversationStatus.SUCCESS,
-                        selected_agent=next_dep,
+                        selected_agent=_dep_agent_id(request, next_dep) or next_dep,
                         selected_intent=intent.name,
                         intent_confidence=1.0,
                         locked_intent_name=intent.name,
@@ -1190,8 +1376,8 @@ class ConversationOrchestrator:
                         user_id=user_id,
                     )
                     if request.current_intent_name:
-                        intent = dataclass_replace(
-                            _KNOWN_INTENTS[request.current_intent_name], confidence=1.0
+                        intent = _reconstruct_locked_intent(
+                            request.current_intent_name, extra_intents
                         )
 
             if handoff_blocked:
@@ -1217,7 +1403,7 @@ class ConversationOrchestrator:
             active_config = agent.config
 
             # 3. Select active tool.
-            active_tool = self._select_active_tool(
+            active_tool = await self._select_active_tool(
                 request.messages,
                 agent,
                 # confirmation_id IS the pending tool's id: pinning on it keeps
@@ -1226,6 +1412,9 @@ class ConversationOrchestrator:
                 active_tool_id=request.active_tool_id or request.confirmation_id,
                 intent=intent,
                 current_agent=request.selected_agent or request.agent_config.id,
+                db=db,
+                user_id=user_id,
+                executing_prereq=bool(executing_prereq_id),
             )
 
             # Pre-extraction scope short-circuit (parity with the text path, #168):
@@ -1297,6 +1486,16 @@ class ConversationOrchestrator:
             # before any tokens are sent to the client. Also fires BEFORE the
             # system prompt is built so tool_data (e.g. external_api results)
             # can be injected for the LLM.
+            # Reload external_api data earlier agents retrieved so it survives a
+            # handoff and can be re-injected into this agent's prompt (voice path).
+            prior_tool_data: list[dict] = []
+            if db is not None and request.conversation_id:
+                from taskorbit.database.crud import get_recent_external_api_results
+
+                prior_tool_data = await get_recent_external_api_results(
+                    db, request.conversation_id
+                )
+
             dispatch = await self._run_dispatch_step(
                 request, active_tool, slot_result, intent, agent, db=db, user_id=user_id
             )
@@ -1304,13 +1503,36 @@ class ConversationOrchestrator:
                 yield dispatch.early_response
                 return
 
-            # 4d. Build system prompt WITH tool_data if a tool just fired.
+            # Persist this turn's external_api result for a downstream agent.
+            if (
+                db is not None
+                and request.conversation_id
+                and active_tool is not None
+                and active_tool.type == ToolType.EXTERNAL_API
+                and isinstance(dispatch.tool_data, dict)
+                and dispatch.tool_data.get("data")
+                and not dispatch.tool_data.get("tool_failed")
+                and not dispatch.tool_data.get("aborted")
+            ):
+                from taskorbit.database.crud import create_tool_execution
+
+                await create_tool_execution(
+                    db,
+                    request.conversation_id,
+                    active_tool.id,
+                    ToolType.EXTERNAL_API.value,
+                    result=dispatch.tool_data,
+                )
+
+            # 4d. Build system prompt WITH tool_data if a tool just fired, plus any
+            # data a prior agent retrieved before handing off to this one.
             system_prompt = self._build_system_prompt(
                 active_config,
                 active_tool,
                 slot_result,
                 routed_agent=agent,
                 tool_data=dispatch.tool_data,
+                prior_tool_data=prior_tool_data,
             )
 
             # Pre-LLM scope short-circuit: final guard before streaming tokens (#168).
@@ -1698,6 +1920,7 @@ class ConversationOrchestrator:
         slot_result: Any | None = None,
         routed_agent: Any | None = None,
         tool_data: dict[str, Any] | None = None,
+        prior_tool_data: list[dict[str, Any]] | None = None,
     ) -> str:
         """Construct a system prompt (LLM context) for the current task.
 
@@ -1749,6 +1972,18 @@ class ConversationOrchestrator:
                 "Tool result (use this concrete data to answer the user's question, "
                 "do NOT answer from prior knowledge if the tool result is relevant): "
                 + _json.dumps(tool_data, default=str)
+            )
+        if prior_tool_data:
+            import json as _json
+
+            # Data an earlier agent retrieved in this conversation (e.g. Rachel's
+            # external_api result before a handoff to Chris). Re-inject it so the
+            # current agent can present it instead of claiming it is unavailable.
+            lines.append(
+                "Previously retrieved data (gathered earlier in this same conversation — "
+                "treat it as available and use it to answer; do NOT tell the user the "
+                "information is unavailable if it appears here): "
+                + _json.dumps(prior_tool_data, default=str)
             )
         if slot_result is not None:
             if slot_result.filled:
@@ -1838,13 +2073,16 @@ class ConversationOrchestrator:
             ]
             return SlotExtractionResult(missing=missing)
 
-    def _select_active_tool(
+    async def _select_active_tool(
         self,
         messages: list[Message],
         agent: BaseAgent,
         active_tool_id: str | None = None,
         intent: IntentResult | None = None,
         current_agent: str | None = None,
+        db: AsyncSession | None = None,
+        user_id: int | None = None,
+        executing_prereq: bool = False,
     ) -> ToolDefinition | None:
         """Decide which tool should be in scope for this turn, if any.
 
@@ -1880,8 +2118,16 @@ class ConversationOrchestrator:
             )
             return workflow_tool or tools[0]
 
-        if intent is not None and intent.agent_name:
-            from taskorbit.tools.agent_transfer import resolve_builtin_transfer_target
+        # While this turn is executing a workflow PREREQUISITE agent (e.g. Rachel),
+        # the routed intent still points at the ultimate target (e.g. "chris"), so
+        # the transfer match below would fire the prereq agent's own transfer tool
+        # and skip its data step. Prefer the prereq agent's workflow tool instead;
+        # the workflow engine advances to the target once the prereq completes (#6/#4).
+        if intent is not None and intent.agent_name and not executing_prereq:
+            from taskorbit.tools.agent_transfer import (
+                resolve_builtin_transfer_target,
+                resolve_transfer_target,
+            )
 
             # current_agent can arrive as a template slug after a completed voice
             # handoff ("technical-support-agent"), while intent.agent_name is a
@@ -1899,11 +2145,29 @@ class ConversationOrchestrator:
                     continue
                 targets = tool.parameters.get("targets") or []
                 for raw in targets:
+                    # Fast path: built-in target resolves without DB access.
                     if resolve_builtin_transfer_target(str(raw)) == intent.agent_name:
                         logger.info(
                             "agent_transfer_tool_selected",
                             destination=intent.agent_name,
                             requested_target=str(raw),
+                            tool_id=tool.id,
+                        )
+                        return tool
+                    # Custom/DB target: intent.agent_name is the logical agent_id
+                    # ("chris"), but the configured target is the DB row-id, so the
+                    # built-in match above misses it. Resolve and compare the
+                    # logical agent_id so a transfer to a custom agent fires (#4).
+                    resolved = await resolve_transfer_target(str(raw), db=db, user_id=user_id)
+                    if resolved is not None and intent.agent_name in (
+                        resolved.agent_id,
+                        resolved.canonical_id,
+                    ):
+                        logger.info(
+                            "agent_transfer_tool_selected",
+                            destination=intent.agent_name,
+                            requested_target=str(raw),
+                            resolved_agent_id=resolved.agent_id,
                             tool_id=tool.id,
                         )
                         return tool
@@ -2008,7 +2272,11 @@ class ConversationOrchestrator:
                         conversation_id=request.conversation_id,
                         reply=self._make_assistant_message(
                             active_tool.confirmation.prompt
-                            or f"I need your confirmation before I proceed with {active_tool.name}. Should I go ahead?"
+                            or (
+                                "Shall I hand you over now?"
+                                if active_tool.type == ToolType.AGENT_TRANSFER
+                                else "I need your confirmation before I proceed. Should I go ahead?"
+                            )
                         ),
                         status=ConversationStatus.CONFIRMATION_REQUIRED,
                         tool_invoked=active_tool,

--- a/backend/src/taskorbit/tools/agent_transfer.py
+++ b/backend/src/taskorbit/tools/agent_transfer.py
@@ -18,6 +18,15 @@ def _get_known_agent_names() -> frozenset[str]:
     return AgentRegistry.known_agent_names()
 
 
+def _logical_agent_id(config: Any) -> str | None:
+    """Logical routing id from a stored config blob (config.agent_id / config.id)."""
+    if isinstance(config, dict):
+        aid = config.get("agent_id") or config.get("id")
+        if aid:
+            return str(aid)
+    return None
+
+
 @dataclass(frozen=True)
 class ResolvedTransferTarget:
     """Outcome of resolving a configured transfer target to a real agent.
@@ -31,6 +40,11 @@ class ResolvedTransferTarget:
     canonical_id: str
     kind: str  # "builtin" | "config" | "template"
     display_name: str | None = None
+    # Logical routing id (config.agent_id, e.g. "chris") for saved configs.
+    # intent.agent_name is this logical id, NOT the DB-row canonical_id, so tool
+    # selection must compare against agent_id to fire a transfer to a custom
+    # agent (#4). Falls back to canonical_id for built-ins/templates.
+    agent_id: str | None = None
 
 
 def resolve_builtin_transfer_target(target: str) -> str | None:
@@ -90,7 +104,12 @@ async def resolve_transfer_target(
         #    A PK hit means record.id == raw, so raw IS the canonical id.
         record = await get_agent_configuration_by_id(db, raw, user_id=user_id)
         if record is not None:
-            return ResolvedTransferTarget(canonical_id=raw, kind="config", display_name=record.name)
+            return ResolvedTransferTarget(
+                canonical_id=raw,
+                kind="config",
+                display_name=record.name,
+                agent_id=_logical_agent_id(record.config),
+            )
 
         # 3. Un-customized built-in template by slug id ("general-inquiry-agent").
         #    The manual-transfer path checks this table too; the tool must match it.
@@ -105,7 +124,10 @@ async def resolve_transfer_target(
         record = await get_agent_configuration_by_name(db, raw, user_id=user_id)
         if record is not None:
             return ResolvedTransferTarget(
-                canonical_id=record.id, kind="config", display_name=record.name
+                canonical_id=record.id,
+                kind="config",
+                display_name=record.name,
+                agent_id=_logical_agent_id(record.config),
             )
 
     # 5. Registry keyword mapping, fuzzy last resort ("inquiry-agent" ->

--- a/backend/src/taskorbit/types.py
+++ b/backend/src/taskorbit/types.py
@@ -105,6 +105,19 @@ class LLMConfig(BaseModel):
     provider: LLMProvider = LLMProvider.OPENAI
     model: str = "gpt-4o-mini"
 
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_provider(cls, data: Any) -> Any:
+        # The frontend labels Google's provider "gemini" (pipelineOptions.ts),
+        # while the backend enum uses "google" (which maps to the GeminiClient).
+        # Accept "gemini" as an alias for "google" so a config saved via the UI
+        # validates, e.g. on the voice path where raw metadata is model_validate()'d.
+        # This is a naming reconciliation only — a genuine provider/model MISMATCH
+        # (e.g. openai + a gemini model) is left for the factory guard to reject.
+        if isinstance(data, dict) and str(data.get("provider", "")).lower() == "gemini":
+            data = {**data, "provider": "google"}
+        return data
+
 
 class TTSConfig(BaseModel):
     provider: TTSProvider = TTSProvider.ELEVENLABS

--- a/backend/tests/test_livekit_agent.py
+++ b/backend/tests/test_livekit_agent.py
@@ -177,6 +177,92 @@ async def test_llm_node_yields_orchestrator_reply() -> None:
 
 
 @pytest.mark.asyncio
+async def test_llm_node_swaps_agent_config_on_completed_transfer() -> None:
+    """A completed voice agent_transfer PERSISTENTLY swaps the worker's own agent
+    config to the target (loaded from the DB and mapped via
+    agent_config_from_stored_blob), so the NEXT turn runs the target agent — not
+    the entry agent, whose confirmation-gated transfer tool would otherwise
+    re-fire on every turn (#212 voice loop). Also asserts the routed id becomes
+    the target's clean logical id (the pill fix) while the FE handoff target
+    stays the row id.
+    """
+    from taskorbit.types import ConversationStatus, ToolDefinition, ToolType
+
+    row_id = "3e0d2d7475a348a0a08ab9d4b3f4f931"
+    transfer_resp = ConversationResponse(
+        conversation_id="test-conv",
+        reply=Message(role=MessageRole.ASSISTANT, content="Handing you over."),
+        status=ConversationStatus.SUCCESS,
+        selected_agent="maya",
+        tool_invoked=ToolDefinition(
+            id="transfer_to_chris",
+            name="transfer_to_chris",
+            type=ToolType.AGENT_TRANSFER,
+            parameters={"targets": [row_id]},
+        ),
+    )
+    chris_resp = ConversationResponse(
+        conversation_id="test-conv",
+        reply=Message(role=MessageRole.ASSISTANT, content="The conclusion is X."),
+        status=ConversationStatus.SUCCESS,
+        selected_agent="chris",
+    )
+
+    orchestrator = MagicMock()
+    captured: list[Any] = []
+    responses = [transfer_resp, chris_resp]
+
+    async def _process_message_stream(request: Any, db: Any = None, user_id: Any = None):
+        captured.append(request)
+        yield responses[len(captured) - 1]
+
+    orchestrator.process_message_stream = _process_message_stream
+    orchestrator._captured = captured
+    agent = OrchestratorAgent(
+        orchestrator=orchestrator,
+        agent_config=AgentConfig(id="maya", name="Maya", persona="Maya.", greeting="Hi, Maya."),
+        conversation_id="test-conv",
+        user_id=1,
+    )
+
+    # Chris's STORED (frontend-shaped) blob: instructions/first_message, NOT persona/greeting.
+    chris_blob = {
+        "agent_id": "chris",
+        "name": "Chris",
+        "instructions": "You are Chris, the presentation agent.",
+        "first_message": {"type": "text", "message": "Hi, I'm Chris.", "prompt": ""},
+        "tools": [{"id": "end_call", "name": "end_call", "type": "end_call", "description": "end"}],
+        "llm": {"provider": "google", "model": "gemini-2.5-flash"},
+    }
+    fake_record = MagicMock()
+    fake_record.config = chris_blob
+
+    with patch(
+        "taskorbit.database.crud.get_agent_configuration_by_id",
+        new_callable=AsyncMock,
+        return_value=fake_record,
+    ):
+        # Turn 1: the transfer fires → the worker swaps its own config to Chris.
+        agent.request_reply()
+        [_ async for _ in agent.llm_node(_make_chat_ctx([("user", "the conclusion")]), [], MagicMock())]
+
+        assert agent._agent_config.id == "chris"
+        assert agent._agent_config.name == "Chris"
+        # instructions mapped to persona proves the FE-blob mapper ran (not AgentConfig(**blob)).
+        assert agent._agent_config.persona.startswith("You are Chris")
+        assert agent._current_routed_agent == "chris"  # clean pill label, not the row id
+        assert agent._pending_handoff_target == row_id  # FE agent_handoff match preserved
+
+        # Turn 2: the next turn must run AS Chris (swap persisted into worker state).
+        agent.request_reply()
+        [_ async for _ in agent.llm_node(_make_chat_ctx([("user", "please continue")]), [], MagicMock())]
+
+    assert len(captured) == 2
+    assert captured[1].agent_config.id == "chris"  # worker now sends Chris, not Maya
+    assert captured[1].selected_agent == "chris"
+
+
+@pytest.mark.asyncio
 async def test_llm_node_skips_empty_reply() -> None:
     agent, _ = _make_agent("")
     chat_ctx = _make_chat_ctx([("user", "Hi")])

--- a/backend/tests/test_livekit_agent.py
+++ b/backend/tests/test_livekit_agent.py
@@ -244,7 +244,12 @@ async def test_llm_node_swaps_agent_config_on_completed_transfer() -> None:
     ):
         # Turn 1: the transfer fires → the worker swaps its own config to Chris.
         agent.request_reply()
-        [_ async for _ in agent.llm_node(_make_chat_ctx([("user", "the conclusion")]), [], MagicMock())]
+        [
+            _
+            async for _ in agent.llm_node(
+                _make_chat_ctx([("user", "the conclusion")]), [], MagicMock()
+            )
+        ]
 
         assert agent._agent_config.id == "chris"
         assert agent._agent_config.name == "Chris"
@@ -255,7 +260,12 @@ async def test_llm_node_swaps_agent_config_on_completed_transfer() -> None:
 
         # Turn 2: the next turn must run AS Chris (swap persisted into worker state).
         agent.request_reply()
-        [_ async for _ in agent.llm_node(_make_chat_ctx([("user", "please continue")]), [], MagicMock())]
+        [
+            _
+            async for _ in agent.llm_node(
+                _make_chat_ctx([("user", "please continue")]), [], MagicMock()
+            )
+        ]
 
     assert len(captured) == 2
     assert captured[1].agent_config.id == "chris"  # worker now sends Chris, not Maya

--- a/backend/tests/test_orchestration.py
+++ b/backend/tests/test_orchestration.py
@@ -423,7 +423,12 @@ async def test_agent_transfer_dispatch_sets_tool_invoked() -> None:
 
     with (
         patch.object(orch._intent_router, "detect", new_callable=AsyncMock, return_value=intent),
-        patch.object(ConversationOrchestrator, "_select_active_tool", new_callable=AsyncMock, return_value=transfer_tool),
+        patch.object(
+            ConversationOrchestrator,
+            "_select_active_tool",
+            new_callable=AsyncMock,
+            return_value=transfer_tool,
+        ),
         patch.object(
             ConversationOrchestrator,
             "_extract_slots",
@@ -640,7 +645,12 @@ async def test_external_api_arg_extracted_and_dispatched() -> None:
 
     with (
         patch.object(orch._intent_router, "detect", new_callable=AsyncMock, return_value=intent),
-        patch.object(ConversationOrchestrator, "_select_active_tool", new_callable=AsyncMock, return_value=tool),
+        patch.object(
+            ConversationOrchestrator,
+            "_select_active_tool",
+            new_callable=AsyncMock,
+            return_value=tool,
+        ),
         patch.object(ConversationOrchestrator, "_extract_slots", new=_fake_extract),
         patch.object(ConversationOrchestrator, "_dispatch_tool", new=_fake_dispatch),
         patch.object(
@@ -702,7 +712,12 @@ async def test_no_arg_external_api_active_does_not_leak_guidance() -> None:
 
     with (
         patch.object(orch._intent_router, "detect", new_callable=AsyncMock, return_value=intent),
-        patch.object(ConversationOrchestrator, "_select_active_tool", new_callable=AsyncMock, return_value=tool),
+        patch.object(
+            ConversationOrchestrator,
+            "_select_active_tool",
+            new_callable=AsyncMock,
+            return_value=tool,
+        ),
         patch.object(ConversationOrchestrator, "_extract_slots", new=_fake_extract),
         patch.object(ConversationOrchestrator, "_dispatch_tool", new=_fake_dispatch),
         patch.object(
@@ -828,7 +843,12 @@ async def test_failed_external_api_tool_makes_agent_report_not_fabricate() -> No
 
     with (
         patch.object(orch._intent_router, "detect", new_callable=AsyncMock, return_value=intent),
-        patch.object(ConversationOrchestrator, "_select_active_tool", new_callable=AsyncMock, return_value=tool),
+        patch.object(
+            ConversationOrchestrator,
+            "_select_active_tool",
+            new_callable=AsyncMock,
+            return_value=tool,
+        ),
         patch.object(ConversationOrchestrator, "_extract_slots", new=_fake_extract),
         patch.object(ConversationOrchestrator, "_dispatch_tool", new=_fake_dispatch),
         patch.object(ConversationOrchestrator, "_call_llm", new=_capture_llm),
@@ -958,7 +978,12 @@ async def test_no_arg_external_api_dispatches_and_llm_sees_result() -> None:
 
     with (
         patch.object(orch._intent_router, "detect", new_callable=AsyncMock, return_value=intent),
-        patch.object(ConversationOrchestrator, "_select_active_tool", new_callable=AsyncMock, return_value=tool),
+        patch.object(
+            ConversationOrchestrator,
+            "_select_active_tool",
+            new_callable=AsyncMock,
+            return_value=tool,
+        ),
         patch.object(
             ConversationOrchestrator,
             "_extract_slots",
@@ -1858,7 +1883,12 @@ async def test_auto_transfer_to_custom_agent_via_process_message() -> None:
 
     with (
         patch.object(orch._intent_router, "detect", new_callable=AsyncMock, return_value=intent),
-        patch.object(ConversationOrchestrator, "_select_active_tool", new_callable=AsyncMock, return_value=transfer_tool),
+        patch.object(
+            ConversationOrchestrator,
+            "_select_active_tool",
+            new_callable=AsyncMock,
+            return_value=transfer_tool,
+        ),
         patch.object(
             ConversationOrchestrator,
             "_extract_slots",
@@ -2379,7 +2409,12 @@ async def test_transfer_tool_invoked_carries_canonical_target() -> None:
 
     with (
         patch.object(orch._intent_router, "detect", new_callable=AsyncMock, return_value=intent),
-        patch.object(ConversationOrchestrator, "_select_active_tool", new_callable=AsyncMock, return_value=transfer_tool),
+        patch.object(
+            ConversationOrchestrator,
+            "_select_active_tool",
+            new_callable=AsyncMock,
+            return_value=transfer_tool,
+        ),
         patch.object(
             ConversationOrchestrator,
             "_extract_slots",

--- a/backend/tests/test_orchestration.py
+++ b/backend/tests/test_orchestration.py
@@ -423,7 +423,7 @@ async def test_agent_transfer_dispatch_sets_tool_invoked() -> None:
 
     with (
         patch.object(orch._intent_router, "detect", new_callable=AsyncMock, return_value=intent),
-        patch.object(ConversationOrchestrator, "_select_active_tool", return_value=transfer_tool),
+        patch.object(ConversationOrchestrator, "_select_active_tool", new_callable=AsyncMock, return_value=transfer_tool),
         patch.object(
             ConversationOrchestrator,
             "_extract_slots",
@@ -640,7 +640,7 @@ async def test_external_api_arg_extracted_and_dispatched() -> None:
 
     with (
         patch.object(orch._intent_router, "detect", new_callable=AsyncMock, return_value=intent),
-        patch.object(ConversationOrchestrator, "_select_active_tool", return_value=tool),
+        patch.object(ConversationOrchestrator, "_select_active_tool", new_callable=AsyncMock, return_value=tool),
         patch.object(ConversationOrchestrator, "_extract_slots", new=_fake_extract),
         patch.object(ConversationOrchestrator, "_dispatch_tool", new=_fake_dispatch),
         patch.object(
@@ -702,7 +702,7 @@ async def test_no_arg_external_api_active_does_not_leak_guidance() -> None:
 
     with (
         patch.object(orch._intent_router, "detect", new_callable=AsyncMock, return_value=intent),
-        patch.object(ConversationOrchestrator, "_select_active_tool", return_value=tool),
+        patch.object(ConversationOrchestrator, "_select_active_tool", new_callable=AsyncMock, return_value=tool),
         patch.object(ConversationOrchestrator, "_extract_slots", new=_fake_extract),
         patch.object(ConversationOrchestrator, "_dispatch_tool", new=_fake_dispatch),
         patch.object(
@@ -828,7 +828,7 @@ async def test_failed_external_api_tool_makes_agent_report_not_fabricate() -> No
 
     with (
         patch.object(orch._intent_router, "detect", new_callable=AsyncMock, return_value=intent),
-        patch.object(ConversationOrchestrator, "_select_active_tool", return_value=tool),
+        patch.object(ConversationOrchestrator, "_select_active_tool", new_callable=AsyncMock, return_value=tool),
         patch.object(ConversationOrchestrator, "_extract_slots", new=_fake_extract),
         patch.object(ConversationOrchestrator, "_dispatch_tool", new=_fake_dispatch),
         patch.object(ConversationOrchestrator, "_call_llm", new=_capture_llm),
@@ -958,7 +958,7 @@ async def test_no_arg_external_api_dispatches_and_llm_sees_result() -> None:
 
     with (
         patch.object(orch._intent_router, "detect", new_callable=AsyncMock, return_value=intent),
-        patch.object(ConversationOrchestrator, "_select_active_tool", return_value=tool),
+        patch.object(ConversationOrchestrator, "_select_active_tool", new_callable=AsyncMock, return_value=tool),
         patch.object(
             ConversationOrchestrator,
             "_extract_slots",
@@ -1858,7 +1858,7 @@ async def test_auto_transfer_to_custom_agent_via_process_message() -> None:
 
     with (
         patch.object(orch._intent_router, "detect", new_callable=AsyncMock, return_value=intent),
-        patch.object(ConversationOrchestrator, "_select_active_tool", return_value=transfer_tool),
+        patch.object(ConversationOrchestrator, "_select_active_tool", new_callable=AsyncMock, return_value=transfer_tool),
         patch.object(
             ConversationOrchestrator,
             "_extract_slots",
@@ -2173,11 +2173,11 @@ def _intent_for(agent_name: str):
     return IntentResult(name=agent_name or "unknown", description="", agent_name=agent_name)
 
 
-def test_select_transfer_when_intent_routes_away() -> None:
+async def test_select_transfer_when_intent_routes_away() -> None:
     """#212: intent routing away + matching transfer tool selects the transfer,
     not tools[0], even though the target is the sloppy prod value."""
     orch = ConversationOrchestrator()
-    tool = orch._select_active_tool(
+    tool = await orch._select_active_tool(
         [],
         _FakeAgent(_john_max_tools()),
         intent=_intent_for("general_inquiry"),
@@ -2187,10 +2187,10 @@ def test_select_transfer_when_intent_routes_away() -> None:
     assert tool.id == "transfer_to_inquiry_agent"
 
 
-def test_select_pin_wins_over_transfer_rule() -> None:
+async def test_select_pin_wins_over_transfer_rule() -> None:
     """A confirmation round-trip pin must still take precedence."""
     orch = ConversationOrchestrator()
-    tool = orch._select_active_tool(
+    tool = await orch._select_active_tool(
         [],
         _FakeAgent(_john_max_tools()),
         active_tool_id="collect_user_info",
@@ -2201,9 +2201,9 @@ def test_select_pin_wins_over_transfer_rule() -> None:
     assert tool.id == "collect_user_info"
 
 
-def test_select_stays_on_first_tool_when_intent_matches_current_agent() -> None:
+async def test_select_stays_on_first_tool_when_intent_matches_current_agent() -> None:
     orch = ConversationOrchestrator()
-    tool = orch._select_active_tool(
+    tool = await orch._select_active_tool(
         [],
         _FakeAgent(_john_max_tools()),
         intent=_intent_for("general_inquiry"),
@@ -2213,9 +2213,9 @@ def test_select_stays_on_first_tool_when_intent_matches_current_agent() -> None:
     assert tool.id == "collect_user_info"
 
 
-def test_select_stays_on_first_tool_when_no_target_matches_destination() -> None:
+async def test_select_stays_on_first_tool_when_no_target_matches_destination() -> None:
     orch = ConversationOrchestrator()
-    tool = orch._select_active_tool(
+    tool = await orch._select_active_tool(
         [],
         _FakeAgent(_john_max_tools()),
         intent=_intent_for("sales"),
@@ -2225,9 +2225,9 @@ def test_select_stays_on_first_tool_when_no_target_matches_destination() -> None
     assert tool.id == "collect_user_info"
 
 
-def test_select_stays_on_first_tool_for_unknown_intent() -> None:
+async def test_select_stays_on_first_tool_for_unknown_intent() -> None:
     orch = ConversationOrchestrator()
-    tool = orch._select_active_tool(
+    tool = await orch._select_active_tool(
         [],
         _FakeAgent(_john_max_tools()),
         intent=_intent_for(""),
@@ -2237,18 +2237,18 @@ def test_select_stays_on_first_tool_for_unknown_intent() -> None:
     assert tool.id == "collect_user_info"
 
 
-def test_select_unchanged_without_intent_argument() -> None:
+async def test_select_unchanged_without_intent_argument() -> None:
     """Callers that never pass intent keep the legacy tools[0] behaviour."""
     orch = ConversationOrchestrator()
-    tool = orch._select_active_tool([], _FakeAgent(_john_max_tools()))
+    tool = await orch._select_active_tool([], _FakeAgent(_john_max_tools()))
     assert tool is not None
     assert tool.id == "collect_user_info"
 
 
-def test_select_no_tools_returns_none_still() -> None:
+async def test_select_no_tools_returns_none_still() -> None:
     orch = ConversationOrchestrator()
     assert (
-        orch._select_active_tool(
+        await orch._select_active_tool(
             [], _FakeAgent([]), intent=_intent_for("general_inquiry"), current_agent="x"
         )
         is None
@@ -2289,12 +2289,12 @@ def _end_call_first_tools():
     ]
 
 
-def test_select_skips_end_call_default_when_saved_first() -> None:
+async def test_select_skips_end_call_default_when_saved_first() -> None:
     """An end_call tool saved before data_extraction tools must never win the
     no-pin default — it would otherwise fire on the very first turn regardless
     of user intent, and the data_extraction tools would never be reached."""
     orch = ConversationOrchestrator()
-    tool = orch._select_active_tool(
+    tool = await orch._select_active_tool(
         [],
         _FakeAgent(_end_call_first_tools()),
         intent=_intent_for("general_inquiry"),
@@ -2304,26 +2304,26 @@ def test_select_skips_end_call_default_when_saved_first() -> None:
     assert tool.id == "collect_contact_info"
 
 
-def test_select_skips_end_call_default_without_intent_argument() -> None:
+async def test_select_skips_end_call_default_without_intent_argument() -> None:
     orch = ConversationOrchestrator()
-    tool = orch._select_active_tool([], _FakeAgent(_end_call_first_tools()))
+    tool = await orch._select_active_tool([], _FakeAgent(_end_call_first_tools()))
     assert tool is not None
     assert tool.id == "collect_contact_info"
 
 
-def test_select_pin_still_reaches_end_call_when_explicitly_targeted() -> None:
+async def test_select_pin_still_reaches_end_call_when_explicitly_targeted() -> None:
     """The default skips end_call, but an explicit pin (e.g. after the
     end-call short-circuit or a confirmation round-trip) must still resolve
     it — the skip only applies to the no-signal fallback."""
     orch = ConversationOrchestrator()
-    tool = orch._select_active_tool(
+    tool = await orch._select_active_tool(
         [], _FakeAgent(_end_call_first_tools()), active_tool_id="end_call"
     )
     assert tool is not None
     assert tool.id == "end_call"
 
 
-def test_select_falls_back_to_end_call_when_no_workflow_tool_exists() -> None:
+async def test_select_falls_back_to_end_call_when_no_workflow_tool_exists() -> None:
     """An agent with only end_call/agent_transfer tools (no data_extraction or
     external_api) must still get a tool back, not None."""
     from taskorbit.types import ConfirmationConfig, ToolDefinition, ToolType
@@ -2340,7 +2340,7 @@ def test_select_falls_back_to_end_call_when_no_workflow_tool_exists() -> None:
         ),
     ]
     orch = ConversationOrchestrator()
-    tool = orch._select_active_tool([], _FakeAgent(tools))
+    tool = await orch._select_active_tool([], _FakeAgent(tools))
     assert tool is not None
     assert tool.id == "end_call"
 
@@ -2379,7 +2379,7 @@ async def test_transfer_tool_invoked_carries_canonical_target() -> None:
 
     with (
         patch.object(orch._intent_router, "detect", new_callable=AsyncMock, return_value=intent),
-        patch.object(ConversationOrchestrator, "_select_active_tool", return_value=transfer_tool),
+        patch.object(ConversationOrchestrator, "_select_active_tool", new_callable=AsyncMock, return_value=transfer_tool),
         patch.object(
             ConversationOrchestrator,
             "_extract_slots",
@@ -2410,11 +2410,11 @@ async def test_transfer_tool_invoked_carries_canonical_target() -> None:
     assert response.tool_invoked.parameters["targets"] == ["general_inquiry"]
 
 
-def test_select_no_refire_when_current_agent_is_template_slug() -> None:
+async def test_select_no_refire_when_current_agent_is_template_slug() -> None:
     """After a completed voice handoff the worker reports the canonical
     template slug as the current agent; the transfer must NOT re-fire (#212)."""
     orch = ConversationOrchestrator()
-    tool = orch._select_active_tool(
+    tool = await orch._select_active_tool(
         [],
         _FakeAgent(_john_max_tools()),
         intent=_intent_for("general_inquiry"),

--- a/backend/tests/test_workflow_engine.py
+++ b/backend/tests/test_workflow_engine.py
@@ -180,6 +180,51 @@ async def test_handoff_blocked_if_not_allowed(orchestrator):
 
 
 @pytest.mark.asyncio
+async def test_committed_entry_agent_answers_catch_all_intent(orchestrator):
+    """A committed custom entry agent (selected_agent == its own id, e.g. a
+    post-transfer presenter whose workflow prerequisites are satisfied) must
+    answer a general_inquiry / unknown catch-all turn itself, not refuse it.
+
+    Regression for the voice agent handoff: after Maya -> Rachel -> Chris, the
+    user asks Chris to present the conclusion. That utterance classifies as the
+    general_inquiry catch-all, which is never in Chris's allowed_handoffs, so the
+    handoff-block used to refuse every one of Chris's own turns and he could
+    never present the result.
+    """
+    config = AgentConfig(
+        id="chris",
+        name="Chris",
+        persona="I present the conclusion.",
+        greeting="Hi, I'm Chris.",
+        workflow_dependencies=["rachel"],  # dependency already satisfied below
+        allowed_handoffs=["rachel"],  # non-empty => the handoff-block could fire
+    )
+    request = ConversationRequest(
+        conversation_id="conv-1",
+        agent_config=config,
+        selected_agent="chris",  # committed: the routed agent IS the entry agent
+        completed_workflow_steps=["rachel"],
+        messages=[Message(role=MessageRole.USER, content="Please tell me the conclusion now.")],
+    )
+    catch_all = IntentResult(
+        name="general_inquiry",
+        description="d",
+        agent_name="general_inquiry",
+        confidence=0.7,
+    )
+
+    with mock.patch.object(orchestrator._intent_router, "detect", return_value=catch_all):
+        with mock.patch.object(
+            orchestrator, "_call_llm", return_value="The conclusion is that it works."
+        ):
+            response = await orchestrator.process_message(request)
+
+    assert response.status == ConversationStatus.SUCCESS
+    assert response.selected_agent == "chris"
+    assert "conclusion" in response.reply.content.lower()
+
+
+@pytest.mark.asyncio
 async def test_turn_1_entry_agent_locked(orchestrator):
     # Config says Sales
     config = AgentConfig(


### PR DESCRIPTION
## Summary
On the voice path, a transfer to a custom target agent never completed: the
target agent never ran, the entry agent's transfer prompt re-fired every turn,
and the routed indicator showed the target's raw database row id instead of its
name. This fixes the handoff end to end so the target agent runs, answers, and
is labeled by name.

## Root causes
1. The voice worker bound its agent config once at session start and never
   reassigned it. After a transfer it only updated internal strings and notified
   the frontend while it kept executing as the entry agent, so the confirmation
   gated transfer tool re-fired every turn and the target never ran.
2. Once the worker ran as the target agent, that agent could not answer general
   turns. A request like "tell me the conclusion" classifies as the
   general_inquiry catch-all, which is never in the agent's allowed_handoffs, so
   the handoff rule refused every turn.

## What changed
- The worker loads the target's stored config and reassigns itself when a
  transfer completes, so from the next turn it runs as the target agent and
  publishes the target's logical id, not the raw row id. The reload falls back
  to the previous behavior on any lookup failure and never breaks the turn.
- When the routed agent is the entry agent itself, general_inquiry and unknown
  resolve to that agent answering directly instead of a handoff block or a
  clarification prompt. The cross-agent handoff block is unchanged (it still
  fires only when the routed agent differs from the entry agent).
- Supporting pieces the custom flow needs: per-call intents for custom agents,
  resolution of row-prefixed workflow dependencies and transfer targets,
  reinjection of a prior agent's retrieved data, loading stored config blobs
  through the shared mapper, and a gemini provider alias.

## Testing
- New worker test drives a transfer through the voice node and asserts the
  config swaps and persists to the next turn.
- New orchestration test asserts a committed entry agent answers a catch-all
  turn instead of being handoff-blocked (verified to fail without the fix).
- Full backend suite passes; the three pre-existing environment failures are
  unrelated.
- Verified end to end on live voice: Maya to Rachel (fetches data) to Chris
  (presents the retrieved conclusion), no loop, name in the routed label.

## Generality
Field-driven, not tied to the demo agents. It keys on the resolved transfer
target, the config's allowed_handoffs and workflow_dependencies, and the entry
agent's own id. Any agent created in the config panel with prerequisites and
handoffs works with no code changes. Built-in registry transfers and manual
@route transfers are separate paths and are unchanged.